### PR TITLE
Analytics titles

### DIFF
--- a/pages/404.js
+++ b/pages/404.js
@@ -10,7 +10,7 @@ export default function error404(props) {
   return (
     <div className="min-h-screen relative">
       <Head>
-        <title>404</title>
+        <title>{t("bannerTitle") + " - 404"}</title>
         <link rel="icon" href="/favicon.ico" />
         <meta name="dcterms.title" content={t("bannerTitle") + " - 404"} />
         <meta

--- a/pages/404.js
+++ b/pages/404.js
@@ -12,7 +12,7 @@ export default function error404(props) {
       <Head>
         <title>404</title>
         <link rel="icon" href="/favicon.ico" />
-        <meta name="dcterms.title" content="404" />
+        <meta name="dcterms.title" content={t("bannerTitle") + " - 404"} />
         <meta
           name="dcterms.language"
           content={props.locale === "en" ? "eng" : "fra"}

--- a/pages/500.js
+++ b/pages/500.js
@@ -10,7 +10,7 @@ export default function error500(props) {
   return (
     <div className="min-h-screen relative">
       <Head>
-        <title>500</title>
+        <title>{t("bannerTitle") + " - 500"}</title>
         <link rel="icon" href="/favicon.ico" />
         <meta name="dcterms.title" content={t("bannerTitle") + " - 500"} />
         <meta

--- a/pages/500.js
+++ b/pages/500.js
@@ -12,7 +12,7 @@ export default function error500(props) {
       <Head>
         <title>500</title>
         <link rel="icon" href="/favicon.ico" />
-        <meta name="dcterms.title" content="500" />
+        <meta name="dcterms.title" content={t("bannerTitle") + " - 500"} />
         <meta
           name="dcterms.language"
           content={props.locale === "en" ? "eng" : "fra"}

--- a/pages/about.js
+++ b/pages/about.js
@@ -18,7 +18,7 @@ export default function About(props) {
       breadcrumbItems={[{ text: "Service Canada Labs", link: "/" }]}
     >
       <Head>
-        <title>{t("aboutTitle")}</title>
+        <title>{t("scLabsAbout")}</title>
         <link rel="icon" href="/favicon.ico" />
         <meta name="dcterms.title" content={t("menuLink3")} />
         <meta

--- a/pages/about.js
+++ b/pages/about.js
@@ -20,7 +20,7 @@ export default function About(props) {
       <Head>
         <title>{t("scLabsAbout")}</title>
         <link rel="icon" href="/favicon.ico" />
-        <meta name="dcterms.title" content={t("menuLink3")} />
+        <meta name="dcterms.title" content={t("scLabsAbout")} />
         <meta
           name="dcterms.language"
           content={props.locale === "en" ? "eng" : "fra"}

--- a/pages/confirmation.js
+++ b/pages/confirmation.js
@@ -16,7 +16,7 @@ export default function Confirmation(props) {
       breadcrumbItems={[{ text: "Service Canada Labs", link: "/" }]}
     >
       <Head>
-        <title>{t("emailConfirmationTitle")}</title>
+        <title>{t("scLabsConfirmation")}</title>
         <link rel="icon" href="/favicon.ico" />
         <meta name="dcterms.title" content={t("scLabsConfirmation")} />
         <meta

--- a/pages/confirmation.js
+++ b/pages/confirmation.js
@@ -18,7 +18,7 @@ export default function Confirmation(props) {
       <Head>
         <title>{t("emailConfirmationTitle")}</title>
         <link rel="icon" href="/favicon.ico" />
-        <meta name="dcterms.title" content={t("emailConfirmationTitle")} />
+        <meta name="dcterms.title" content={t("scLabsConfirmation")} />
         <meta
           name="dcterms.language"
           content={props.locale === "en" ? "eng" : "fra"}

--- a/pages/experiments.js
+++ b/pages/experiments.js
@@ -67,7 +67,7 @@ export default function Experiments(props) {
       breadcrumbItems={[{ text: "Service Canada Labs", link: "/" }]}
     >
       <Head>
-        <title>{t("experimentsTitle")}</title>
+        <title>{t("scLabsExperiments")}</title>
         <link rel="icon" href="/favicon.ico" />
         <meta name="dcterms.title" content={t("scLabsExperiments")} />
         <meta

--- a/pages/experiments.js
+++ b/pages/experiments.js
@@ -69,7 +69,7 @@ export default function Experiments(props) {
       <Head>
         <title>{t("experimentsTitle")}</title>
         <link rel="icon" href="/favicon.ico" />
-        <meta name="dcterms.title" content={t("experimentsTitle")} />
+        <meta name="dcterms.title" content={t("scLabsExperiments")} />
         <meta
           name="dcterms.language"
           content={props.locale === "en" ? "eng" : "fra"}

--- a/pages/home.js
+++ b/pages/home.js
@@ -18,7 +18,7 @@ export default function Home(props) {
       langUrl={asPath}
     >
       <Head>
-        <title>{t("siteTitle")}</title>
+        <title>{t("scLabsHome")}</title>
         <link rel="icon" href="/favicon.ico" />
         <meta name="dcterms.title" content={t("scLabsHome")} />
         <meta

--- a/pages/home.js
+++ b/pages/home.js
@@ -20,7 +20,7 @@ export default function Home(props) {
       <Head>
         <title>{t("siteTitle")}</title>
         <link rel="icon" href="/favicon.ico" />
-        <meta name="dcterms.title" content={t("bannerTitle")} />
+        <meta name="dcterms.title" content={t("scLabsHome")} />
         <meta
           name="dcterms.language"
           content={props.locale === "en" ? "eng" : "fra"}

--- a/pages/index.js
+++ b/pages/index.js
@@ -29,7 +29,7 @@ export default function Index(props) {
       <Head>
         <title>alpha.service.canada.ca</title>
         <link rel="icon" href="/favicon.ico" />
-        <meta name="dcterms.title" content="index" />
+        <meta name="dcterms.title" content={t("scLabsSplash")} />
         <meta
           name="dcterms.language"
           content={props.locale === "en" ? "eng" : "fra"}

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -337,7 +337,7 @@ export default function Signup(props) {
       <Head>
         <title>{t("signupPage")}</title>
         <link rel="icon" href="/favicon.ico" />
-        <meta name="dcterms.title" content={t("signupPage")} />
+        <meta name="dcterms.title" content={t("scLabsSignup")} />
         <meta
           name="dcterms.language"
           content={props.locale === "en" ? "eng" : "fra"}

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -335,7 +335,7 @@ export default function Signup(props) {
       breadcrumbItems={[{ text: "Service Canada Labs", link: "/" }]}
     >
       <Head>
-        <title>{t("signupPage")}</title>
+        <title>{t("scLabsSignup")}</title>
         <link rel="icon" href="/favicon.ico" />
         <meta name="dcterms.title" content={t("scLabsSignup")} />
         <meta

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -380,7 +380,13 @@ export default function Signup(props) {
         </div>
       </section>
       <section className="layout-container">
-        <form data-gc-analytics-formname="ESDC:ServiceCanadaLabsSign-up" data-gc-analytics-collect='[{"value":"input,select","emptyField":"N/A"}]' onSubmit={handleSubmit} onReset={handlerClearData} noValidate>
+        <form
+          data-gc-analytics-formname="ESDC:ServiceCanadaLabsSign-up"
+          data-gc-analytics-collect='[{"value":"input,select","emptyField":"N/A"}]'
+          onSubmit={handleSubmit}
+          onReset={handlerClearData}
+          noValidate
+        >
           <a
             className="block font-body hover:text-canada-footer-hover-font-blue text-canada-footer-font underline mb-5"
             href={t("reportAProblemPrivacyStatementLink")}

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -380,7 +380,7 @@ export default function Signup(props) {
         </div>
       </section>
       <section className="layout-container">
-        <form onSubmit={handleSubmit} onReset={handlerClearData} noValidate>
+        <form data-gc-analytics-formname="ESDC:ServiceCanadaLabsSign-up" data-gc-analytics-collect='[{"value":"input,select","emptyField":"N/A"}]' onSubmit={handleSubmit} onReset={handlerClearData} noValidate>
           <a
             className="block font-body hover:text-canada-footer-hover-font-blue text-canada-footer-font underline mb-5"
             href={t("reportAProblemPrivacyStatementLink")}

--- a/pages/thankyou.js
+++ b/pages/thankyou.js
@@ -15,7 +15,7 @@ export default function Confirmation(props) {
       breadcrumbItems={[{ text: "Service Canada Labs", link: "/" }]}
     >
       <Head>
-        <title>{t("thankYouTitle")}</title>
+        <title>{t("scLabsThankYou")}</title>
         <link rel="icon" href="/favicon.ico" />
         <meta name="dcterms.title" content={t("scLabsThankYou")} />
         <meta

--- a/pages/thankyou.js
+++ b/pages/thankyou.js
@@ -17,7 +17,7 @@ export default function Confirmation(props) {
       <Head>
         <title>{t("thankYouTitle")}</title>
         <link rel="icon" href="/favicon.ico" />
-        <meta name="dcterms.title" content={t("thankYouTitle")} />
+        <meta name="dcterms.title" content={t("scLabsThankYou")} />
         <meta
           name="dcterms.language"
           content={props.locale === "en" ? "eng" : "fra"}

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -188,6 +188,12 @@
   "emailConfirmationTitle": "Thank you for confirming your email",
   "emailConfirmationP1": "We’ll invite you to take part in experiments and research activities as they come up to make Service Canada better for everyone.",
   "emailConfirmationP2": "In the meantime, explore our experiments.",
-  "confirmationP4": "We really appreciate having you on the team!",
-  "creator": "Employment and Social Development Canada"
+  "creator": "Employment and Social Development Canada",
+  "scLabsSplash": "Service Canada Labs - Splash",
+  "scLabsHome": "Service Canada Labs - Home",
+  "scLabsSignup": "Service Canada Labs - Sign-Up",
+  "scLabsThankYou": "Service Canada Labs - Thank you",
+  "scLabsExperiments": "Service Canada Labs - Experiments",
+  "scLabsConfirmation": "Service Canada Labs - Confirmation",
+  "scLabsAbout": "Service Canada Labs - About"
 }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1,7 +1,6 @@
 {
   "alphaText": "This site will change as we test ideas.",
   "siteTitle": "Alpha Site",
-  "experimentsTitle": "Experiments",
   "bannerTitle": "Service Canada Labs",
   "bannerText": "Make government work for you",
   "buttonBecomeTester": "Become a tester",
@@ -84,7 +83,6 @@
   "active": "Active",
   "filterBy": "Filter by",
   "skipToMainContentBtn": "Skip to main content",
-  "signupPage": "Sign up",
   "signupTitle": "Become a participant!",
   "signupP1": "You’re invited to test our experimental ideas and participate in research interviews to make Service Canada better for everyone. Every bit of feedback helps us make sure we’re making our services simple and easy to use. Fill out the form below to join our list of participants.",
   "signupTitle2": "Privacy policy",
@@ -178,7 +176,6 @@
   "errorMustBe18": "Must be at least 18 years old",
   "privacyLinkText": "Review the privacy policy",
   "becomeAParticipantDescription": "You’re invited to test our experimental ideas and participate in research interviews to make Service Canada better for everyone. Every bit of feedback helps us make sure we’re making our services simple and easy to use.",
-  "thankYouTitle": "Thank you",
   "thankYou": "Thank you!",
   "confirmationP1": "We’ve added you to our list and sent you a confirmation email from",
   "confirmationEmail": "Experience@servicecanada.gc.ca",

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -1,7 +1,6 @@
 {
   "alphaText": "Ce site changera au fur et à mesure que nous testons des idées.",
   "siteTitle": "Site Alpha",
-  "experimentsTitle": "Expériences",
   "bannerTitle": "Laboratoires de Service Canada",
   "bannerText": "Faites travailler le gouvernement pour vous",
   "buttonBecomeTester": "Devenez testeur",
@@ -84,7 +83,6 @@
   "active": "Active",
   "filterBy": "Filtrer par:",
   "skipToMainContentBtn": "Passer au contenu principal",
-  "signupPage": "Inscrivez-vous",
   "signupTitle": "Inscrivez-vous pour participer aux expériences",
   "signupP1": "Vous êtes invité à tester des idées expérimentales et participer à d’autres entretiens de recherche afin d’améliorer Service Canada pour tous. Chaque commentaire nous aide à nous assurer que nos services sont simples et faciles à utiliser. Remplissez le formulaire ci-dessous pour vous ajouter à notre liste de participants.",
   "signupTitle2": "Politique en matière de protection des renseignements personnels",
@@ -178,7 +176,6 @@
   "errorMustBe18": "Vous devez être âgé de 18 ans ou plus",
   "privacyLinkText": "Lire la politique en matière de protection des renseignements personnels dans son intégralité",
   "becomeAParticipantDescription": "Vous êtes invité à tester des idées expérimentales et participer à d’autres entretiens de recherche afin d’améliorer Service Canada pour tous. Chaque commentaire nous aide à nous assurer que nos services sont simples et faciles à utiliser.",
-  "thankYouTitle": "Thank you",
   "thankYou": "Merci!",
   "confirmationP1": "Nous vous avons ajouté à notre liste et vous avons envoyé un courriel de confirmation à partir de l’adresse",
   "confirmationEmail": "Experience@servicecanada.gc.ca",

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -188,6 +188,12 @@
   "emailConfirmationTitle": "(FR) Thank you for confirming your email",
   "emailConfirmationP1": "(FR) We’ll invite you to take part in experiments and research activities as they come up to make Service Canada better for everyone.",
   "emailConfirmationP2": "(FR) In the meantime, explore our experiments.",
-  "confirmationP4": "Nous sommes véritablement heureux de vous avoir dans l’équipe!",
-  "creator": "Emploi et Développement social Canada"
+  "creator": "Emploi et Développement social Canada",
+  "scLabsSplash": "Laboratoires de Service Canada - Splash",
+  "scLabsHome": "Laboratoires de Service Canada - Accueil",
+  "scLabsSignup": "Laboratoires de Service Canada - Inscrivez-vous",
+  "scLabsThankYou": "Laboratoires de Service Canada - Merci",
+  "scLabsExperiments": "Laboratoires de Service Canada - Expérimentations",
+  "scLabsConfirmation": "Laboratoires de Service Canada - Confirmation",
+  "scLabsAbout": "Laboratoires de Service Canada - À propos"
 }


### PR DESCRIPTION
# Description

[Fix blank titles being sent to Adobe Analytics from the website](https://trello.com/c/vWvq0iL8/300-fix-blank-titles-being-sent-to-adobe-analytics-from-the-website)

The page titles for the alpha site are not showing up in the analytics. It might be because there too generic like About so their hard to find so I updated them so Ashley will find them easier.

## Acceptance Criteria

The page title and the dcterms.title meta tag should have Service Canada labs followed by the page as a title. It should also translate.

## Test Instructions

1. Check the title for each page and make sure they have Service Canada Labs in it.
2. Check the dcterms.title meta tag in the inspector and make sure it also has Service Canada Labs
3. Make sure the titles are translated depending on the language of the page.

## Checklist

- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
