### PR TITLE
Make Experiment cards selectable through tabbing

### DIFF
--- a/components/molecules/Experiment.js
+++ b/components/molecules/Experiment.js
@@ -18,6 +18,7 @@ export const Experiment = (props) => {
       }`}
       data-testid={props.dataTestId}
       data-cy={props.dataCy}
+      tabIndex="0"
     >
       <h2 className="mb-2 text-p">{props.title}</h2>
       <span


### PR DESCRIPTION
# Description

[Experiment cards are not selectable through tabbing](https://trello.com/c/zwZU3Ycm/217-217-experiment-cards-are-not-selectable-through-tabbing)

Make cards selectable with tab and logically fit within the tab order.

## Acceptance Criteria

The cards on the experiments page should be selectable with tab.

## Test Instructions

1. Go on the experiments page and check if we're able to select a card with the tab button.

## Checklist

- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
