### PR TITLE
Footer fix

### DIFF
--- a/components/organisms/Footer.js
+++ b/components/organisms/Footer.js
@@ -36,7 +36,7 @@ export function Footer(props) {
                     key={index}
                     className={
                       index === 0
-                        ? "lg:mb-4 mb-5 mr-2.5 list-inside text-xxs"
+                        ? "lg:mb-4 mb-5 mr-2.5 list-inside list-disc xl:list-none text-xxs"
                         : "lg:mb-4 mb-5 mr-2.5 list-inside list-disc text-xxs"
                     }
                   >

--- a/components/organisms/Footer.js
+++ b/components/organisms/Footer.js
@@ -34,7 +34,11 @@ export function Footer(props) {
                 return (
                   <li
                     key={index}
-                    className="lg:mb-4 mb-5 mr-2.5 list-inside list-disc text-xxs"
+                    className={
+                      index === 0
+                        ? "lg:mb-4 mb-5 mr-2.5 list-inside text-xxs"
+                        : "lg:mb-4 mb-5 mr-2.5 list-inside list-disc text-xxs"
+                    }
                   >
                     <a
                       className="text-xs font-body hover:text-canada-footer-hover-font-blue text-canada-footer-font "


### PR DESCRIPTION
# Description

There isn't any task on the board. I just saw that our footer link wasn't like the canada.ca one, so I fixed it.

On Canada.ca:
![image](https://user-images.githubusercontent.com/72703030/120854935-c992eb00-c54b-11eb-892b-d8244e313348.png)

On the alpha site:
![image](https://user-images.githubusercontent.com/72703030/120855032-f0512180-c54b-11eb-81f9-2336f9717ea1.png)

Fix:
![image](https://user-images.githubusercontent.com/72703030/120855074-019a2e00-c54c-11eb-94f5-2b9733e2fc6d.png)

## Acceptance Criteria
There shouldn't be a dot before the first list item.

## Test Instructions

1. Run the code and see if the first list item has a dot in the footer.

## Checklist

- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
