### PR TITLE
Changed experiments title text so it wraps

### DIFF
--- a/pages/experiments.js
+++ b/pages/experiments.js
@@ -78,7 +78,7 @@ export default function Experiments(props) {
         <meta name="dcterms.accessRights" content="2" />
       </Head>
       <section className="layout-container mb-10">
-        <h1 id="pageMainTitle" tabIndex="-1" className="w-max">
+        <h1 id="pageMainTitle" tabIndex="-1" className="flex-wrap">
           {t("experimentsAndExplorationTitle")}
         </h1>
         <Filter


### PR DESCRIPTION
# Description

[Page title on the "experiments" page is cut off on mobile phones](https://github.com/DTS-STN/Alpha-Site/issues/142)

Very simple PR. Made it so the page title on the experiments page wraps so it is no longer cut off on smaller screens.

![Screenshot 2021-06-28 142547](https://user-images.githubusercontent.com/71025360/123686377-bb1fb280-d81d-11eb-842a-745402080955.png)

## Acceptance Criteria

Done when the H1 is no longer cut off on smaller screens/mobile.

## Test Instructions

1. Pull in branch
2. Type `npm run dev`
3. Navigate to the experiments page and play with the screen size


