### PR TITLE
Moved scroll property at the right location.

### DIFF
--- a/pages/signup.js
+++ b/pages/signup.js
@@ -348,13 +348,6 @@ export default function Signup(props) {
       await setErrorBoxText(
         `${t("errorSubmit1")} ${errorsList.length} ${t("errorSubmit2")}`
       );
-      document.getElementById("error-box").scrollIntoView({
-        behavior: "smooth",
-      });
-      setTimeout(
-        () => document.querySelector(`#error-box-items > li > button`).focus(),
-        600
-      );
     } else {
       //submit data to the api and then redirect to the thank you page
       const response = await fetch("/api/sign-up", {
@@ -375,6 +368,13 @@ export default function Signup(props) {
         await setErrorBoxText(t("errorUnknown"));
       }
     }
+    document.getElementById("error-box").scrollIntoView({
+      behavior: "smooth",
+    });
+    const firstErrorListItem = document.querySelector(
+      `#error-box-items > li > button`
+    );
+    if (firstErrorListItem) setTimeout(() => firstErrorListItem.focus(), 600);
   };
 
   const handleScrollToError = (id) => {

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -368,13 +368,17 @@ export default function Signup(props) {
         await setErrorBoxText(t("errorUnknown"));
       }
     }
-    document.getElementById("error-box").scrollIntoView({
-      behavior: "smooth",
-    });
-    const firstErrorListItem = document.querySelector(
+    // Checks if error box exists
+    const errorBoxEl = document.getElementById("error-box");
+    if (errorBoxEl)
+      errorBoxEl.scrollIntoView({
+        behavior: "smooth",
+      });
+    // Checks if there are list items in the error box
+    const firstErrorListEl = document.querySelector(
       `#error-box-items > li > button`
     );
-    if (firstErrorListItem) setTimeout(() => firstErrorListItem.focus(), 600);
+    if (firstErrorListEl) setTimeout(() => firstErrorListEl.focus(), 600);
   };
 
   const handleScrollToError = (id) => {


### PR DESCRIPTION
# Description

When the form displays error like: "email already exists" or "Unknown error", the page would not scroll up on its own.

This PR ensures the page scrolls up after any error.

## Test Instructions
There are 2 ways to test this.
1. The first, is to `npm run dev`. This means that your first signup will throw this known bug:
 ![image](https://user-images.githubusercontent.com/77116011/125113372-95649a00-e0b6-11eb-90c3-3da81a6c5093.png)

2. Sign up with an already existing email to get this:
 ![image](https://user-images.githubusercontent.com/77116011/125113508-c0e78480-e0b6-11eb-9895-1f0923612cbb.png)

## Checklist

- [x] Strings use placeholders for translation (No hard coded strings)
- [x] Unit tests have been added/updated