### PR TITLE
Skip button

### DIFF
--- a/components/atoms/Banner.js
+++ b/components/atoms/Banner.js
@@ -10,7 +10,10 @@ export const Banner = ({ siteTitle, headline }) => {
     <div title="Home banner" className="bg-banner-img py-8">
       <div className="lg:container xxs:mx-0 xxs:px-0 lg:mx-auto lg:px-6 xxl:mx-auto">
         <div className="xxs:w-screen lg:w-2/3 xl:w-1/2 bg-dk-blue bg-opacity-90 text-white p-4">
-          <h1 className="text-h1-xl font-medium pt-4 pb-2 break-words">
+          <h1
+            id="pageMainTitle"
+            className="text-h1-xl font-medium pt-4 pb-2 break-words"
+          >
             {siteTitle}
           </h1>
           <hr className="border-2 border-hr-red-bar bg-hr-red-bar bg-opacity-90 border-opacity-90 w-3/4" />

--- a/components/atoms/Banner.js
+++ b/components/atoms/Banner.js
@@ -13,6 +13,7 @@ export const Banner = ({ siteTitle, headline }) => {
           <h1
             id="pageMainTitle"
             className="text-h1-xl font-medium pt-4 pb-2 break-words"
+            tabIndex="-1"
           >
             {siteTitle}
           </h1>

--- a/components/organisms/Layout.js
+++ b/components/organisms/Layout.js
@@ -10,6 +10,7 @@ import { useTranslation } from "next-i18next";
 import { DateModified } from "../atoms/DateModified";
 import { SearchBar } from "../atoms/SearchBar";
 import { Breadcrumb } from "../atoms/Breadcrumb";
+import { ActionButton } from "../atoms/ActionButton";
 
 const setLanguage = (language) => {
   language === "fr"
@@ -33,6 +34,15 @@ export const Layout = ({
 
   return (
     <div className="overflow-x-hidden">
+      <div className="skip-main">
+        <ActionButton
+          id="skipToMainContent"
+          text={t("skipToMainContentBtn")}
+          custom="bg-custom-blue-dark text-white py-1 px-2 hover:bg-gray-dark"
+          href="#pageMainTitle"
+          dataCyButton={"skip-Content"}
+        />
+      </div>
       <header>
         <PhaseBanner phase={t("Alpha")}>{t("alphaText")}</PhaseBanner>
         <div className="layout-container flex-col flex lg:flex lg:flex-row justify-between  mt-2">

--- a/components/organisms/Layout.js
+++ b/components/organisms/Layout.js
@@ -38,7 +38,7 @@ export const Layout = ({
           id="skipToMainContent"
           className="bg-custom-blue-dark text-white py-1 px-2 hover:bg-gray-dark"
           href="#pageMainTitle"
-          dataCyButton={"skip-Content"}
+          data-cy-button={"skip-Content"}
           role="button"
           draggable="false"
         >

--- a/components/organisms/Layout.js
+++ b/components/organisms/Layout.js
@@ -34,7 +34,7 @@ export const Layout = ({
 
   return (
     <div className="overflow-x-hidden">
-      <div className="skip-main">
+      <nav className="skip-main">
         <ActionButton
           id="skipToMainContent"
           text={t("skipToMainContentBtn")}
@@ -42,7 +42,7 @@ export const Layout = ({
           href="#pageMainTitle"
           dataCyButton={"skip-Content"}
         />
-      </div>
+      </nav>
       <header>
         <PhaseBanner phase={t("Alpha")}>{t("alphaText")}</PhaseBanner>
         <div className="layout-container flex-col flex lg:flex lg:flex-row justify-between  mt-2">

--- a/components/organisms/Layout.js
+++ b/components/organisms/Layout.js
@@ -10,7 +10,6 @@ import { useTranslation } from "next-i18next";
 import { DateModified } from "../atoms/DateModified";
 import { SearchBar } from "../atoms/SearchBar";
 import { Breadcrumb } from "../atoms/Breadcrumb";
-import { ActionButton } from "../atoms/ActionButton";
 
 const setLanguage = (language) => {
   language === "fr"
@@ -35,13 +34,16 @@ export const Layout = ({
   return (
     <div className="overflow-x-hidden">
       <nav className="skip-main">
-        <ActionButton
+        <a
           id="skipToMainContent"
-          text={t("skipToMainContentBtn")}
-          custom="bg-custom-blue-dark text-white py-1 px-2 hover:bg-gray-dark"
+          className="bg-custom-blue-dark text-white py-1 px-2 hover:bg-gray-dark"
           href="#pageMainTitle"
           dataCyButton={"skip-Content"}
-        />
+          role="button"
+          draggable="false"
+        >
+          {t("skipToMainContentBtn")}
+        </a>
       </nav>
       <header>
         <PhaseBanner phase={t("Alpha")}>{t("alphaText")}</PhaseBanner>

--- a/cypress/integration/experiment.spec.js
+++ b/cypress/integration/experiment.spec.js
@@ -37,7 +37,7 @@ describe("experiment page", () => {
 
     it("Filter experiments: All", () => {
         cy.get('[data-cy="all"]').click()
-        cy.get('[data-cy="experiments-list"]>li').should('have.length', 5); // 5 needs to be changed when more or less experiments are added/removed.
+        cy.get('[data-cy="experiments-list"]>li').should('have.length', 4); // 4 needs to be changed when more or less experiments are added/removed.
     });
 
     it("Filter experiments: Active", () => {

--- a/cypress/integration/experiment.spec.js
+++ b/cypress/integration/experiment.spec.js
@@ -37,7 +37,7 @@ describe("experiment page", () => {
 
     it("Filter experiments: All", () => {
         cy.get('[data-cy="all"]').click()
-        cy.get('[data-cy="experiments-list"]>li').should('have.length', 4); // 4 needs to be changed when more or less experiments are added/removed.
+        cy.get('[data-cy="experiments-list"]>li').should('have.length', 5); // 5 needs to be changed when more or less experiments are added/removed.
     });
 
     it("Filter experiments: Active", () => {

--- a/pages/about.js
+++ b/pages/about.js
@@ -26,7 +26,11 @@ export default function About(props) {
             alt=""
           />
         </div>
-        <h1 id="pageMainTitle" className="mb-10 text-h1l font-bold">
+        <h1
+          id="pageMainTitle"
+          className="mb-10 text-h1l font-bold w-max"
+          tabIndex="-1"
+        >
           {t("aboutTitle")}
         </h1>
         <h2 className="mb-6 font-bold">{t("aboutThisSiteHeader")}</h2>

--- a/pages/about.js
+++ b/pages/about.js
@@ -26,7 +26,9 @@ export default function About(props) {
             alt=""
           />
         </div>
-        <h1 className="mb-10 text-h1l font-bold">{t("aboutTitle")}</h1>
+        <h1 id="pageMainTitle" className="mb-10 text-h1l font-bold">
+          {t("aboutTitle")}
+        </h1>
         <h2 className="mb-6 font-bold">{t("aboutThisSiteHeader")}</h2>
         <div className="xl:w-2/3">
           <p className="mb-4">{t("aboutThisSiteContent1")}</p>

--- a/pages/experiments.js
+++ b/pages/experiments.js
@@ -70,7 +70,7 @@ export default function experiments(props) {
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <section className="layout-container mb-10">
-        <h1>{t("experimentsAndExplorationTitle")}</h1>
+        <h1 id="pageMainTitle">{t("experimentsAndExplorationTitle")}</h1>
         <Filter
           label={t("filterBy")}
           options={filters}

--- a/pages/experiments.js
+++ b/pages/experiments.js
@@ -70,7 +70,9 @@ export default function experiments(props) {
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <section className="layout-container mb-10">
-        <h1 id="pageMainTitle">{t("experimentsAndExplorationTitle")}</h1>
+        <h1 id="pageMainTitle" tabIndex="-1" className="w-max">
+          {t("experimentsAndExplorationTitle")}
+        </h1>
         <Filter
           label={t("filterBy")}
           options={filters}

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -83,5 +83,6 @@
   "all": "All",
   "alpha": "Alpha",
   "active": "Active",
-  "filterBy": "Filter by"
+  "filterBy": "Filter by",
+  "skipToMainContentBtn": "Skip to main content"
 }

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -82,5 +82,6 @@
   "all": "Toute",
   "alpha": "Alpha",
   "active": "Active",
-  "filterBy": "Filtrer par:"
+  "filterBy": "Filtrer par:",
+  "skipToMainContentBtn": "Passer au contenu principal"
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -38,6 +38,10 @@ html {
   h6 {
     @apply text-base;
   }
+  /*Focused*/
+  h1:focus {
+    @apply ring-1;
+  }
 }
 
 @layer utilities {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -92,6 +92,14 @@ html {
     content: url(../public/up-caret.svg);
   }
 
+  .skip-main{
+    @apply absolute w-px h-px -left-96
+  }
+
+  .skip-main:focus-within{
+    @apply absolute w-screen h-auto top-16 left-0 z-50 flex justify-center
+  }
+
   .layout-container {
     @apply mx-6;
   }


### PR DESCRIPTION
# Description

[Create a "Skip to Content" link in the layout for a11y](https://trello.com/c/1hxhUiQZ/231-231-create-a-skip-to-content-link-in-the-layout-for-a11y)

I made Skip to Content button accessible for keyboard users to skip straight to the main content without going through multiple things with tab.
![image](https://user-images.githubusercontent.com/72703030/120817919-1eb90780-c520-11eb-85d8-158f3b49d0b4.png)

## Acceptance Criteria

Skip to main content button should be the first thing reachable with tab and also should skip to the main title.

## Test Instructions

1. Test the button to see if it skips to the main title on each page (Home, Experiments, About)
2. It should always be invisible unless it's focused
3. It should always be centered horizontally no matter the screen size

## Help Requested

- I put the place under the alpha banner since like Canada.ca doesn't have an alpha banner but if anyone has suggestions for placement, I'm open to it!

## Checklist

- [x] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
