### PR TITLE
remove image opts config

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -14,17 +14,6 @@ module.exports = {
     "@storybook/addon-postcss",
   ],
   webpackFinal: (config) => {
-    config.plugins.push(
-      new webpack.DefinePlugin({
-        "process.env.__NEXT_IMAGE_OPTS": JSON.stringify({
-          deviceSizes: [640, 750, 828, 1080, 1200, 1920, 2048, 3840],
-          imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],
-          domains: [],
-          path: "/",
-          loader: "default",
-        }),
-      })
-    );
     // useTranslation() hook in next-i18next is looking for a server environment and storybooks
     // runs client-side, so use client-side react-i18next to allow components to render outside server environment
     config.resolve.alias = {


### PR DESCRIPTION
# Description

No task here again 

There was an unnecessary webpack config related to setting image options for the `next/image` component in storybooks. Considering we're monkey patching the component this isn't necessary. So I removed it.  

## Acceptance Criteria

N/A

## Test Instructions

N/A

## Help Requested

N/A

## Checklist

- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
