### PR TITLE
Moved error box close to form.

### DIFF
--- a/pages/signup.js
+++ b/pages/signup.js
@@ -379,7 +379,7 @@ export default function Signup(props) {
 
   const handleScrollToError = (id) => {
     const input = document.getElementById(`${id}`);
-    setTimeout(() => input.focus(), 700);
+    setTimeout(() => input.focus(), 600);
     const inputType = input.getAttribute("type");
     let parentDiv = input.parentNode;
     if (inputType === "radio") parentDiv = parentDiv.parentNode;
@@ -407,13 +407,6 @@ export default function Signup(props) {
         <meta name="dcterms.accessRights" content="2" />
       </Head>
       <section className="layout-container mb-2 mt-12 xl:bg-lightbulb-right-img xl:bg-right xl:bg-no-repeat">
-        {errorBoxText ? (
-          <ErrorBox
-            text={errorBoxText}
-            errors={errorBoxErrors}
-            onClick={handleScrollToError}
-          />
-        ) : undefined}
         <div className="xl:w-2/3 ">
           <h1 className="mb-12" id="pageMainTitle" tabIndex="-1">
             {t("signupTitle")}
@@ -445,6 +438,13 @@ export default function Signup(props) {
         </div>
       </section>
       <section className="layout-container">
+        {errorBoxText ? (
+          <ErrorBox
+            text={errorBoxText}
+            errors={errorBoxErrors}
+            onClick={handleScrollToError}
+          />
+        ) : undefined}
         <form
           data-gc-analytics-formname="ESDC:ServiceCanadaLabsSign-up"
           data-gc-analytics-collect='[{"value":"input:not(.exclude),select","emptyField":"N/A"}]'

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -438,6 +438,12 @@ export default function Signup(props) {
         </div>
       </section>
       <section className="layout-container">
+        <a
+          className="block font-body hover:text-canada-footer-hover-font-blue text-canada-footer-font underline mb-5"
+          href={t("privacyLink")}
+        >
+          {t("privacy")}
+        </a>
         {errorBoxText ? (
           <ErrorBox
             text={errorBoxText}
@@ -452,12 +458,6 @@ export default function Signup(props) {
           onReset={handlerClearData}
           noValidate
         >
-          <a
-            className="block font-body hover:text-canada-footer-hover-font-blue text-canada-footer-font underline mb-5"
-            href={t("privacyLink")}
-          >
-            {t("privacy")}
-          </a>
           <ActionButton
             id="reset"
             custom="block font-body hover:text-canada-footer-hover-font-blue text-canada-footer-font underline mb-5"


### PR DESCRIPTION
# Description

There is no task for this one, it was found in the a11y audit.

## Acceptance Criteria

- Error-box should be right on top of the form.

## Help Requested

N/A

## Checklist

- [x] Strings use placeholders for translation (No hard coded strings)
- [x] Unit tests have been added/updated

