### PR TITLE
Fix html dateTime attribute

### DIFF
--- a/components/atoms/DateModified.js
+++ b/components/atoms/DateModified.js
@@ -14,7 +14,7 @@ export function DateModified(props) {
         {dateFormatted === "NA" ? (
           <time>{` ${dateFormatted}`}</time>
         ) : (
-          <time datetime={dateFormatted}>{` ${dateFormatted}`}</time>
+          <time dateTime={dateFormatted}>{` ${dateFormatted}`}</time>
         )}
       </dd>
     </dl>


### PR DESCRIPTION
# Description

Small bug fix to remove error from having an improperly cased dateTime html attribute.

## Acceptance Criteria

Should get no error related to an improper datetime attribute on the DateModified widget.

## Test Instructions

1. Run unit tests
2. See no error related to html dateTime attribute.

## Help Requested

NA

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
