### PR TITLE
Title fix

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -36,8 +36,8 @@ export default function Index(props) {
               src={"/sig-blk-en.svg"}
               alt={"Symbol of the Government of Canada"}
             />
-            <div className="w-max container mx-auto py-11 text-p xl:text-h4 font-bold font-display">
-              <h1>alpha.service.canada.ca</h1>
+            <div className="w-max container mx-auto py-11 font-bold font-display">
+              <h1 className="text-p xl:text-h4">alpha.service.canada.ca</h1>
             </div>
             <div className="flex w-max container pb-11 mx-auto font-display">
               <ActionButton


### PR DESCRIPTION
# Description

I just fixed the title for the splash page since it doesn't fit on mobile view in main live.

What it is right now:
![image](https://user-images.githubusercontent.com/72703030/122572773-0ff04b80-d01c-11eb-9059-1314d2c98fb4.png)

Fix:
![image](https://user-images.githubusercontent.com/72703030/122572833-20a0c180-d01c-11eb-8c37-bd8e6f0f3b8f.png)

## Acceptance Criteria

Title should fit on mobile screens

## Test Instructions

1. Go to the splash page and check the mobile view

## Checklist

- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
