### PR TITLE
Remove email analytics

### DIFF
--- a/components/atoms/TextField.js
+++ b/components/atoms/TextField.js
@@ -39,7 +39,7 @@ export function TextField(props) {
       <input
         className={`text-input font-body w-full min-h-40px shadow-sm text-form-input-gray border-2 py-6px px-12px ${
           props.error ? "border-error-border-red" : "border-black"
-        }`}
+        } ${props.exclude ? "exclude" : ""}`}
         id={props.id}
         name={props.name}
         placeholder={props.placeholder}
@@ -147,4 +147,9 @@ TextField.propTypes = {
    * cypress tests selector
    */
   dataCy: PropTypes.string,
+
+  /**
+   * Exclude option for adding exclude class to the textfield
+   */
+  exclude: PropTypes.bool,
 };

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -382,7 +382,7 @@ export default function Signup(props) {
       <section className="layout-container">
         <form
           data-gc-analytics-formname="ESDC:ServiceCanadaLabsSign-up"
-          data-gc-analytics-collect='[{"value":"input,select","emptyField":"N/A"}]'
+          data-gc-analytics-collect='[{"value":"input:not(.exclude),select","emptyField":"N/A"}]'
           onSubmit={handleSubmit}
           onReset={handlerClearData}
           noValidate
@@ -412,6 +412,7 @@ export default function Signup(props) {
               onChange={setEmail}
               boldLabel={true}
               required
+              exclude
             />
             <TextField
               className="mb-10"


### PR DESCRIPTION
# Description

[Remove email from analytics tracking](https://trello.com/c/OJ3mXzw5/342-342-remove-email-from-analytics-tracking)

I excluded the email from the analytics tracking.

## Acceptance Criteria

The email input should have an "exclude" class

## Test Instructions

1. Go to the sign-up page and inspect the email input, it should have an "exclude" class.

## Checklist

- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
