### PR TITLE
Added lang attribute to french content in english pages

### DIFF
--- a/pages/404.js
+++ b/pages/404.js
@@ -60,7 +60,10 @@ export default function error404(props) {
             />
           </div>
           <div>
-            <div className="relative h-auto xl:w-96 xxl:w-400px lg:w-72 xl:h-400px lg:h-500px mb-8 lg:mb-0">
+            <div
+              className="relative h-auto xl:w-96 xxl:w-400px lg:w-72 xl:h-400px lg:h-500px mb-8 lg:mb-0"
+              lang="fr"
+            >
               <h1 className="font-bold font-display mb-4">
                 Nous ne pouvons trouver cette page Web
               </h1>

--- a/pages/500.js
+++ b/pages/500.js
@@ -59,7 +59,10 @@ export default function error500(props) {
             />
           </div>
           <div>
-            <div className="relative h-auto xl:w-96 xxl:w-400px lg:w-72 xl:h-400px lg:h-500px mb-8 lg:mb-0">
+            <div
+              className="relative h-auto xl:w-96 xxl:w-400px lg:w-72 xl:h-400px lg:h-500px mb-8 lg:mb-0"
+              lang="fr"
+            >
               <h1 className="font-bold font-display mb-4">
                 Le site Web a signalé une erreur. Veuiller réessayer plus tard.
               </h1>

--- a/pages/error.js
+++ b/pages/error.js
@@ -75,7 +75,10 @@ export default function ErrorPage(props) {
               />
             </div>
             <div>
-              <div className="relative h-auto xl:w-96 xxl:w-400px lg:w-72 xl:h-400px lg:h-500px mb-8 lg:mb-0">
+              <div
+                className="relative h-auto xl:w-96 xxl:w-400px lg:w-72 xl:h-400px lg:h-500px mb-8 lg:mb-0"
+                lang="fr"
+              >
                 <h1
                   className="font-bold font-display mb-4"
                   data-testid="heading-fr"

--- a/pages/index.js
+++ b/pages/index.js
@@ -61,6 +61,7 @@ export default function Index(props) {
                 text="Français"
                 className="text-center w-7.5rem xl:w-138px text-sm py-3.5 rounded leading-3"
                 href="/fr/home"
+                lang="fr"
                 onClick={setLanguage}
               />
             </div>
@@ -73,7 +74,10 @@ export default function Index(props) {
                 </a>
               </Link>
               <Link href="https://www.canada.ca/fr/transparence/avis.html">
-                <a className="inline-block hover:text-canada-footer-hover-font-blue text-canada-footer-font">
+                <a
+                  className="inline-block hover:text-canada-footer-hover-font-blue text-canada-footer-font"
+                  lang="fr"
+                >
                   Avis
                 </a>
               </Link>


### PR DESCRIPTION
# Description

a11y audit

I added a lang="fr" attribute to the links and to any other text that has a different language than the main document. I did it on the splash page and the 404, 500 and error pages.

## Acceptance Criteria

The french content on those pages should have a lang="fr" attribute.

## Test Instructions

1. Look at the code or inspect the french content  for the splash, 404, 500 and error pages and see if they have a lang="fr" attribute.

## Checklist

- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
