### PR TITLE
Update error box to alert users using assistive technologies

### DIFF
--- a/components/molecules/ErrorBox.js
+++ b/components/molecules/ErrorBox.js
@@ -10,6 +10,8 @@ export function ErrorBox(props) {
       id="error-box"
       className="relative border-l-4 border-error-border-red min-h-40px mb-10"
       data-cy="error-box"
+      role="alert"
+      aria-atomic="true"
     >
       <span className="icon-error absolute top-1 -left-2.5 bg-white" />
       <p className="font-bold ml-4">{props.text}</p>


### PR DESCRIPTION
# Description

Providing status messages that cannot be programmatically determined through role or properties | Sign up | There is no way to notify assistive technology users of the error message that appears at the very top of the page when submitting the form with errors.  To see the issue, inspect the code, there are no techniques, such as aria used to notify assistive technology users.  To fix this, visit the following link for more details: https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA19
-- | -- | --

Add `role="alert"` and `aria-atomic="true"` to the ErrorBox component so assistive technologies are informed about errors when submitting the form with errors.

## Acceptance Criteria

The errors alert users using assistive technologies.

## Checklist

- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
