### PR TITLE
changed e2e testing mock handler to env variable

### DIFF
--- a/mocks/handlers.js
+++ b/mocks/handlers.js
@@ -2,7 +2,7 @@ import { rest } from 'msw'
 import experimentsFixture from '../cypress/fixtures/experiments.json'
 
 export const handlers = [
-  rest.get('https://alphasite-api.dts-stn.com/experiments', async (req, res, ctx) => {
+  rest.get(`${process.env.STRAPI_API_BACKEND_URL}/experiments`, async (req, res, ctx) => {
     return res(
       ctx.json(experimentsFixture)
     )


### PR DESCRIPTION
# Description

Simple fix to change our mock route handler to an env variable from a hardcoded string.

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
