### PR TITLE
404 reload error Fix and Stored Lang fix

### DIFF
--- a/components/organisms/Layout.js
+++ b/components/organisms/Layout.js
@@ -10,8 +10,6 @@ import { useTranslation } from "next-i18next";
 import { DateModified } from "../atoms/DateModified";
 import { SearchBar } from "../atoms/SearchBar";
 import { Breadcrumb } from "../atoms/Breadcrumb";
-import { useEffect } from "react";
-import { useRouter } from "next/router";
 
 const setLanguage = (language) => {
   language === "fr"
@@ -30,19 +28,6 @@ export const Layout = ({
   langUrl,
   breadcrumbItems,
 }) => {
-  const router = useRouter();
-
-  useEffect(() => {
-    if (typeof window !== "undefined") {
-      const lang = window.localStorage.getItem("lang");
-      if (lang === "en" || lang === "fr") {
-        router.push(router.asPath, {}, { locale: lang });
-      } else {
-        router.push("splash");
-      }
-    }
-  }, []);
-
   const { t } = useTranslation("common");
   const language = locale === "en" ? "fr" : "en";
 

--- a/components/organisms/Layout.js
+++ b/components/organisms/Layout.js
@@ -10,6 +10,8 @@ import { useTranslation } from "next-i18next";
 import { DateModified } from "../atoms/DateModified";
 import { SearchBar } from "../atoms/SearchBar";
 import { Breadcrumb } from "../atoms/Breadcrumb";
+import { useEffect } from "react";
+import { useRouter } from "next/router";
 
 const setLanguage = (language) => {
   language === "fr"
@@ -28,6 +30,19 @@ export const Layout = ({
   langUrl,
   breadcrumbItems,
 }) => {
+  const router = useRouter();
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const lang = window.localStorage.getItem("lang");
+      if (lang === "en" || lang === "fr") {
+        router.push(router.asPath, {}, { locale: lang });
+      } else {
+        router.push("splash");
+      }
+    }
+  }, []);
+
   const { t } = useTranslation("common");
   const language = locale === "en" ? "fr" : "en";
 

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -18,7 +18,7 @@ function MyApp({ Component, pageProps }) {
   useEffect(() => {
     if (typeof window !== "undefined") {
       const lang = window.localStorage.getItem("lang");
-      if (lang === null) {
+      if (!lang) {
         router.push("splash");
       }
     }

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -5,27 +5,12 @@ import "../styles/forms.css";
 import "../styles/fonts.css";
 import "../styles/menu.css";
 import Head from "next/head";
-import { useEffect } from "react";
-import { useRouter } from "next/router";
 
 if (process.env.NEXT_PUBLIC_API_MOCKING === "enabled") {
   require("../mocks");
 }
 
 function MyApp({ Component, pageProps }) {
-  const router = useRouter();
-
-  useEffect(() => {
-    if (typeof window !== "undefined") {
-      const lang = window.localStorage.getItem("lang");
-      if (lang === "en" || lang === "fr") {
-        router.push(router.asPath, {}, { locale: lang });
-      } else {
-        router.push("splash");
-      }
-    }
-  }, []);
-
   return (
     <>
       <Head>

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -5,12 +5,25 @@ import "../styles/forms.css";
 import "../styles/fonts.css";
 import "../styles/menu.css";
 import Head from "next/head";
+import { useEffect } from "react";
+import { useRouter } from "next/router";
 
 if (process.env.NEXT_PUBLIC_API_MOCKING === "enabled") {
   require("../mocks");
 }
 
 function MyApp({ Component, pageProps }) {
+  const router = useRouter();
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const lang = window.localStorage.getItem("lang");
+      if (lang === null) {
+        router.push("splash");
+      }
+    }
+  }, []);
+
   return (
     <>
       <Head>


### PR DESCRIPTION
# Description

[404 page refreshes over and over when it is served](https://trello.com/c/bWcrLvBj/238-238-404-page-refreshes-over-and-over-when-it-is-served)
[Do not route users to their stored locale/language](https://trello.com/c/SQKHI9rL/251-251-do-not-route-users-to-their-stored-locale-language)

These two tasks are related. Fixing the route issue also fixed the 404 reload issue. So now the 404 page shouldn't reload. Also if there's isn't any lang value in your local storage, you should be redirected to the splash page. 

## Acceptance Criteria
404 page shouldn't keep reloading.

If a user enters an English link into their browser, they should be taken to the English page regardless of the language selected on the splash page. The language selected after the splash page should only be relevant to that session.

## Test Instructions

1. Test 404 error
2. Delete lang value in local storage if you have one and go on the site, it should redirect to splash page
3. Go to the opposite language using a link and not the button on the page, it should show in that language even if lang value is the opposite

## Checklist

- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
