### PR TITLE
Change incorrect information to privacy statement

### DIFF
--- a/components/organisms/ReportAProblem.js
+++ b/components/organisms/ReportAProblem.js
@@ -160,7 +160,7 @@ export function ReportAProblem(props) {
               textFieldId="privacyIssuesTextField"
               controlName="privacy_issues"
               textFieldName="privacy_issues_details"
-              controlLabel={t("reportAProblemIncorrectInformation", {
+              controlLabel={t("reportAProblemYoureWorriedAboutYourPrivacy", {
                 lng: props.language,
               })}
               textFieldLabel={t("reportAProblemProvideMoreDetails", {


### PR DESCRIPTION
# Description

There's no task on Trello. I removed the second "Incorrect information" option in the report a problem dropdown.
![image](https://user-images.githubusercontent.com/72703030/120374994-3efe8180-c2e8-11eb-8ed5-23b9bcd755cb.png)

## Acceptance Criteria

There shouldn't be any duplicates in the dropdown.

## Test Instructions

1. Run the website and check the Report a problem dropdown.

## Checklist

- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
