### PR TITLE
Accessibility audit - home page lacks meaningful heading structure

### DIFF
--- a/components/atoms/Banner.js
+++ b/components/atoms/Banner.js
@@ -10,10 +10,7 @@ export const Banner = ({ siteTitle, headline }) => {
     <div title="Home banner" className="bg-banner-img py-8">
       <div className="lg:container xxs:mx-0 xxs:px-0 lg:mx-auto lg:px-6 xxl:mx-auto">
         <div className="xxs:w-screen lg:w-2/3 xl:w-1/2 bg-dk-blue bg-opacity-90 text-white p-4">
-          <h1
-            className="text-h1 font-medium pt-4 pb-2 break-words"
-            id="pageMainTitle"
-          >
+          <h1 className="text-h1 font-medium pt-4 pb-2 break-words">
             {siteTitle}
           </h1>
           <hr className="border-2 border-hr-red-bar bg-hr-red-bar bg-opacity-90 border-opacity-90 w-3/4" />

--- a/components/atoms/Banner.js
+++ b/components/atoms/Banner.js
@@ -10,7 +10,10 @@ export const Banner = ({ siteTitle, headline }) => {
     <div title="Home banner" className="bg-banner-img py-8">
       <div className="lg:container xxs:mx-0 xxs:px-0 lg:mx-auto lg:px-6 xxl:mx-auto">
         <div className="xxs:w-screen lg:w-2/3 xl:w-1/2 bg-dk-blue bg-opacity-90 text-white p-4">
-          <h1 className="text-h1-xl font-medium pt-4 pb-2 break-words">
+          <h1
+            className="text-h1 font-medium pt-4 pb-2 break-words"
+            id="pageMainTitle"
+          >
             {siteTitle}
           </h1>
           <hr className="border-2 border-hr-red-bar bg-hr-red-bar bg-opacity-90 border-opacity-90 w-3/4" />

--- a/components/organisms/Layout.js
+++ b/components/organisms/Layout.js
@@ -107,12 +107,12 @@ export const Layout = ({
         <div className="layout-container my-2">
           <Breadcrumb items={breadcrumbItems} />
         </div>
-        {bannerText && bannerTitle ? (
-          <Banner siteTitle={bannerTitle} headline={bannerText} />
-        ) : null}
       </header>
 
       <main>
+        {bannerText && bannerTitle ? (
+          <Banner siteTitle={bannerTitle} headline={bannerText} />
+        ) : null}
         <div>{children}</div>
       </main>
 

--- a/components/organisms/Layout.js
+++ b/components/organisms/Layout.js
@@ -107,12 +107,12 @@ export const Layout = ({
         <div className="layout-container my-2">
           <Breadcrumb items={breadcrumbItems} />
         </div>
-      </header>
-
-      <main>
         {bannerText && bannerTitle ? (
           <Banner siteTitle={bannerTitle} headline={bannerText} />
         ) : null}
+      </header>
+
+      <main>
         <div>{children}</div>
       </main>
 

--- a/pages/home.js
+++ b/pages/home.js
@@ -31,9 +31,9 @@ export default function Home(props) {
 
       <section className="layout-container mb-2 mt-12">
         <div className="xl:w-2/3">
-          <h1 className="mb-10" id="pageMainTitle" tabIndex="-1">
+          <h2 className="mb-10" tabIndex="-1">
             {t("experimentsAndExplorationTitle")}
-          </h1>
+          </h2>
           <p className="mb-4">{t("experimentsAndExploration-1/3")}</p>
           <p className="mb-4">{t("experimentsAndExploration-2/3")}</p>
           <p className="mb-10">{t("experimentsAndExploration-3/3")}</p>

--- a/pages/home.js
+++ b/pages/home.js
@@ -31,7 +31,7 @@ export default function Home(props) {
 
       <section className="layout-container mb-2 mt-12">
         <div className="xl:w-2/3">
-          <h2 className="mb-10" tabIndex="-1">
+          <h2 className="mb-10" tabIndex="-1" id="pageMainTitle">
             {t("experimentsAndExplorationTitle")}
           </h2>
           <p className="mb-4">{t("experimentsAndExploration-1/3")}</p>


### PR DESCRIPTION
# Description

From the accessibility audit:

Page lacks meaningful heading structure | Home | On this page, there are two heading level 1 "Service Canada Labs" and "Explore new services and help improve them". Both are acting as the main heading of the page.  Identify the main heading and update the second heading level to `<h2>`.  Also, the "Skip to main content" link should point to that heading which should be placed in the "Main" region of the page.
-- | -- | --

This PR moves the Banner component into the `<main>` region of the Layout component and updates to previous `<h1>` on the homepage to an `<h2>`. The skip to main content button links to the heading in the banner.

## Acceptance Criteria

Page structure updated as recommended from the accessibility audit

## Test Instructions

1. Navigate to the home page
2. Verify that there is only one `<h1>` and that the skip button links to it

## Checklist

- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
