### PR TITLE
Action button Link

### DIFF
--- a/components/atoms/ActionButton.js
+++ b/components/atoms/ActionButton.js
@@ -6,6 +6,8 @@ import Link from "next/link";
  */
 export function ActionButton(props) {
   //Styling for buttons and links
+  const basicStyle =
+    "flex justify-center content-center h-auto p-1 w-max rounded-sm py-2 px-4 focus:ring-1 focus:ring-black focus:ring-offset-2 text-xs md:text-base font-body";
   const defaultStyle =
     "bg-custom-blue-blue text-white border border-custom-blue-blue active:bg-custom-blue-dark hover:bg-custom-blue-light";
   const secondaryStyle =
@@ -14,7 +16,7 @@ export function ActionButton(props) {
   return props.href ? (
     <Link href={props.href}>
       <a
-        className={`flex justify-center content-center h-auto p-1 w-max rounded-sm py-2 px-4 focus:ring-1 focus:ring-black focus:ring-offset-2
+        className={`${basicStyle}
         ${
           !props.secondary && !props.disabled && !props.custom
             ? defaultStyle
@@ -22,11 +24,8 @@ export function ActionButton(props) {
         }
         ${props.secondary && !props.disabled ? secondaryStyle : props.className}
         ${props.custom && !props.secondary ? props.custom : ""}
-        ${
-          props.disabled ? disabledStyle : props.className
-        } text-xs md:text-base font-body`}
+        ${props.disabled ? disabledStyle : props.className}`}
         onClick={props.onClick}
-        type={props.type}
         id={props.id}
         data-testid={props.dataTestId}
         data-cy={props.dataCy || props.id}
@@ -42,7 +41,7 @@ export function ActionButton(props) {
     </Link>
   ) : (
     <button
-      className={`flex justify-center content-center h-auto p-1 rounded-sm py-2 px-4 focus:ring-1 focus:ring-black focus:ring-offset-2
+      className={`${basicStyle}
       ${
         !props.secondary && !props.disabled && !props.custom
           ? defaultStyle
@@ -50,9 +49,7 @@ export function ActionButton(props) {
       }
       ${props.secondary && !props.disabled ? secondaryStyle : props.className}
       ${props.custom && !props.secondary ? props.custom : ""}
-      ${
-        props.disabled ? disabledStyle : props.className
-      } text-xs md:text-base font-body`}
+      ${props.disabled ? disabledStyle : props.className}`}
       onClick={props.onClick}
       type={props.type}
       id={props.id}

--- a/components/atoms/ActionButton.js
+++ b/components/atoms/ActionButton.js
@@ -1,27 +1,57 @@
 import PropTypes from "prop-types";
+import Link from "next/link";
 
 /**
  * Button component
  */
 export function ActionButton(props) {
-  return (
+  //Styling for buttons and links
+  const defaultStyle =
+    "bg-custom-blue-blue text-white border border-custom-blue-blue active:bg-custom-blue-dark hover:bg-custom-blue-light";
+  const secondaryStyle =
+    "bg-white text-custom-blue-blue border border-custom-blue-blue active:bg-gray-400 hover:bg-gray-200";
+  const disabledStyle = "bg-gray-light text-gray-600 border border-gray-md";
+  return props.href ? (
+    <Link href={props.href}>
+      <a
+        className={`flex justify-center content-center h-auto p-1 w-max rounded-sm py-2 px-4 focus:ring-1 focus:ring-black focus:ring-offset-2
+        ${
+          !props.secondary && !props.disabled && !props.custom
+            ? defaultStyle
+            : props.className
+        }
+        ${props.secondary && !props.disabled ? secondaryStyle : props.className}
+        ${props.custom && !props.secondary ? props.custom : ""}
+        ${
+          props.disabled ? disabledStyle : props.className
+        } text-xs md:text-base font-body`}
+        onClick={props.onClick}
+        type={props.type}
+        id={props.id}
+        data-testid={props.dataTestId}
+        data-cy={props.dataCy || props.id}
+        data-cy-button={props.dataCyButton}
+        disabled={props.disabled}
+      >
+        {props.icon ? (
+          <span className={props.icon} data-testid={props.dataTestId} />
+        ) : undefined}
+        {props.text}
+        {props.children}
+      </a>
+    </Link>
+  ) : (
     <button
       className={`flex justify-center content-center h-auto p-1 rounded-sm py-2 px-4 focus:ring-1 focus:ring-black focus:ring-offset-2
       ${
         !props.secondary && !props.disabled && !props.custom
-          ? "bg-custom-blue-blue text-white border border-custom-blue-blue active:bg-custom-blue-dark hover:bg-custom-blue-light"
+          ? defaultStyle
           : props.className
       }
-      ${
-        props.secondary && !props.disabled
-          ? "bg-white text-custom-blue-blue border border-custom-blue-blue active:bg-gray-400 hover:bg-gray-200"
-          : props.className
-      }
+      ${props.secondary && !props.disabled ? secondaryStyle : props.className}
       ${props.custom && !props.secondary ? props.custom : ""}
       ${
-        props.disabled
-          ? "bg-gray-light text-gray-600 border border-gray-md"
-          : props.className
+        props.disabled ? disabledStyle : props.className
       } text-xs md:text-base font-body`}
       onClick={props.onClick}
       type={props.type}
@@ -50,6 +80,11 @@ ActionButton.propTypes = {
    * The text that the button will display
    */
   text: PropTypes.string,
+
+  /**
+   * Style link as a button when there's a href
+   */
+  href: PropTypes.string,
 
   /**
    * Identify which button being clicked

--- a/components/atoms/ActionButton.stories.js
+++ b/components/atoms/ActionButton.stories.js
@@ -10,6 +10,7 @@ const Template = (args) => <ActionButton {...args} />;
 export const Default = Template.bind({});
 export const Secondary = Template.bind({});
 export const Disabled = Template.bind({});
+export const Link = Template.bind({});
 
 Default.args = {
   className:
@@ -27,5 +28,13 @@ Secondary.args = {
 Disabled.args = {
   text: "Disabled Button 🚀",
   className: "bg-gray-light text-gray-600 border border-gray-md",
+  disabled: true,
+};
+
+Link.args = {
+  text: "Link Button 🚀",
+  className:
+    "bg-custom-blue-blue text-white border border-custom-blue-blue active:bg-custom-blue-dark hover:bg-custom-blue-light",
+  href: "/",
   disabled: true,
 };

--- a/components/atoms/ActionButton.test.js
+++ b/components/atoms/ActionButton.test.js
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom/extend-expect";
 import { axe, toHaveNoViolations } from "jest-axe";
-import { Default, Secondary, Disabled } from "./ActionButton.stories";
+import { Default, Secondary, Disabled, Link } from "./ActionButton.stories";
 
 expect.extend(toHaveNoViolations);
 
@@ -26,6 +26,12 @@ describe("Action Button", () => {
     render(<Disabled {...Disabled.args} />);
     expect(screen.getByRole("button")).toHaveTextContent(Disabled.args.text);
     expect(screen.getByRole("button")).toHaveAttribute("disabled");
+  });
+
+  it("renders link styles as button", () => {
+    render(<Link {...Link.args} />);
+    expect(screen.getByRole("link")).toHaveTextContent(Link.args.text);
+    expect(screen.getByRole("link")).toHaveAttribute("href");
   });
 
   it("has no a11y violations", async () => {

--- a/pages/index.js
+++ b/pages/index.js
@@ -50,7 +50,8 @@ export default function Home(props) {
           className={"text-xs md:text-base"}
           text={t("experimentsBtnTxt")}
           secondary
-          dataCyButton={"see-the-experiements"}
+          href="/experiments"
+          dataCyButton={"see-the-experiments"}
         />
       </section>
 


### PR DESCRIPTION
# Description

[Button Link](https://trello.com/c/Slo61xKI/130-130-create-a-button-link-component)

Turning Action Button component in a link styled as a button when "href" is passed as a prop.
![image](https://user-images.githubusercontent.com/72703030/115899929-629ef400-a42d-11eb-9b66-8c1d21a22e4b.png)
![image](https://user-images.githubusercontent.com/72703030/115900088-8bbf8480-a42d-11eb-8e56-212e86c2334b.png)

## Acceptance Criteria

When creating a button, we can use a link, or we can use a button proper depending on the function of that button. 

## Test Instructions

1. Make sure ActionButton components with a href value are links and the opposite as well.

## Checklist

- [x] Strings use placeholders for translation (No hard coded strings)
- [x] Unit tests have been added/updated

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
