### PR TITLE
Add TTL to new mongo records

### DIFF
--- a/lib/mongodb/connect.js
+++ b/lib/mongodb/connect.js
@@ -47,6 +47,11 @@ export async function connectToDatabase(mongoURI, mongoDB) {
       unique: true,
       partialFilterExpression: { email: { $exists: true } },
     },
+    {
+      key: { expiryDate: 1 },
+      name: "expiry_date",
+      expireAfterSeconds: 0,
+    },
   ]);
   return cached.conn;
 }

--- a/lib/users/createUser.js
+++ b/lib/users/createUser.js
@@ -9,7 +9,6 @@ import { Db, Collection } from "mongodb"; //lgtm [js/unused-local-variable]
  * @returns {Promise<Collection.insertWriteOpResult>}
  */
 export async function createUser(client, email, data = {}) {
-  const date = new Date();
   return await client.collection("users").insertOne({
     cuid: cuid(),
     email: email,

--- a/lib/users/createUser.js
+++ b/lib/users/createUser.js
@@ -9,10 +9,13 @@ import { Db, Collection } from "mongodb"; //lgtm [js/unused-local-variable]
  * @returns {Promise<Collection.insertWriteOpResult>}
  */
 export async function createUser(client, email, data = {}) {
+  const date = new Date();
   return await client.collection("users").insertOne({
     cuid: cuid(),
     email: email,
     verified: false,
+    createdDate: new Date(),
+    expiryDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
     ...data,
   });
 }

--- a/lib/users/createUser.test.js
+++ b/lib/users/createUser.test.js
@@ -53,4 +53,16 @@ describe("test user creation", () => {
       expect(e).toBeInstanceOf(MongoError);
     }
   });
+
+  it("sets the expiry date to 24 hours from the created date", async () => {
+    cuid.mockImplementationOnce(() => "ckp7kjqao0000c7p9e8osgyaq");
+    let createdUser = await createUser(db, "email@email.com", {
+      test: "hello",
+      hello: "hi",
+    });
+
+    expect(
+      createdUser.ops[0].expiryDate - createdUser.ops[0].createdDate
+    ).toEqual(24 * 60 * 60 * 1000);
+  });
 });

--- a/lib/users/unsubscribeUser.js
+++ b/lib/users/unsubscribeUser.js
@@ -26,6 +26,8 @@ export async function unsubscribeUser(client, cuid) {
         minorityGroupOther: "",
         incomeLevel: "",
         agreeToConditions: "",
+        expiryDate: "",
+        createdDate: "",
       },
     },
     {

--- a/lib/users/verifyUser.js
+++ b/lib/users/verifyUser.js
@@ -13,6 +13,9 @@ export async function verifyUser(client, cuid) {
       $set: {
         verified: true,
       },
+      $unset: {
+        expiryDate: "",
+      },
     },
     {
       returnDocument: "after",

--- a/lib/users/verifyUser.test.js
+++ b/lib/users/verifyUser.test.js
@@ -7,6 +7,7 @@ describe("verifyUser", () => {
   let cUID;
   let db;
   let connectClient;
+
   beforeAll(async () => {
     cUID = cuid();
     const conn = await connectToDatabase(
@@ -18,10 +19,12 @@ describe("verifyUser", () => {
       .collection("users")
       .insertOne({ email: "email@email.com", cuid: cUID, verified: false });
   });
+
   afterAll(async () => {
     await db.dropDatabase();
     await closeConnection();
   });
+
   it("verify user", async () => {
     const receivedUser = await verifyUser(db, cUID);
     expect(receivedUser.value._id.toString()).toEqual(
@@ -29,8 +32,15 @@ describe("verifyUser", () => {
     );
     expect(receivedUser.value.verified).toBe(true);
   });
+
   it("returns null when there is no user", async () => {
     const recievedUser = await verifyUser(db, "somenonexistantid");
     expect(recievedUser.value).toBeNull();
+  });
+
+  it("removes expiry date when verifying", async () => {
+    const receivedUser = await verifyUser(db, cUID);
+
+    expect(receivedUser.value.expiryDate).toBe(undefined);
   });
 });


### PR DESCRIPTION
# Description

[Add TTL to new Mongo records](https://trello.com/c/fp0IfI41)

When a user signs up, add an expiry date to the new record. When that date is reached, the record will be automatically deleted. When a user verifies their email, the expiry date is removed, so the record won't be automatically removed.

## Acceptance Criteria

Records are automatically deleted after 24 hours without validating their emails. When the email is validated, the corresponding record shouldn't be deleted.

## Test Instructions

1. Go through the signup flow without validating
2. Wait 24 hours
3. Try the link after waiting and see that you get an expired link error

## Checklist

- [ ] Strings use placeholders for translation (No hard coded strings)
- [x] Unit tests have been added/updated

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
