### PR TITLE
Remove more info button on about page

### DIFF
--- a/pages/about.js
+++ b/pages/about.js
@@ -67,17 +67,6 @@ export default function About(props) {
               ]}
             />
           </div>
-          <div className="xl:bg-footer-background-color  bg-white ">
-            <div className="xl:invisible layout-container pt-6 xl:pt-0 xl:pb-0 pb-10 ">
-              <ActionButton
-                id="LearnMoreButtonSmScreen"
-                text={t("learnMoreBtn")}
-                className={"text-xs md:text-base"}
-                secondary
-                dataCyButton={"learn-more"}
-              />
-            </div>
-          </div>
         </div>
       </section>
       <CallToAction

--- a/pages/about.js
+++ b/pages/about.js
@@ -4,7 +4,6 @@ import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { useTranslation } from "next-i18next";
 import { useRouter } from "next/router";
 import { List } from "../components/molecules/List";
-import { ActionButton } from "../components/atoms/ActionButton";
 import { CallToAction } from "../components/molecules/CallToAction";
 
 export default function About(props) {


### PR DESCRIPTION
# Description

Providing descriptive labels | About us | The "Learn More" button text, that shows on smaller screen sizes, is not descriptive. Code: <button class="..." id="LearnMoreButtonSmScreen" data-cy="LearnMoreButtonSmScreen" data-cy-button="learn-more">Learn more</button>  To fix it, add a descriptive text, so it is clear to users what this button does.
-- | -- | --

There was a button labelled "Learn More" that only showed up in the mobile view of the about page that didn't link anywhere and was causing an accessibility issue. This button is now removed.


## Acceptance Criteria

Learn more button on the about page is gone.

## Test Instructions

1. Navigate to the about page in mobile view
2. Notice that there is no Learn More button after the list


## Checklist

- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
