### PR TITLE
Focus on error summary on submit

### DIFF
--- a/components/molecules/ErrorBox.js
+++ b/components/molecules/ErrorBox.js
@@ -13,7 +13,10 @@ export function ErrorBox(props) {
   };
 
   return (
-    <div className="relative border-l-4 border-error-border-red min-h-40px mb-10">
+    <div
+      id="error-box"
+      className="relative border-l-4 border-error-border-red min-h-40px mb-10"
+    >
       <span className="icon-error absolute top-1 -left-2.5 bg-white" />
       <p className="font-bold ml-4">{props.text}</p>
       <ul className="w-full list-disc list-inside leading-loose ml-4">

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -300,6 +300,7 @@ export default function Signup(props) {
       await setErrorBoxText(
         `The form could not be submitted because ${errorsList.length} errors were found`
       );
+      document.getElementById("error-box").scrollIntoView();
     } else {
       //submit data to the api and then redirect to the thank you page
       const response = await fetch("/api/sign-up", {


### PR DESCRIPTION
# Description

https://trello.com/c/cHUQcnSm

Move the focus to the list of errors (if there are any) when submitting the user signup form.

## Test Instructions

1. Navigate to the user signup form
2. Move to the bottom without entering anything in the form
3. Try to submit the from and notice that focus moves up to the summary of errors.

## Checklist

- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
