### PR TITLE
Call to action component

### DIFF
--- a/components/molecules/CallToAction.js
+++ b/components/molecules/CallToAction.js
@@ -1,0 +1,53 @@
+import PropTypes from "prop-types";
+import { ActionButton } from "../atoms/ActionButton";
+import Link from "next/link";
+
+/**
+ * A section that will have a title, small description, and a link to some action we want to user to make
+ */
+export function CallToAction(props) {
+  return (
+    <div className="bg-custom-blue-experiment-blue text-white">
+      <h2>{props.title}</h2>
+      <div className="layout-container mb-2 mt-5">
+        <div className="flex flex-col lg:grid lg:grid-cols-2 lg:gap-24">
+          <p>{props.description}</p>
+          <div>
+            <ActionButton
+              id="become-a-participant-btn"
+              href={props.href}
+              text={props.hrefText}
+            />
+            <Link href="#">
+              <a className="text-sm hover:text-canada-footer-hover-font-blue text-canada-footer-font visited:text-purple-700 underline">
+                {item.text}
+              </a>
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+CallToAction.propTypes = {
+  /**
+   * title of the call to action
+   */
+  title: PropTypes.string.isRequired,
+
+  /**
+   * a short description about what the call to action is about
+   */
+  description: PropTypes.string.isRequired,
+
+  /**
+   * the url to the action
+   */
+  href: PropTypes.string.isRequired,
+
+  /**
+   * url text to be displayed
+   */
+  hrefText: PropTypes.string.isRequired,
+};

--- a/components/molecules/CallToAction.js
+++ b/components/molecules/CallToAction.js
@@ -10,22 +10,24 @@ export function CallToAction(props) {
   const { t } = useTranslation("common");
   return (
     <div className="bg-custom-blue-experiment-blue text-white">
-      <h2>{props.title}</h2>
-      <div className="layout-container mb-2 mt-5">
+      <div className="layout-container pb-10 pt-10 text-xs md:text-base">
+        <h2>{props.title}</h2>
         <div className="flex flex-col lg:grid lg:grid-cols-2 lg:gap-24">
           <p>{props.description}</p>
           <div>
-            <ActionButton
-              id="become-a-participant-btn"
-              href={props.href}
-              text={props.hrefText}
-            />
-            {/*TODO: figure out what the privacy link is*/}
-            <Link href="#">
-              <a className="text-sm hover:text-canada-footer-hover-font-blue text-canada-footer-font visited:text-purple-700 underline">
-                {t("privacyLinkText")}
-              </a>
-            </Link>
+            <p className="mb-4">
+              <ActionButton
+                id="become-a-participant-btn"
+                href={props.href}
+                text={props.hrefText}
+              />
+            </p>
+            <p>
+              {/*TODO: figure out what the privacy link is*/}
+              <Link href="#">
+                <a className="text-sm underline">{t("privacyLinkText")}</a>
+              </Link>
+            </p>
           </div>
         </div>
       </div>

--- a/components/molecules/CallToAction.js
+++ b/components/molecules/CallToAction.js
@@ -1,11 +1,13 @@
 import PropTypes from "prop-types";
 import { ActionButton } from "../atoms/ActionButton";
 import Link from "next/link";
+import { useTranslation } from "next-i18next";
 
 /**
  * A section that will have a title, small description, and a link to some action we want to user to make
  */
 export function CallToAction(props) {
+  const { t } = useTranslation("common");
   return (
     <div className="bg-custom-blue-experiment-blue text-white">
       <h2>{props.title}</h2>
@@ -18,9 +20,10 @@ export function CallToAction(props) {
               href={props.href}
               text={props.hrefText}
             />
+            {/*TODO: figure out what the privacy link is*/}
             <Link href="#">
               <a className="text-sm hover:text-canada-footer-hover-font-blue text-canada-footer-font visited:text-purple-700 underline">
-                {item.text}
+                {t("privacyLinkText")}
               </a>
             </Link>
           </div>

--- a/components/molecules/CallToAction.stories.js
+++ b/components/molecules/CallToAction.stories.js
@@ -1,0 +1,17 @@
+import React from "react";
+import { CallToAction } from "./CallToAction";
+
+export default {
+  title: "Components/Molecules/CallToAction",
+  component: CallToAction,
+};
+
+const Template = (args) => <CallToAction {...args} />;
+
+export const Primary = Template.bind({});
+Primary.args = {
+  title: "the title",
+  description: "a description that should be short and concise",
+  href: "#",
+  hrefText: "the link text",
+};

--- a/components/molecules/CallToAction.test.js
+++ b/components/molecules/CallToAction.test.js
@@ -1,0 +1,25 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/extend-expect";
+import { Primary } from "./CallToAction.stories";
+import { axe, toHaveNoViolations } from "jest-axe";
+
+expect.extend(toHaveNoViolations);
+
+describe("CallToAction", () => {
+  it("renders component correctly", () => {
+    render(<Primary {...Primary.args} />);
+    screen.getByText(Primary.args.title);
+    screen.getByText(Primary.args.description);
+    screen.getByText(Primary.args.hrefText);
+    screen.getByText("privacyLinkText");
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(<Primary {...Primary.args} />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -172,5 +172,6 @@
   "errorUnknown": "An unknown error has occurred during your registration. Please contact experience@servicecanada.gc.ca to continue your registration or try again later",
   "error": "Error",
   "signupBtn": "Sign up",
-  "errorMustBe18": "Must be at least 18 years old"
+  "errorMustBe18": "Must be at least 18 years old",
+  "privacyLinkText": "Review the privacy policy"
 }

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -45,7 +45,7 @@
   "experimentsAndExploration-2/3": "Ce site Web présente des tests et des premiers modèles de fonctionnalités et de services sur lesquels nous travaillons actuellement. Ces fonctionnalités et services en sont encore à leurs débuts et ne sont pas encore prêts pour les heures de grande écoute, mais nous vous invitons dans les coulisses à nous aider à les tester et à les améliorer au fur et à mesure.",
   "experimentsAndExploration-3/3": "Vous pouvez voir tous nos tests en cours au même endroit, pour nous faciliter la collaboration et vous montrer sur quoi nous travaillons. Nous avons rendu ces tests accessibles au public dans l’esprit de travailler en plein air.",
   "experimentsComment": "“L'expérimentation entraîne la surprise et la découverte.”",
-  "experimentsBtnTxt" :"Voir les expériences",
+  "experimentsBtnTxt": "Voir les expériences",
   "experimentsTagAll": "Tout",
   "experimentsTagActive": "Active",
   "experimentsTagComingSoon": "Bientôt disponible",
@@ -56,8 +56,8 @@
   "circleTxt2/4": "Inscription de personnes pour rejoindre notre liste de testeurs",
   "circleTxt3/4": "Essayer de nouvelles technologies",
   "circleTxt4/4": "Créer un dialogue ouvert via les blogs, le code ouvert et les premiers modèles",
-  "aboutTitle" : "À propos de ce site",
-  "learnMoreBtn" : "Apprendre encore plus",
+  "aboutTitle": "À propos de ce site",
+  "learnMoreBtn": "Apprendre encore plus",
   "footerContactUs": "Contactez-nous",
   "footerNews": "Nouvelles",
   "footerPm": "Premier ministre",
@@ -171,5 +171,6 @@
   "errorUnknown": "Une erreur inconnue s'est produite lors de votre inscription. Veuillez contacter experience@servicecanada.gc.ca pour poursuivre votre inscription ou réessayer plus tard",
   "error": "Erreur",
   "signupBtn": "Inscrivez-vous",
-  "errorMustBe18": "Vous devez être âgé de 18 ans ou plus"
+  "errorMustBe18": "Vous devez être âgé de 18 ans ou plus",
+  "privacyLinkText": "Lire la politique en matière de protection des renseignements personnels dans son intégralité"
 }


### PR DESCRIPTION
# Description

[Content updates](https://trello.com/c/SWSpQsId)

As part of the content update, a new component is necessary. I'm trying to make it reusable in case there will be other calls to action later on.

From Figma:
![image](https://user-images.githubusercontent.com/34345435/121919065-a5ca6480-cd04-11eb-99c7-ede0baedaea0.png)

In storybooks:
![image](https://user-images.githubusercontent.com/34345435/121919163-bed31580-cd04-11eb-89a3-d1868c3bd2ca.png)


## Acceptance Criteria

The component create looks like what is in Figma.


## Checklist

- [x] Strings use placeholders for translation (No hard coded strings)
- [x] Unit tests have been added/updated

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
