### PR TITLE
_app.js check for stored language, show splash if none

### DIFF
--- a/components/organisms/Layout.js
+++ b/components/organisms/Layout.js
@@ -10,6 +10,15 @@ import { useTranslation } from "next-i18next";
 import { DateModified } from "../atoms/DateModified";
 import { SearchBar } from "../atoms/SearchBar";
 
+const setLanguage = (language) => {
+  if (typeof window !== "undefined") {
+    console.log(language);
+    language === "fr"
+      ? window.localStorage.setItem("lang", "fr")
+      : window.localStorage.setItem("lang", "en");
+  }
+};
+
 /**
  * Component which defines the layout of the page for all screen sizes
  */
@@ -35,16 +44,25 @@ export const Layout = ({
               alt="Symbol of the Government of Canada"
             />
             <Link key={language} href={langUrl} locale={language}>
-              <a className="visible lg:invisible ml-6 sm:ml-16 underline font-body font-bold text-canada-footer-font lg:text-sm text-base hover:text-canada-footer-hover-font-blue ">
+              <a
+                className="visible lg:invisible ml-6 sm:ml-16 underline font-body font-bold text-canada-footer-font lg:text-sm text-base hover:text-canada-footer-hover-font-blue"
+                onClick={() => setLanguage(language)}
+              >
                 {language === "en" ? "EN" : "FR"}
               </a>
             </Link>
           </div>
           <div className="flex-col flex">
-            <Link key={language} href={langUrl} locale={language}>
+            <Link
+              key={language}
+              href={langUrl}
+              locale={language}
+              onClick={() => setLanguage(language)}
+            >
               <a
                 className="lg:visible invisible pb-0 lg:pb-2 self-end underline font-body text-canada-footer-font hover:text-canada-footer-hover-font-blue "
                 data-cy="toggle-language-link"
+                onClick={() => setLanguage(language)}
               >
                 {language === "en" ? "English" : "Français"}
               </a>

--- a/components/organisms/Layout.js
+++ b/components/organisms/Layout.js
@@ -11,12 +11,9 @@ import { DateModified } from "../atoms/DateModified";
 import { SearchBar } from "../atoms/SearchBar";
 
 const setLanguage = (language) => {
-  if (typeof window !== "undefined") {
-    console.log(language);
-    language === "fr"
-      ? window.localStorage.setItem("lang", "fr")
-      : window.localStorage.setItem("lang", "en");
-  }
+  language === "fr"
+    ? window.localStorage.setItem("lang", "fr")
+    : window.localStorage.setItem("lang", "en");
 };
 
 /**

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -23,3 +23,7 @@
 //
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
+
+import "cypress-localstorage-commands";
+
+Cypress.Commands.add("setLanguage", () => cy.setLocalStorage("lang", "en"))

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -21,3 +21,16 @@ import 'cypress-axe'
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
+
+// Set default language for all tests that do not test the Splash page
+before(() => {
+  // Set language in cypress instance localstorage to skip the splash page
+  cy.setLanguage()
+  // Save localstorage
+  cy.saveLocalStorage()
+})
+
+beforeEach(() => {
+  // Restore localstorage to initial state before each test
+  cy.restoreLocalStorage();
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "babel-loader": "^8.2.2",
         "cypress": "^7.3.0",
         "cypress-axe": "^0.12.2",
+        "cypress-localstorage-commands": "^1.4.5",
         "fetch-mock": "^9.11.0",
         "husky": "^6.0.0",
         "jest": "^26.6.3",
@@ -9282,6 +9283,18 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/cypress-localstorage-commands": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/cypress-localstorage-commands/-/cypress-localstorage-commands-1.4.5.tgz",
+      "integrity": "sha512-mr86nv74GvOE4zOFwoMrksFCykNSbRh57Pg7xUGpm2ax+wfHhqwBA56Sn5dhHV73gzz7C6B1kfNpMrjMH/hgyg==",
+      "dev": true,
+      "engines": {
+        "node": "10.x || 12.x || 14.x || 15.x || 16.x"
+      },
+      "peerDependencies": {
+        "cypress": "^2.1.0 || 3.x || 4.x || 5.x || 6.x || 7.x"
       }
     },
     "node_modules/cypress/node_modules/ansi-styles": {
@@ -33128,6 +33141,13 @@
       "resolved": "https://registry.npmjs.org/cypress-axe/-/cypress-axe-0.12.2.tgz",
       "integrity": "sha512-gn+rVJ2JnvUWhBshbZ/8dkJdANaEB96zgtAEClJ7vNvDgmqAYb+HhQpW0GM04EqtIiPhenqUeKNQDoqrquY5+w==",
       "dev": true
+    },
+    "cypress-localstorage-commands": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/cypress-localstorage-commands/-/cypress-localstorage-commands-1.4.5.tgz",
+      "integrity": "sha512-mr86nv74GvOE4zOFwoMrksFCykNSbRh57Pg7xUGpm2ax+wfHhqwBA56Sn5dhHV73gzz7C6B1kfNpMrjMH/hgyg==",
+      "dev": true,
+      "requires": {}
     },
     "dashdash": {
       "version": "1.14.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "alpha-site",
       "version": "0.1.0",
       "dependencies": {
         "@tailwindcss/typography": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "babel-loader": "^8.2.2",
     "cypress": "^7.3.0",
     "cypress-axe": "^0.12.2",
+    "cypress-localstorage-commands": "^1.4.5",
     "fetch-mock": "^9.11.0",
     "husky": "^6.0.0",
     "jest": "^26.6.3",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -18,10 +18,10 @@ function MyApp({ Component, pageProps }) {
   useEffect(() => {
     if (typeof window !== "undefined") {
       const lang = window.localStorage.getItem("lang");
-      if (!lang) {
-        router.push("/splash");
-      } else {
+      if (lang === "en" || lang === "fr") {
         router.push(router.asPath, {}, { locale: lang });
+      } else {
+        router.push("splash");
       }
     }
   }, []);

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -5,12 +5,27 @@ import "../styles/forms.css";
 import "../styles/fonts.css";
 import "../styles/menu.css";
 import Head from "next/head";
+import { useEffect } from "react";
+import { useRouter } from "next/router";
 
 if (process.env.NEXT_PUBLIC_API_MOCKING === "enabled") {
   require("../mocks");
 }
 
 function MyApp({ Component, pageProps }) {
+  const router = useRouter();
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const lang = window.localStorage.getItem("lang");
+      if (!lang) {
+        router.push("/splash");
+      } else {
+        router.push(router.asPath, {}, { locale: lang });
+      }
+    }
+  }, []);
+
   return (
     <>
       <Head>

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -10,7 +10,7 @@ class MyDocument extends Document {
 
   render() {
     return (
-      <Html lang="en">
+      <Html>
         <Head />
         <body>
           <Main />

--- a/pages/splash.js
+++ b/pages/splash.js
@@ -5,11 +5,9 @@ import Link from "next/link";
 import { useRouter } from "next/router";
 
 const setLanguage = (event) => {
-  if (typeof window !== "undefined") {
-    event.target.id === "french-button"
-      ? window.localStorage.setItem("lang", "fr")
-      : window.localStorage.setItem("lang", "en");
-  }
+  event.target.id === "french-button"
+    ? window.localStorage.setItem("lang", "fr")
+    : window.localStorage.setItem("lang", "en");
 };
 
 export default function splash(props) {

--- a/pages/splash.js
+++ b/pages/splash.js
@@ -2,6 +2,15 @@ import Head from "next/head";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { ActionButton } from "../components/atoms/ActionButton";
 import Link from "next/link";
+import { useRouter } from "next/router";
+
+const setLanguage = (event) => {
+  if (typeof window !== "undefined") {
+    event.target.id === "french-button"
+      ? window.localStorage.setItem("lang", "fr")
+      : window.localStorage.setItem("lang", "en");
+  }
+};
 
 export default function splash(props) {
   return (
@@ -27,12 +36,14 @@ export default function splash(props) {
               text="English"
               className="inline-block text-sm w-7.5rem xl:w-138px py-3.5 mr-6 rounded leading-3"
               href="/"
+              onClick={setLanguage}
             />
             <ActionButton
               id="french-button"
               text="Français"
               className="w-7.5rem xl:w-138px text-sm py-3.5 inline-block rounded leading-3"
               href="/fr"
+              onClick={setLanguage}
             />
           </div>
         </div>

--- a/pages/splash.js
+++ b/pages/splash.js
@@ -2,7 +2,6 @@ import Head from "next/head";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { ActionButton } from "../components/atoms/ActionButton";
 import Link from "next/link";
-import { useRouter } from "next/router";
 
 const setLanguage = (event) => {
   event.target.id === "french-button"


### PR DESCRIPTION
# Description

[Hook up splash page](https://trello.com/c/D5Zys6KN/224-224-hook-up-splash-page)

This PR hooks up the splash page to the site and works as so:

When a user navigates to any page on the site, the top level `_app.js` component checks the client browser's localstorage for a `lang` property with some value. If the value is neither `en` or `fr`, the user is sent to the splash page to select their preferred language. Once selected, that value is stored under `lang` in localstorage as either `en` or `fr`.

Once the value is stored, on subsequent visits to any page on the site, the localstorage `lang` property will be checked and the user will be routed to the desired page and routed to their selected locale if required. 

For example if a user has selected French as their preferred language, and they try to access the url `alphasite.ca/experiments`, they will be automatically routed to `alphasite.ca/fr/experiments`. They can change their locale anytime with the language toggle on the page, which will also update the `lang` value in localstorage.

## Acceptance Criteria

* If user has never been on site for that browser ( no language set in local storage) and heads to the home page they should be redirected to the splash page to select their language

* Once a user selects their language it should be stored in local storage 

* If a user returns to the home page after navigating off ( has language selected in localstorage ) their language preference should be loaded in and they should be redirected to the appropriate language

* If a user switches languages by using the language toggle their new language preference should be stored

## Test Instructions

1. Clear your localstorage (at least the `lang` property)
2. Navigate to the site
3. Splash page should appear and select a language
4. You are taken to homepage after selecting language, appropriate locale is displayed with content in correct language
5. Toggle language, see that `lang` value is updating

## Help Requested

- Any improvements you think could be made

## Checklist

- [ ] Unit tests have been added/updated

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
