### PR TITLE
modified menu font sizes and family to match design

### DIFF
--- a/components/molecules/Menu.js
+++ b/components/molecules/Menu.js
@@ -34,8 +34,10 @@ export function Menu(props) {
         aria-expanded="false"
         aria-controls="menuDropdown"
       >
-        <span className="icon-menu" />
-        <span className="pl-3">{props.menuButtonTitle}</span>
+        <span className="inline-block align-middle icon-menu" />
+        <span className="inline-block align-middle pl-3 font-body text-p leading-none">
+          {props.menuButtonTitle}
+        </span>
       </button>
 
       <ul id="menuDropdown" className="menuDropdown" role="menu">
@@ -51,7 +53,7 @@ export function Menu(props) {
           return (
             <li key={key} className={itemClass} role="menuitem">
               <Link href={item.link}>
-                <a>{item.text}</a>
+                <a className="font-body text-base">{item.text}</a>
               </Link>
             </li>
           );


### PR DESCRIPTION
# Description

[#202 Fix menu fonts to match design](https://trello.com/c/bFjvnwh6/202-202-fix-menu-fonts-to-match-design)

Small fix to ensure the menu items are using the correct fonts and that their sizes match the current Figma designs.

## Acceptance Criteria

Styling in the menu should match what is seen in [Figma](https://www.figma.com/file/t5uDkPa86nsS3ssFESX2Em/BDM-DECD-Alpha-Site-Sprint-3?node-id=298%3A6705)

## Test Instructions

1. View website in the browser
2. use devtools to ensure rendered fonts match the design

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
