### PR TITLE
Skip link home fix

### DIFF
--- a/components/atoms/Banner.js
+++ b/components/atoms/Banner.js
@@ -10,11 +10,7 @@ export const Banner = ({ siteTitle, headline }) => {
     <div title="Home banner" className="bg-banner-img py-8">
       <div className="lg:container xxs:mx-0 xxs:px-0 lg:mx-auto lg:px-6 xxl:mx-auto">
         <div className="xxs:w-screen lg:w-2/3 xl:w-1/2 bg-dk-blue bg-opacity-90 text-white p-4">
-          <h1
-            id="pageMainTitle"
-            className="text-h1-xl font-medium pt-4 pb-2 break-words"
-            tabIndex="-1"
-          >
+          <h1 className="text-h1-xl font-medium pt-4 pb-2 break-words">
             {siteTitle}
           </h1>
           <hr className="border-2 border-hr-red-bar bg-hr-red-bar bg-opacity-90 border-opacity-90 w-3/4" />

--- a/pages/home.js
+++ b/pages/home.js
@@ -31,7 +31,9 @@ export default function Home(props) {
 
       <section className="layout-container mb-2 mt-12">
         <div className="xl:w-2/3">
-          <h1 className="mb-10">{t("experimentsAndExplorationTitle")}</h1>
+          <h1 className="mb-10" id="pageMainTitle" tabIndex="-1">
+            {t("experimentsAndExplorationTitle")}
+          </h1>
           <p className="mb-4">{t("experimentsAndExploration-1/3")}</p>
           <p className="mb-4">{t("experimentsAndExploration-2/3")}</p>
           <p className="mb-10">{t("experimentsAndExploration-3/3")}</p>

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -371,7 +371,7 @@ export default function Signup(props) {
           <ErrorBox text={errorBoxText} errors={errorBoxErrors} />
         ) : undefined}
         <div className="xl:w-2/3 ">
-          <h1 className="mb-12" id="pageMainTitle">
+          <h1 className="mb-12" id="pageMainTitle" tabIndex="-1">
             {t("signupTitle")}
           </h1>
           <p className="mb-10">{t("signupP1")}</p>


### PR DESCRIPTION
# Description

A11y audit

The skip content on the home page now links to the title of the main page instead of the banner. I also made the title of the sign-up form focusable.

## Acceptance Criteria

The skip to content button on the home page should link to "Explore new services and help improve them" and the title on the sign-up form should be focusable after we used the skip to content link.

## Test Instructions

1. Go to the home page and press the skip to main content button, it should link to "Explore new services and help improve them". 
2. Go on the sign-up form and tab to the skip to main content button, press it to see if the title has a focus.

## Checklist

- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
