### PR TITLE
Fixed HTML validation errors

### DIFF
--- a/components/atoms/SelectField.js
+++ b/components/atoms/SelectField.js
@@ -29,7 +29,9 @@ export function SelectField(props) {
         {props.required ? (
           <b className="text-error-border-red">{t("required")}</b>
         ) : (
-          <p className="inline text-form-input-gray text-sm">{t("optional")}</p>
+          <cite className="inline text-form-input-gray text-sm not-italic">
+            {t("optional")}
+          </cite>
         )}
       </label>
       {props.error ? <ErrorLabel message={props.error} /> : undefined}

--- a/components/atoms/SelectField.js
+++ b/components/atoms/SelectField.js
@@ -29,9 +29,9 @@ export function SelectField(props) {
         {props.required ? (
           <b className="text-error-border-red">{t("required")}</b>
         ) : (
-          <cite className="inline text-form-input-gray text-sm not-italic">
+          <span className="inline text-form-input-gray text-sm">
             {t("optional")}
-          </cite>
+          </span>
         )}
       </label>
       {props.error ? <ErrorLabel message={props.error} /> : undefined}

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -164,10 +164,6 @@ export default function Signup(props) {
 
   const [errorBoxText, setErrorBoxText] = useState("");
 
-  const errorBoxOnClick = (id) => {
-    document.getElementById(id).scrollIntoView();
-  };
-
   const handlerMinorityGroupOnChange = (checked, name, value) => {
     // pop value from list
     if (checked) {
@@ -351,11 +347,7 @@ export default function Signup(props) {
       </Head>
       <section className="layout-container mb-2 mt-12 xl:bg-lightbulb-right-img xl:bg-right xl:bg-no-repeat">
         {errorBoxText ? (
-          <ErrorBox
-            text={errorBoxText}
-            errors={errorBoxErrors}
-            onClick={errorBoxOnClick}
-          />
+          <ErrorBox text={errorBoxText} errors={errorBoxErrors} />
         ) : undefined}
         <div className="xl:w-2/3 ">
           <h1 className="mb-12" id="pageMainTitle">
@@ -547,9 +539,9 @@ export default function Signup(props) {
             <fieldset className="mb-6">
               <legend className="block leading-tight text-sm font-body mb-5 font-bold">
                 {t("formGender")}{" "}
-                <p className="inline text-form-input-gray text-sm">
+                <cite className="inline text-form-input-gray text-sm not-italic">
                   {t("optional")}
-                </p>
+                </cite>
               </legend>
               <RadioField
                 label={t("woman")}
@@ -598,9 +590,9 @@ export default function Signup(props) {
             <fieldset className="mb-6">
               <legend className="block leading-tight text-sm font-body mb-5 font-bold">
                 {t("formIndigenous")}{" "}
-                <p className="inline text-form-input-gray text-sm">
+                <cite className="inline text-form-input-gray text-sm not-italic">
                   {t("optional")}
-                </p>
+                </cite>
               </legend>
               <RadioField
                 label={t("FN")}
@@ -657,9 +649,9 @@ export default function Signup(props) {
             <fieldset className="mb-6">
               <legend className="block leading-tight text-sm font-body mb-5 font-bold">
                 {t("disability")}{" "}
-                <p className="inline text-form-input-gray text-sm">
+                <cite className="inline text-form-input-gray text-sm not-italic">
                   {t("optional")}
-                </p>
+                </cite>
               </legend>
               <OptionalTextField
                 controlLabel={t("yes")}
@@ -709,9 +701,9 @@ export default function Signup(props) {
             <fieldset className="mb-6">
               <legend className="block leading-tight text-sm font-body mb-5 font-bold">
                 {t("formMinority")}{" "}
-                <p className="inline text-form-input-gray text-sm">
+                <cite className="inline text-form-input-gray text-sm not-italic">
                   {t("optional")}
-                </p>
+                </cite>
               </legend>
               <OptionalListField
                 controlName="minority"
@@ -849,9 +841,9 @@ export default function Signup(props) {
             <fieldset className="mb-6">
               <legend className="block leading-tight text-sm font-body mb-5 font-bold">
                 {t("formIncome")}{" "}
-                <p className="inline text-form-input-gray text-sm">
+                <cite className="inline text-form-input-gray text-sm not-italic">
                   {t("optional")}
-                </p>
+                </cite>
               </legend>
               <RadioField
                 label={t("income1")}

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -539,9 +539,9 @@ export default function Signup(props) {
             <fieldset className="mb-6">
               <legend className="block leading-tight text-sm font-body mb-5 font-bold">
                 {t("formGender")}{" "}
-                <cite className="inline text-form-input-gray text-sm not-italic">
+                <span className="inline text-form-input-gray text-sm">
                   {t("optional")}
-                </cite>
+                </span>
               </legend>
               <RadioField
                 label={t("woman")}
@@ -590,9 +590,9 @@ export default function Signup(props) {
             <fieldset className="mb-6">
               <legend className="block leading-tight text-sm font-body mb-5 font-bold">
                 {t("formIndigenous")}{" "}
-                <cite className="inline text-form-input-gray text-sm not-italic">
+                <span className="inline text-form-input-gray text-sm">
                   {t("optional")}
-                </cite>
+                </span>
               </legend>
               <RadioField
                 label={t("FN")}
@@ -649,9 +649,9 @@ export default function Signup(props) {
             <fieldset className="mb-6">
               <legend className="block leading-tight text-sm font-body mb-5 font-bold">
                 {t("disability")}{" "}
-                <cite className="inline text-form-input-gray text-sm not-italic">
+                <span className="inline text-form-input-gray text-sm">
                   {t("optional")}
-                </cite>
+                </span>
               </legend>
               <OptionalTextField
                 controlLabel={t("yes")}
@@ -701,9 +701,9 @@ export default function Signup(props) {
             <fieldset className="mb-6">
               <legend className="block leading-tight text-sm font-body mb-5 font-bold">
                 {t("formMinority")}{" "}
-                <cite className="inline text-form-input-gray text-sm not-italic">
+                <span className="inline text-form-input-gray text-sm">
                   {t("optional")}
-                </cite>
+                </span>
               </legend>
               <OptionalListField
                 controlName="minority"
@@ -841,9 +841,9 @@ export default function Signup(props) {
             <fieldset className="mb-6">
               <legend className="block leading-tight text-sm font-body mb-5 font-bold">
                 {t("formIncome")}{" "}
-                <cite className="inline text-form-input-gray text-sm not-italic">
+                <span className="inline text-form-input-gray text-sm not-italic">
                   {t("optional")}
-                </cite>
+                </span>
               </legend>
               <RadioField
                 label={t("income1")}


### PR DESCRIPTION
# Description
[Fix HTML validation errors](https://trello.com/c/ebP2ENED)

The signup page was failing HTML validation because `p` tags were being used in spots that aren't allowed as per HTML5 standards. Based on current HTML standard, the the only elements allowed inside a `legend` tag are those in the Phrasing Content group (listed [here](https://html.spec.whatwg.org/multipage/dom.html#phrasing-content)). To get around the errors showing up on the screenshot on Trello, I changed the `p` tags that were children of `legend` tags to be `cite` tags and removed the italic styling. I also did this with the `p` tag inside the `SelectField` component.

## Acceptance Criteria

Done when there the HTML validation errors are resolved.

## Test Instructions

1. Pull in branch
2. Type `npm run dev`
3.  Use your favorite validator extension to see that the errors are gone.

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
