### PR TITLE
Fixed padding for the Phasebanner.

### DIFF
--- a/components/atoms/PhaseBanner.js
+++ b/components/atoms/PhaseBanner.js
@@ -8,7 +8,7 @@ import PropTypes from "prop-types";
 export const PhaseBanner = ({ phase, children }) => {
   return (
     <div className="bg-gray-100 sm:max-h-14">
-      <div className="flex items-start p-4 layout-container">
+      <div className="flex items-start py-4 layout-container">
         <span className="font-body text-xs leading-5 sm:text-sm sm:leading-5 uppercase tracking-normal border-2 border-black px-2">
           {phase}
         </span>


### PR DESCRIPTION
# Description

[#150 Bug]
https://trello.com/c/it69d3kr/150-150-bug-alpha-banner-doesnt-respect-our-cool-container-element

Very short PR...

Mobile: 
![image](https://user-images.githubusercontent.com/77116011/115904087-6123fa80-a432-11eb-8e57-eac7e22728db.png)

Desktop:
![image](https://user-images.githubusercontent.com/77116011/115904158-76992480-a432-11eb-957d-07d7887ea5d9.png)


## Acceptance Criteria

Must match as close as possible this website: https://covid-benefits.alpha.canada.ca/en/start

## Test Instructions

1. go to branch Bug/#150-AplhaBanner   (I know there is a typo.. My mistake when creating the branch.)
2. npm run dev
3. See the top Alpha banner on different screen widths.

## Help Requested

Do not be shy with the reviews. I accept all constructive comments. :) 

## Checklist

- [x] Strings use placeholders for translation (No hard coded strings)
- [x] Unit tests have been added/updated

## Product and Sprint Backlog

[#150 Bug]
https://trello.com/c/it69d3kr/150-150-bug-alpha-banner-doesnt-respect-our-cool-container-element
