### PR TITLE
Fixed list contrast

### DIFF
--- a/components/molecules/List.js
+++ b/components/molecules/List.js
@@ -4,11 +4,11 @@ import PropTypes from "prop-types";
  *  List component
  */
 export function List(props) {
-  let opacity = 20;
+  let opacity = 60;
   return (
     <ol className={props.className}>
       {props.items.map((item, key) => {
-        if (opacity < 100) opacity += 20;
+        if (opacity < 100) opacity += 10;
         let className =
           "opacity-" +
           opacity +


### PR DESCRIPTION
# Description

[Increase contrast of list element](https://trello.com/c/yULReiTr)

I changed the incremental and starting values for opacity in the List component so that the first list item has a color contrast ratio of at least 3:1. You can check this yourself by adding the [WCAG Color Contrast Checker](https://chrome.google.com/webstore/detail/wcag-color-contrast-check/plnahcmalebffmaghcpcmpaciebdhgdf/related?hl=en) extension to your browser and running it on the `about` page.

## Acceptance Criteria

Done when the contrast ratio for the first list item is 3:1

## Test Instructions

1. Pull in branch
2. Type `npm run dev`
3. Run WCAG Color Contrast Checker extension

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
