### PR TITLE
Add attributes

### DIFF
--- a/pages/signup.js
+++ b/pages/signup.js
@@ -380,7 +380,13 @@ export default function Signup(props) {
         </div>
       </section>
       <section className="layout-container">
-        <form data-gc-analytics-formname="ESDC:ServiceCanadaLabsSign-up" data-gc-analytics-collect='[{"value":"input,select","emptyField":"N/A"}]' onSubmit={handleSubmit} onReset={handlerClearData} noValidate>
+        <form
+          data-gc-analytics-formname="ESDC:ServiceCanadaLabsSign-up"
+          data-gc-analytics-collect='[{"value":"input,select","emptyField":"N/A"}]'
+          onSubmit={handleSubmit}
+          onReset={handlerClearData}
+          noValidate
+        >
           <a
             className="block font-body hover:text-canada-footer-hover-font-blue text-canada-footer-font underline mb-5"
             href={t("reportAProblemPrivacyStatementLink")}

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -380,7 +380,7 @@ export default function Signup(props) {
         </div>
       </section>
       <section className="layout-container">
-        <form onSubmit={handleSubmit} onReset={handlerClearData} noValidate>
+        <form data-gc-analytics-formname="ESDC:ServiceCanadaLabsSign-up" data-gc-analytics-collect='[{"value":"input,select","emptyField":"N/A"}]' onSubmit={handleSubmit} onReset={handlerClearData} noValidate>
           <a
             className="block font-body hover:text-canada-footer-hover-font-blue text-canada-footer-font underline mb-5"
             href={t("reportAProblemPrivacyStatementLink")}


### PR DESCRIPTION
# Description

[Implement "Form Tracking (event79, event80)" as on page 10 of the implementation guide](https://trello.com/c/D8kDfHfv/301-implement-form-tracking-event79-event80-as-on-page-10-of-the-implementation-guide)

I just added some attributes to the form for the form tracking.

## Acceptance Criteria

The form should have two data-gc attributes for analytics. I can only test it when it'll be merged.

## Test Instructions

1. Go to the sign-up page and open up the inspector. Look for the form tag and see if it has data-gc-analytics-formname and data-gc-analytics-collect as attributes.

## Help Requested

I left it in English since that's what I saw on a subpage of canada.ca but let me know if we should have translations or not.

## Checklist

- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
