### PR TITLE
Feature/122 form elements

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,3 +2,4 @@
 . "$(dirname "$0")/_/husky.sh"
 
 npm run lint
+git add .

--- a/components/atoms/CheckBox.js
+++ b/components/atoms/CheckBox.js
@@ -24,6 +24,7 @@ export function CheckBox(props) {
             props.value
           )
         }
+        required={props.required}
         data-cy={props.dataCy}
         data-testid={props.dataTestId}
         {...ifControlledProps}
@@ -69,6 +70,11 @@ CheckBox.propTypes = {
    * the label for the checkbox
    */
   label: PropTypes.string.isRequired,
+
+  /**
+   * whether or not the field is required
+   */
+  required: PropTypes.bool,
 
   /**
    * callback to handle change in checked state, takes three arguments, the checked state, the name and the value

--- a/components/atoms/MultiTextField.js
+++ b/components/atoms/MultiTextField.js
@@ -24,6 +24,7 @@ export function MultiTextField(props) {
         rows={props.rows}
         spellCheck={props.spellCheck}
         wrap={props.wrap}
+        required={props.required}
         data-testid={props.dataTestId}
         data-cy={props.dataCy}
       >
@@ -51,10 +52,16 @@ MultiTextField.propTypes = {
    * the label for the multi text field
    */
   label: PropTypes.string.isRequired,
+
   /**
    * the value for the multi text field
    */
   value: PropTypes.string,
+
+  /**
+   * whether or not the field is required
+   */
+  required: PropTypes.bool,
 
   /**
    * whether or not spellchecking is enabled for this field, by default it is

--- a/components/atoms/RadioButton.js
+++ b/components/atoms/RadioButton.js
@@ -33,6 +33,7 @@ export function RadioButton(props) {
         }}
         data-testid={props.dataTestId}
         data-cy={props.dataCy}
+        required={props.required}
         {...ifControlledProps}
       />
       <label
@@ -71,6 +72,11 @@ RadioButton.propTypes = {
    * the label for the radio button
    */
   label: PropTypes.string.isRequired,
+
+  /**
+   * whether or not the field is required
+   */
+  required: PropTypes.bool,
 
   /**
    * whether the radio button is checked or not

--- a/components/atoms/RadioField.js
+++ b/components/atoms/RadioField.js
@@ -1,9 +1,9 @@
 import PropTypes from "prop-types";
 
 /**
- * check box component for forms
+ * radio field
  */
-export function CheckBox(props) {
+export function RadioField(props) {
   const ifControlledProps = !props.uncontrolled
     ? {
         checked: props.checked,
@@ -16,7 +16,7 @@ export function CheckBox(props) {
         id={props.id}
         name={props.name}
         value={props.value}
-        type="checkbox"
+        type="radio"
         onChange={(e) =>
           props.onChange(
             props.uncontrolled ? !e.currentTarget.checked : props.checked,
@@ -29,7 +29,7 @@ export function CheckBox(props) {
         {...ifControlledProps}
       />
       <label
-        className="checkbox-label control-label inline-block cursor-pointer pt-4px pb-5px px-15px text-xs sm:text-sm leading-tight sm:leading-6 font-normal font-body"
+        className="radio-field-label control-label inline-block cursor-pointer pt-4px pb-5px px-15px text-xs sm:text-sm leading-tight sm:leading-6 font-normal font-body"
         htmlFor={props.id}
         onClick={() => props.onChange(props.checked, props.name, props.value)}
       >
@@ -39,12 +39,12 @@ export function CheckBox(props) {
   );
 }
 
-CheckBox.defaultProps = {
+RadioField.defaultProps = {
   checked: false,
   value: "true",
 };
 
-CheckBox.propTypes = {
+RadioField.propTypes = {
   /**
    * whether or not the checkbox is checked
    */

--- a/components/atoms/RadioField.js
+++ b/components/atoms/RadioField.js
@@ -24,6 +24,7 @@ export function RadioField(props) {
             props.value
           )
         }
+        required={props.required}
         data-cy={props.dataCy}
         data-testid={props.dataTestId}
         {...ifControlledProps}
@@ -59,6 +60,11 @@ RadioField.propTypes = {
    * the name of the checkbox
    */
   name: PropTypes.string.isRequired,
+
+  /**
+   * whether or not the field is required
+   */
+  required: PropTypes.bool,
 
   /**
    * the id of the checkbox

--- a/components/atoms/RadioField.stories.js
+++ b/components/atoms/RadioField.stories.js
@@ -1,0 +1,47 @@
+import React from "react";
+import { RadioField } from "./RadioField";
+
+export default {
+  title: "Components/Atoms/RadioField",
+  component: RadioField,
+  decorators: [
+    (Story) => (
+      <div className="w-full flex justify-center">
+        <div className="w-96">
+          <Story />
+        </div>
+      </div>
+    ),
+  ],
+};
+
+const Template = (args) => <RadioField {...args} />;
+
+export const UnChecked = Template.bind({});
+UnChecked.args = {
+  id: "radio 1",
+  name: "RadioField1",
+  value: "IsChecked",
+  label: "I am a radio button",
+  dataTestId: "unchecked-radio-field",
+};
+
+export const Checked = Template.bind({});
+Checked.args = {
+  id: "radio 1",
+  name: "RadioField1",
+  value: "IsChecked",
+  label: "I am a radio button",
+  dataTestId: "checked-radio-field",
+  checked: true,
+};
+
+export const UnControlled = Template.bind({});
+UnControlled.args = {
+  id: "radio 1",
+  name: "RadioField1",
+  value: "IsChecked",
+  label: "I am an uncontrolled checkbox",
+  dataTestId: "uncontrolled-checkbox",
+  uncontrolled: true,
+};

--- a/components/atoms/RadioField.test.js
+++ b/components/atoms/RadioField.test.js
@@ -1,0 +1,51 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/extend-expect";
+import { axe, toHaveNoViolations } from "jest-axe";
+import { Checked, UnChecked } from "./RadioField.stories";
+
+expect.extend(toHaveNoViolations);
+
+describe("RadioField", () => {
+  let mockFn;
+  beforeEach(() => {
+    mockFn = jest.fn();
+  });
+  afterEach(() => {
+    mockFn.mockRestore();
+  });
+  it("renders in an unchecked state", () => {
+    render(<UnChecked {...UnChecked.args} onChange={mockFn} />);
+    expect(screen.getByText(UnChecked.args.label)).toBeTruthy();
+    screen.getByTestId("unchecked-radio-field").click();
+    expect(mockFn.mock.calls.length).toBe(1);
+    expect(mockFn.mock.calls[0]).toEqual([
+      false,
+      UnChecked.args.name,
+      UnChecked.args.value,
+    ]);
+  });
+
+  it("renders in a checked state", () => {
+    render(<Checked {...Checked.args} onChange={mockFn} />);
+    expect(screen.getByTestId("checked-radio-field")).toBeChecked();
+    screen.getByTestId("checked-radio-field").click();
+    expect(mockFn.mock.calls.length).toBe(1);
+    expect(mockFn.mock.calls[0]).toEqual([
+      true,
+      Checked.args.name,
+      Checked.args.value,
+    ]);
+  });
+
+  it("has no accessibility violations unchecked", async () => {
+    const uncheckedContainer = render(<UnChecked {...UnChecked.args} />);
+    const resultsUnchecked = await axe(uncheckedContainer.container);
+    expect(resultsUnchecked).toHaveNoViolations();
+  });
+
+  it("has no accessibility violations checked", async () => {
+    const checkedContainer = render(<Checked {...Checked.args} />);
+    const resultsChecked = await axe(checkedContainer.container);
+    expect(resultsChecked).toHaveNoViolations(resultsChecked);
+  });
+});

--- a/components/atoms/RadioField.test.js
+++ b/components/atoms/RadioField.test.js
@@ -28,13 +28,6 @@ describe("RadioField", () => {
   it("renders in a checked state", () => {
     render(<Checked {...Checked.args} onChange={mockFn} />);
     expect(screen.getByTestId("checked-radio-field")).toBeChecked();
-    screen.getByTestId("checked-radio-field").click();
-    expect(mockFn.mock.calls.length).toBe(1);
-    expect(mockFn.mock.calls[0]).toEqual([
-      true,
-      Checked.args.name,
-      Checked.args.value,
-    ]);
   });
 
   it("has no accessibility violations unchecked", async () => {

--- a/components/atoms/TextField.js
+++ b/components/atoms/TextField.js
@@ -25,6 +25,7 @@ export function TextField(props) {
         name={props.name}
         placeholder={props.placeholder}
         type="text"
+        required={props.required}
         onChange={(e) => props.onChange(e.currentTarget.value)}
         {...ifControlledProps}
         data-testid={props.dataTestId}
@@ -53,6 +54,11 @@ TextField.propTypes = {
    * the label of the text field
    */
   label: PropTypes.string.isRequired,
+
+  /**
+   * whether ot not the field is required
+   */
+  required: PropTypes.bool,
 
   /**
    * value of the text field

--- a/components/molecules/OptionalTextField.js
+++ b/components/molecules/OptionalTextField.js
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { CheckBox } from "../atoms/CheckBox";
 import { TextField } from "../atoms/TextField";
 import { MultiTextField } from "../atoms/MultiTextField";
+import { RadioField } from "../atoms/RadioField";
 import PropTypes from "prop-types";
 
 /**
@@ -16,23 +17,38 @@ export function OptionalTextField(props) {
       setShowTextField(true);
     }
 
-    if (props.onCheckBoxChange) {
-      props.onCheckBoxChange(wasChecked, name, value);
+    if (props.onControlChange) {
+      props.onControlChange(wasChecked, name, value);
     }
   };
   return (
     <>
-      <CheckBox
-        label={props.checkBoxLabel}
-        id={props.checkBoxId}
-        name={props.checkBoxName}
-        checked={props.checked}
-        uncontrolled={props.uncontrolled}
-        value={props.checkBoxValue}
-        onChange={handleCheckChange}
-        dataTestId={props.checkBoxDataTestId}
-        dataCy={props.checkBoxDataCy}
-      />
+      {props.controlType === "checkbox" && (
+        <CheckBox
+          label={props.controlLabel}
+          id={props.controlId}
+          name={props.controlName}
+          checked={props.checked}
+          uncontrolled={props.uncontrolled}
+          value={props.controlValue}
+          onChange={handleCheckChange}
+          dataTestId={props.controlDataTestId}
+          dataCy={props.controlDataCy}
+        />
+      )}
+      {props.controlType === "radiofield" && (
+        <RadioField
+          label={props.controlLabel}
+          id={props.controlId}
+          name={props.controlName}
+          checked={props.checked}
+          uncontrolled={props.uncontrolled}
+          value={props.controlValue}
+          onChange={handleCheckChange}
+          dataTestId={props.controlDataTestId}
+          dataCy={props.controlDataCy}
+        />
+      )}
       {(props.uncontrolled && showTextField) || props.checked ? (
         props.multiText ? (
           <MultiTextField
@@ -73,11 +89,19 @@ export function OptionalTextField(props) {
   );
 }
 
+OptionalTextField.defaultProps = {
+  controlType: "checkbox",
+};
+
 OptionalTextField.propTypes = {
+  /**
+   * the type of field that should be used
+   */
+  controlType: PropTypes.oneOf(["checkbox", "radiofield"]),
   /**
    * the id for the checkbox
    */
-  checkBoxId: PropTypes.string.isRequired,
+  controlId: PropTypes.string.isRequired,
 
   /**
    * the id for the text field
@@ -87,7 +111,7 @@ OptionalTextField.propTypes = {
   /**
    * the name for the checkbox
    */
-  checkBoxName: PropTypes.string.isRequired,
+  controlName: PropTypes.string.isRequired,
 
   /**
    * the name for the text field
@@ -97,7 +121,7 @@ OptionalTextField.propTypes = {
   /**
    * the label for the checkbox
    */
-  checkBoxLabel: PropTypes.string.isRequired,
+  controlLabel: PropTypes.string.isRequired,
 
   /**
    * the label for the text field
@@ -112,7 +136,7 @@ OptionalTextField.propTypes = {
   /**
    * the value for the checkbox
    */
-  checkBoxValue: PropTypes.string,
+  controlValue: PropTypes.string,
 
   /**
    * the value for the text field
@@ -137,7 +161,7 @@ OptionalTextField.propTypes = {
   /**
    * the test id for the checkbox to select in unit tests
    */
-  checkBoxDataTestId: PropTypes.string,
+  controlDataTestId: PropTypes.string,
 
   /**
    * the test id for the text field to select in unit tests
@@ -147,7 +171,7 @@ OptionalTextField.propTypes = {
   /**
    * the cypress selector for the checkbox
    */
-  checkBoxDataCy: PropTypes.string,
+  controlDataCy: PropTypes.string,
 
   /**
    * the cypress selector for the text field
@@ -157,7 +181,7 @@ OptionalTextField.propTypes = {
   /**
    * callback when the checkbox changes
    */
-  onCheckBoxChange: PropTypes.func,
+  onControlChange: PropTypes.func,
 
   /**
    * callback when the text field changes

--- a/components/molecules/OptionalTextField.js
+++ b/components/molecules/OptionalTextField.js
@@ -192,7 +192,6 @@ OptionalTextField.propTypes = {
    */
   textFieldDataCy: PropTypes.string,
 
-
   /**
    * callback when the checkbox changes
    */

--- a/components/molecules/OptionalTextField.js
+++ b/components/molecules/OptionalTextField.js
@@ -33,6 +33,7 @@ export function OptionalTextField(props) {
           value={props.controlValue}
           onChange={handleCheckChange}
           dataTestId={props.controlDataTestId}
+          required={props.controlRequired}
           dataCy={props.controlDataCy}
         />
       )}
@@ -45,6 +46,7 @@ export function OptionalTextField(props) {
           uncontrolled={props.uncontrolled}
           value={props.controlValue}
           onChange={handleCheckChange}
+          required={props.controlRequired}
           dataTestId={props.controlDataTestId}
           dataCy={props.controlDataCy}
         />
@@ -62,6 +64,7 @@ export function OptionalTextField(props) {
             cols={props.cols}
             spellCheck={props.spellCheck}
             wrap={props.wrap}
+            required={props.textFieldRequired}
             onChange={
               props.onTextFieldChange ? props.onTextFieldChange : () => {}
             }
@@ -77,6 +80,7 @@ export function OptionalTextField(props) {
             value={props.textFieldValue}
             boldLabel={props.textLabelBold}
             uncontrolled={props.uncontrolled}
+            required={props.textFieldRequired}
             onChange={
               props.onTextFieldChange ? props.onTextFieldChange : () => {}
             }
@@ -159,6 +163,16 @@ OptionalTextField.propTypes = {
   uncontrolled: PropTypes.bool,
 
   /**
+   * whether or not the control is required
+   */
+  controlRequired: PropTypes.bool,
+
+  /**
+   * whether or not the text field is required
+   */
+  textFieldRequired: PropTypes.bool,
+
+  /**
    * the test id for the checkbox to select in unit tests
    */
   controlDataTestId: PropTypes.string,
@@ -177,6 +191,7 @@ OptionalTextField.propTypes = {
    * the cypress selector for the text field
    */
   textFieldDataCy: PropTypes.string,
+
 
   /**
    * callback when the checkbox changes

--- a/components/molecules/OptionalTextField.stories.js
+++ b/components/molecules/OptionalTextField.stories.js
@@ -19,53 +19,67 @@ const Template = (args) => <OptionalTextField {...args} />;
 
 export const UnOpened = Template.bind({});
 UnOpened.args = {
-  checkBoxId: "nutella-check-1",
+  controlId: "nutella-check-1",
   textFieldId: "nutella-text-1",
-  checkBoxName: "nutellaCheckOne",
+  controlName: "nutellaCheckOne",
   textFieldName: "nutellaTextOne",
-  checkBoxLabel: "Do you not like Nutella ?",
+  controlLabel: "Do you not like Nutella ?",
   textFieldLabel: "Please explain why you are wrong ?",
-  checkBoxDataTestId: "unopened-check-1",
+  controlDataTestId: "unopened-check-1",
   textFieldDataTestId: "unopened-text-1",
 };
 
 export const Opened = Template.bind({});
 Opened.args = {
-  checkBoxId: "nutella-check-1",
+  controlId: "nutella-check-1",
   textFieldId: "nutella-text-1",
-  checkBoxName: "nutellaCheckOne",
+  controlName: "nutellaCheckOne",
   textFieldName: "nutellaTextOne",
-  checkBoxLabel: "Do you not like Nutella ?",
+  controlLabel: "Do you not like Nutella ?",
   checked: true,
   textFieldLabel: "Please explain why you are wrong ?",
-  checkBoxDataTestId: "opened-check-1",
+  controlDataTestId: "opened-check-1",
   textFieldDataTestId: "opened-text-1",
+};
+
+export const Radio = Template.bind({});
+Radio.args = {
+  controlType: "radiofield",
+  controlId: "nutella-check-1",
+  textFieldId: "nutella-text-1",
+  controlName: "nutellaCheckOne",
+  textFieldName: "nutellaTextOne",
+  controlLabel: "Do you not like Nutella ?",
+  checked: true,
+  textFieldLabel: "Please explain why you are wrong ?",
+  controlDataTestId: "radio-check-1",
+  textFieldDataTestId: "radio-text-1",
 };
 
 export const UnControlled = Template.bind({});
 UnControlled.args = {
-  checkBoxId: "nutella-check-1",
+  controlId: "nutella-check-1",
   textFieldId: "nutella-text-1",
-  checkBoxName: "nutellaCheckOne",
+  controlName: "nutellaCheckOne",
   textFieldName: "nutellaTextOne",
-  checkBoxLabel: "Do you not like Nutella ?",
+  controlLabel: "Do you not like Nutella ?",
   uncontrolled: true,
   textFieldLabel: "Please explain why you are wrong ?",
-  checkBoxDataTestId: "uncontrolled-check-1",
+  controlDataTestId: "uncontrolled-check-1",
   textFieldDataTestId: "uncontrolled-text-1",
 };
 
 export const MultiText = Template.bind({});
 MultiText.args = {
-  checkBoxId: "nutella-check-1",
+  controlId: "nutella-check-1",
   textFieldId: "nutella-text-1",
-  checkBoxName: "nutellaCheckOne",
+  controlName: "nutellaCheckOne",
   textFieldName: "nutellaTextOne",
-  checkBoxLabel: "Do you not like Nutella ?",
+  controlLabel: "Do you not like Nutella ?",
   uncontrolled: true,
   multiText: true,
   rows: 5,
   textFieldLabel: "Please explain why you are wrong ?",
-  checkBoxDataTestId: "multitext-check-1",
+  controlDataTestId: "multitext-check-1",
   textFieldDataTestId: "multitext-text-1",
 };

--- a/components/molecules/OptionalTextField.test.js
+++ b/components/molecules/OptionalTextField.test.js
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom/extend-expect";
 import { axe, toHaveNoViolations } from "jest-axe";
-import { UnControlled, MultiText, Opened } from "./OptionalTextField.stories";
+import { UnControlled, MultiText, Radio } from "./OptionalTextField.stories";
 
 expect.extend(toHaveNoViolations);
 
@@ -25,6 +25,12 @@ describe("OptionalTextField", () => {
     expect(screen.getByTestId("uncontrolled-text-1")).toBeTruthy();
     const results = await axe(container);
     expect(results).toHaveNoViolations();
+  });
+
+  it("renders radio input when specified", async () => {
+    render(<Radio {...Radio.args} />);
+    let radio = screen.getByTestId("radio-check-1");
+    expect(radio.type).toBe("radio");
   });
 
   it("renders multitext field when specified", async () => {

--- a/components/organisms/ReportAProblem.js
+++ b/components/organisms/ReportAProblem.js
@@ -70,62 +70,62 @@ export function ReportAProblem(props) {
               {t("reportAProblemCheckAllThatApply")}
             </legend>
             <OptionalTextField
-              checkBoxId="incorrectInformationCheckBox"
+              controlId="incorrectInformationCheckBox"
               textFieldId="incorrectInformationTextField"
-              checkBoxName="incorrect_information"
+              controlName="incorrect_information"
               textFieldName="incorrect_information_details"
-              checkBoxLabel={t("reportAProblemIncorrectInformation")}
+              controlLabel={t("reportAProblemIncorrectInformation")}
               textFieldLabel={t("reportAProblemProvideMoreDetails")}
               uncontrolled={true}
               multiText={true}
               textLabelBold={true}
               wrap="hard"
               maxLength={750}
-              checkBoxDataTestId="incorrectInformation-checkbox"
+              controlDataTestId="incorrectInformation-checkbox"
               textFieldDataTestId="incorrectInformation-text"
-              checkBoxDataCy="incorrectInformation-checkbox"
+              controlDataCy="incorrectInformation-checkbox"
               textFieldDataCy="incorrectInformation-text"
             />
             <OptionalTextField
-              checkBoxId="unclearInformationCheckBox"
+              controlId="unclearInformationCheckBox"
               textFieldId="unclearInformationTextField"
-              checkBoxName="unclear_information"
+              controlName="unclear_information"
               textFieldName="unclear_information_details"
-              checkBoxLabel={t("reportAProblemUnclearInformation")}
+              controlLabel={t("reportAProblemUnclearInformation")}
               textFieldLabel={t("reportAProblemProvideMoreDetails")}
               uncontrolled={true}
               multiText={true}
               textLabelBold={true}
               wrap="hard"
               maxLength={750}
-              checkBoxDataTestId="unclearInformation-checkbox"
+              controlDataTestId="unclearInformation-checkbox"
               textFieldDataTestId="unclearInformation-text"
-              checkBoxDataCy="unclearInformation-checkbox"
+              controlDataCy="unclearInformation-checkbox"
               textFieldDataCy="unclearInformation-text"
             />
             <OptionalTextField
-              checkBoxId="infoNotFoundCheckBox"
+              controlId="infoNotFoundCheckBox"
               textFieldId="infoNotFoundTextField"
-              checkBoxName="info_not_found"
+              controlName="info_not_found"
               textFieldName="info_not_found_details"
-              checkBoxLabel={t("reportAProblemDidNotFindWhatYoureLookingFor")}
+              controlLabel={t("reportAProblemDidNotFindWhatYoureLookingFor")}
               textFieldLabel={t("reportAProblemProvideMoreDetails")}
               uncontrolled={true}
               multiText={true}
               textLabelBold={true}
               wrap="hard"
               maxLength={750}
-              checkBoxDataTestId="infoNotFound-checkbox"
+              controlDataTestId="infoNotFound-checkbox"
               textFieldDataTestId="infoNotFound-text"
-              checkBoxDataCy="infoNotFound-checkbox"
+              controlDataCy="infoNotFound-checkbox"
               textFieldDataCy="infoNotFound-text"
             />
             <OptionalTextField
-              checkBoxId="adaptiveTechnologyCheckBox"
+              controlId="adaptiveTechnologyCheckBox"
               textFieldId="adaptiveTechnologyTextField"
-              checkBoxName="adaptive_technology"
+              controlName="adaptive_technology"
               textFieldName="adaptive_technology_details"
-              checkBoxLabel={t(
+              controlLabel={t(
                 "reportAProblemPageDoesNotWorkWithAdaptiveTechnology"
               )}
               textFieldLabel={t("reportAProblemProvideMoreDetails")}
@@ -134,60 +134,60 @@ export function ReportAProblem(props) {
               textLabelBold={true}
               wrap="hard"
               maxLength={750}
-              checkBoxDataTestId="adaptiveTechnology-checkbox"
+              controlDataTestId="adaptiveTechnology-checkbox"
               textFieldDataTestId="adaptiveTechnology-text"
-              checkBoxDataCy="adaptiveTechnology-checkbox"
+              controlDataCy="adaptiveTechnology-checkbox"
               textFieldDataCy="adaptiveTechnology-text"
             />
             <OptionalTextField
-              checkBoxId="privacyIssuesCheckBox"
+              controlId="privacyIssuesCheckBox"
               textFieldId="privacyIssuesTextField"
-              checkBoxName="privacy_issues"
+              controlName="privacy_issues"
               textFieldName="privacy_issues_details"
-              checkBoxLabel={t("reportAProblemIncorrectInformation")}
+              controlLabel={t("reportAProblemIncorrectInformation")}
               textFieldLabel={t("reportAProblemProvideMoreDetails")}
               uncontrolled={true}
               multiText={true}
               textLabelBold={true}
               wrap="hard"
               maxLength={750}
-              checkBoxDataTestId="privacyIssues-checkbox"
+              controlDataTestId="privacyIssues-checkbox"
               textFieldDataTestId="privacyIssues-text"
-              checkBoxDataCy="privacyIssues-checkbox"
+              controlDataCy="privacyIssues-checkbox"
               textFieldDataCy="privacyIssues-text"
             />
             <OptionalTextField
-              checkBoxId="noWhereElseToGoCheckBox"
+              controlId="noWhereElseToGoCheckBox"
               textFieldId="no_where_else_to_go"
-              checkBoxName="no_where_else_to_go_details"
+              controlName="no_where_else_to_go_details"
               textFieldName="noWhereElseToGoTextField"
-              checkBoxLabel={t("reportAProblemNoWhereElseToGo")}
+              controlLabel={t("reportAProblemNoWhereElseToGo")}
               textFieldLabel={t("reportAProblemProvideMoreDetails")}
               uncontrolled={true}
               multiText={true}
               textLabelBold={true}
               wrap="hard"
               maxLength={750}
-              checkBoxDataTestId="noWhereElseToGo-checkbox"
+              controlDataTestId="noWhereElseToGo-checkbox"
               textFieldDataTestId="noWhereElseToGo-text"
-              checkBoxDataCy="noWhereElseToGo-checkbox"
+              controlDataCy="noWhereElseToGo-checkbox"
               textFieldDataCy="noWhereElseToGo-text"
             />
             <OptionalTextField
-              checkBoxId="otherCheckBox"
+              controlId="otherCheckBox"
               textFieldId="otherTextField"
-              checkBoxName="other"
+              controlName="other"
               textFieldName="other_details"
-              checkBoxLabel={t("reportAProblemOther")}
+              controlLabel={t("reportAProblemOther")}
               textFieldLabel={t("reportAProblemProvideMoreDetails")}
               uncontrolled={true}
               multiText={true}
               textLabelBold={true}
               wrap="hard"
               maxLength={750}
-              checkBoxDataTestId="other-checkbox"
+              controlDataTestId="other-checkbox"
               textFieldDataTestId="other-text"
-              checkBoxDataCy="other-checkbox"
+              controlDataCy="other-checkbox"
               textFieldDataCy="other-text"
             />
           </fieldset>

--- a/styles/forms.css
+++ b/styles/forms.css
@@ -1,4 +1,4 @@
-.checkbox-label::before{
+.control-label::before{
     content: "";
     position: absolute;
     top: 0;
@@ -10,31 +10,53 @@
     border: 2px solid black;
 }
 
-.checkbox-label::after {
+.radio-field-label.control-label::before{
+    border-radius: 50%;
+}
+
+.control-label::after {
     content: "";
     box-sizing: border-box;
     position: absolute;
-    top: 11px;
-    left: 9px;
-    width: 23px;
-    height: 13px;
+}
+
+.checkbox-label.control-label::after{
     transform: rotate(-45deg);
     border: solid black;
     border-width: 0 0 5px 5px;
     border-top-color: transparent;
     opacity: 0;
     background: transparent;
+    top: 11px;
+    left: 9px;
+    width: 23px;
+    height: 13px;
 }
 
-.checkbox-label{
+.radio-field-label.control-label::after{
+    border: solid black;
+    border-radius: 50%;
+    opacity: 0;
+    top: 5px;
+    left: 5px;
+    width: 30px;
+    height: 30px;
+    background: black;
+}
+
+.control-label{
     touch-action: manipulation;
 }
 
-.checkbox-input:checked + .checkbox-label::after{
+.control-input:checked + .control-label::after{
     opacity: 1;
 }
 
-.checkbox-input:focus + .checkbox-label::before {
+.radio-field:checked + .control-label::after{
+    opacity: 1;
+}
+
+.control-input:focus + .control-label::before {
     border-width: 4px;
     -webkit-box-shadow: 0 0 0 3px #fd0;
     box-shadow: 0 0 0 3px #fd0;


### PR DESCRIPTION
# Description

[success failure page sign up form](https://trello.com/c/stGZUuwk/122-122-success-failure-page-sign-up-form)

In an effort to keep the PRs small and re-viewable I will open several smaller PRs for this task. This PR includes the following changes.

* Added radio input with similar styling to checkbox
* Refactored form.css to be more modular
* Added required prop to all form fields
* modified the OptionalTextField component to support radio input... You can now either specify `checkbox` or `radiofield` to specify a checkbox or radio input respectively 

## Acceptance Criteria

N/A

## Test Instructions

1. Open Storybooks and check out the RadioField Component as well as the Op

## Help Requested

N/A

## Checklist

- [ ] Strings use placeholders for translation (No hard coded strings)
- [x] Unit tests have been added/updated

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
