### PR TITLE
Search bar removal

### DIFF
--- a/components/organisms/Layout.js
+++ b/components/organisms/Layout.js
@@ -8,7 +8,6 @@ import { ReportAProblem } from "./ReportAProblem";
 import Link from "next/link";
 import { useTranslation } from "next-i18next";
 import { DateModified } from "../atoms/DateModified";
-import { SearchBar } from "../atoms/SearchBar";
 import { Breadcrumb } from "../atoms/Breadcrumb";
 
 const setLanguage = (language) => {
@@ -85,10 +84,6 @@ export const Layout = ({
                 {language === "en" ? "English" : "Français"}
               </a>
             </Link>
-            <SearchBar
-              placeholder={t("searchBarPlaceholder")}
-              dataCy={"search-bar"}
-            />
           </div>
         </div>
 

--- a/cypress/integration/home.spec.js
+++ b/cypress/integration/home.spec.js
@@ -17,10 +17,6 @@ describe("home page", () => {
     cy.checkA11y(null, null, terminalLog);
   });
 
-  it("The search bar appears on the homepage", () => {
-    cy.get('[ data-cy="search-bar"]').should("be.visible");
-  });
-
   it("Toggles content language when language button is clicked", () => {
     cy.get('[data-cy="social-media-link"]').then(($link) => {
       const txt = $link.text();


### PR DESCRIPTION
# Description

[Remove search bar from Alpha Site](https://trello.com/c/pCttFoym/307-remove-search-bar-from-alpha-site)

Removed search bar from every page.
![image](https://user-images.githubusercontent.com/72703030/124006109-de766900-d9a7-11eb-97c8-cfa83bab1f57.png)

## Acceptance Criteria

The search bar shouldn't be on the website.

## Test Instructions

1. Check the pages and see if the search bar is removed

## Checklist

- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
