### PR TITLE
Values for analytics

### DIFF
--- a/pages/500.js
+++ b/pages/500.js
@@ -1,15 +1,24 @@
 import Head from "next/head";
+import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import Link from "next/link";
 import { ReportAProblem } from "../components/organisms/ReportAProblem";
 import { ActionButton } from "../components/atoms/ActionButton";
 
 export default function error500() {
+  const { t } = useTranslation("common");
   return (
     <div className="min-h-screen relative">
       <Head>
         <title>500</title>
         <link rel="icon" href="/favicon.ico" />
+        <meta name="dcterms.title" content="500" />
+        <meta
+          name="dcterms.language"
+          content={props.locale === "en" ? "eng" : "fra"}
+        />
+        <meta name="dcterms.creator" content={t("creator")} />
+        <meta name="dcterms.accessRights" content="2" />
       </Head>
       <section className="layout-container pb-44">
         <img
@@ -97,8 +106,9 @@ export default function error500() {
   );
 }
 
-export const getStaticProps = async () => ({
+export const getStaticProps = async ({ locale }) => ({
   props: {
+    locale: locale,
     ...(await serverSideTranslations("en", ["common"])),
     ...(await serverSideTranslations("fr", ["common"])),
   },

--- a/pages/500.js
+++ b/pages/500.js
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { ReportAProblem } from "../components/organisms/ReportAProblem";
 import { ActionButton } from "../components/atoms/ActionButton";
 
-export default function error500() {
+export default function error500(props) {
   const { t } = useTranslation("common");
   return (
     <div className="min-h-screen relative">

--- a/pages/confirmation.js
+++ b/pages/confirmation.js
@@ -18,6 +18,13 @@ export default function Confirmation(props) {
       <Head>
         <title>{t("emailConfirmationTitle")}</title>
         <link rel="icon" href="/favicon.ico" />
+        <meta name="dcterms.title" content={t("emailConfirmationTitle")} />
+        <meta
+          name="dcterms.language"
+          content={props.locale === "en" ? "eng" : "fra"}
+        />
+        <meta name="dcterms.creator" content={t("creator")} />
+        <meta name="dcterms.accessRights" content="2" />
       </Head>
       <section className="layout-container mb-12">
         <h1


### PR DESCRIPTION
# Description

I just added the required meta tags for analytics on the 500 error page and the confirmation page.

## Acceptance Criteria

500 error page and confirmation page should have the adobe analytics meta tags.

## Test Instructions

1. Check if the tags on the confirmation page and 500 error page are there. The confirmation page should be translated if the page is in French.

## Checklist

- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
