### PR TITLE
copy next config and i18n config into docker production container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ RUN npm run build
 FROM node:current-alpine AS production
 ENV NODE_ENV=production
 WORKDIR /app
+COPY --from=build /build/next.config.js ./
+COPY --from=build /build/next-i18next.config.js ./
 COPY --from=build /build/package*.json ./
 COPY --from=build /build/.next ./.next
 COPY --from=build /build/public ./public


### PR DESCRIPTION
# Description

Fixed issue where docker container could not find the i18n instance. This was only an issue with the container as it requires these two configuration files to be present in the run step.

## Acceptance Criteria

Application does not crash in production.

## Test Instructions

1. `docker build .`
2. `docker run -p 3000:3000 [image]`
3. navigate to localhost:3000
4. see that homepage loads and app doesn't crash

## Help Requested

NA

## Checklist

NA

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
