### PR TITLE
Clickable experiment cards

### DIFF
--- a/components/molecules/Experiment.js
+++ b/components/molecules/Experiment.js
@@ -12,13 +12,14 @@ export const Experiment = (props) => {
     alpha: "custom-blue-experiment-blue",
   };
   return (
-    <div
+    <a
       className={`shadow-experiment-shadow p-4 border-b-4 h-400px ${
         "border-" + (tagColours[props.tag] || "gray-experiment")
       }`}
       data-testid={props.dataTestId}
       data-cy={props.dataCy}
       tabIndex="0"
+      href={props.href}
     >
       <h2 className="mb-2 text-p">{props.title}</h2>
       <span
@@ -29,7 +30,7 @@ export const Experiment = (props) => {
         {props.tagLabel}
       </span>
       <p className="mt-2 text-sm">{props.description}</p>
-    </div>
+    </a>
   );
 };
 
@@ -43,6 +44,11 @@ Experiment.propTypes = {
    * tag of the experiment card
    */
   tag: PropTypes.string.isRequired,
+
+  /**
+   * Link of the card
+   */
+  href: PropTypes.string,
 
   /**
    * the label of the tag card

--- a/cypress/integration/experiment.spec.js
+++ b/cypress/integration/experiment.spec.js
@@ -37,19 +37,19 @@ describe("experiment page", () => {
 
     it("Filter experiments: All", () => {
         cy.get('[data-cy="all"]').click()
-        cy.get('[data-cy="experiments-list"]>li').should('have.length', 5); // 5 needs to be changed when more or less experiments are added/removed.
+        cy.get('[data-cy="experiments-list"]>li').should('have.length', 4); // 4 needs to be changed when more or less experiments are added/removed.
     });
 
     it("Filter experiments: Active", () => {
         cy.get('[data-cy="active"]').click()
-        cy.get('[data-cy="experiments-list"]>li>div>span').each(($el) => {
+        cy.get('[data-cy="experiments-list"]>li>a>span').each(($el) => {
             expect($el.text()).to.eq("Active")
         });
     });
 
     it("Filter experiments: Coming soon", () => {
         cy.get('[data-cy="coming_soon"]').click()
-        cy.get('[data-cy="experiments-list"]>li>div>span').each(($el) => {
+        cy.get('[data-cy="experiments-list"]>li>a>span').each(($el) => {
             expect($el.text()).to.eq("Coming Soon")
         });
     });

--- a/cypress/integration/experiment.spec.js
+++ b/cypress/integration/experiment.spec.js
@@ -37,7 +37,7 @@ describe("experiment page", () => {
 
     it("Filter experiments: All", () => {
         cy.get('[data-cy="all"]').click()
-        cy.get('[data-cy="experiments-list"]>li').should('have.length', 4); // 4 needs to be changed when more or less experiments are added/removed.
+        cy.get('[data-cy="experiments-list"]>li').should('have.length', 5); // 5 needs to be changed when more or less experiments are added/removed.
     });
 
     it("Filter experiments: Active", () => {

--- a/pages/experiments.js
+++ b/pages/experiments.js
@@ -40,6 +40,11 @@ export default function Experiments(props) {
             ? experiment.ExperimentDescription_FR
             : experiment.ExperimentDescription_EN
         }
+        href={
+          props.locale === "fr"
+            ? experiment.ExperimentLink_FR
+            : experiment.ExperimentLink_EN
+        }
         dataTestId={`${experiment.id}`}
         dataCy={`${experiment.id}`}
       />


### PR DESCRIPTION
# Description

[Experiment cards should be clickable with both mouse and keyboard, and take users to the appropriate alpha/experiment](https://trello.com/c/5m5JjtTo/295-experiment-cards-should-be-clickable-with-both-mouse-and-keyboard-and-take-users-to-the-appropriate-alpha-experiment)

The experiment card is now clickable and is a link for different services (Only life journeys for now).
![image](https://user-images.githubusercontent.com/72703030/123692581-fc679080-d824-11eb-8515-4cc08b530564.png)

## Acceptance Criteria

Cards should have a href attribute and be links. Only the life journey one is going to work so far.

## Test Instructions

1. Go to the experiments page and click on the life journey card, it should redirect to life journeys page.

## Checklist

- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
