### PR TITLE
Change about this site to h2

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -59,7 +59,7 @@ export default function Home(props) {
             ]}
           />
           <div>
-            <h1>{t("aboutTitle")}</h1>
+            <h2 className="text-h1">{t("aboutTitle")}</h2>
             <br></br>
             <p className="text-sm md:text-p  leading-normal text-left font-body  font-normal">
               {t("AboutThisSite1/3")}


### PR DESCRIPTION
# Description

There is no task linked on Trello. I put an h2 for the second heading since we were getting warnings from html validators.

## Acceptance Criteria

Use an H2 for the second heading ("About this site"). It should look the same as the "What's service canada labs" heading on the About page.

## Test Instructions

1. Check if About this site is an h2 that has the same styling as an h1

## Checklist

- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
