### PR TITLE
Signup error summary onClick

### DIFF
--- a/components/molecules/ErrorBox.js
+++ b/components/molecules/ErrorBox.js
@@ -16,6 +16,7 @@ export function ErrorBox(props) {
       <ul
         className="w-full list-disc list-outside leading-loose pl-8"
         data-cy="error-box-items"
+        id="error-box-items"
       >
         {props.errors.map(({ id, text }) => {
           return (
@@ -24,6 +25,8 @@ export function ErrorBox(props) {
                 id={`${id}-${text}`}
                 custom="font-body hover:text-canada-footer-hover-font-blue text-canada-footer-font underline inline-block text-left"
                 onClick={() => props.onClick(id)}
+                dataCy={`error-item-${id}`}
+                className="" // This is to avoid all the "undefined" class names applied.
               >
                 {text}
               </ActionButton>

--- a/cypress/integration/signup.spec.js
+++ b/cypress/integration/signup.spec.js
@@ -73,6 +73,17 @@ describe("signup page", () => {
     cy.get('[data-cy="error-box-items"').children().should("have.length", 1);
   });
 
+  it("Validates error clicking scrolls to the desired error", () => {
+    cy.get('[data-cy="signup-submit"]').click();
+    cy.get('[data-cy="error-box"').should("exist");
+    cy.get('[data-cy="error-box"').scrollIntoView().should('be.visible');
+
+    cy.get('[data-cy="error-item-email"]').should('be.visible');
+    cy.get('[data-cy="error-item-email"]').click();
+    cy.get('[data-cy="error-item-email"]').click();
+    cy.get('[data-cy="error-item-email"').scrollIntoView().should('be.visible');
+  });
+
   // skipping for now until thank you page is available
   it("Redirects to thank you page on successful submit", () => {
     cy.intercept("POST", "/api/**", {

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -326,7 +326,13 @@ export default function Signup(props) {
       await setErrorBoxText(
         `${t("errorSubmit1")} ${errorsList.length} ${t("errorSubmit2")}`
       );
-      document.getElementById("error-box").scrollIntoView();
+      document.getElementById("error-box").scrollIntoView({
+        behavior: "smooth",
+      });
+      setTimeout(
+        () => document.querySelector(`#error-box-items > li > button`).focus(),
+        600
+      );
     } else {
       //submit data to the api and then redirect to the thank you page
       const response = await fetch("/api/sign-up", {
@@ -349,6 +355,18 @@ export default function Signup(props) {
     }
   };
 
+  const handleScrollToError = (id) => {
+    const input = document.getElementById(`${id}`);
+    setTimeout(() => input.focus(), 700);
+    const inputType = input.getAttribute("type");
+    let parentDiv = input.parentNode;
+    if (inputType === "radio") parentDiv = parentDiv.parentNode;
+    else if (inputType === "checkbox") parentDiv = parentDiv.previousSibling;
+    parentDiv.scrollIntoView({
+      behavior: "smooth",
+    });
+  };
+
   return (
     <Layout
       locale={props.locale}
@@ -368,7 +386,11 @@ export default function Signup(props) {
       </Head>
       <section className="layout-container mb-2 mt-12 xl:bg-lightbulb-right-img xl:bg-right xl:bg-no-repeat">
         {errorBoxText ? (
-          <ErrorBox text={errorBoxText} errors={errorBoxErrors} />
+          <ErrorBox
+            text={errorBoxText}
+            errors={errorBoxErrors}
+            onClick={handleScrollToError}
+          />
         ) : undefined}
         <div className="xl:w-2/3 ">
           <h1 className="mb-12" id="pageMainTitle">


### PR DESCRIPTION
# Description

[Signup error click](https://trello.com/c/Uo1X4ZYo/344-344-fix-onclick-is-not-a-function-when-user-clicks-on-error-message)

When clicking on an item from the error summary for teh signup form, the app would crash - see Trello board item linked above.

## In This PR

Added the functionality to scroll the user to the desired error.
Added smooth scrolling behaviour to both, the sign up button, and the error summary items.

## Acceptance Criteria

N/A

## Test Instructions

1. `git checkout Bug/344-ErrorOnClick` and `npm run dev`
2.  Navigate to the sign up page.
3.  Scroll all the way down and press on the "Submit" button.
4. See the scrolling animation
5. Press on all 4 of the error items to see where the page is scrolled to.

## Help Requested

- Any constructive feedback is more than welcome!

## Checklist

- [x] Strings use placeholders for translation (No hard coded strings)
- [x] Unit tests have been added/updated
