### PR TITLE
Fixed label clicking issue.

### DIFF
--- a/components/atoms/CheckBox.js
+++ b/components/atoms/CheckBox.js
@@ -41,7 +41,6 @@ export function CheckBox(props) {
           props.error ? " text-error-border-red" : undefined
         }`}
         htmlFor={props.id}
-        onClick={() => props.onChange(props.checked, props.name, props.value)}
       >
         {props.showRequiredLabel ? (
           <b className="text-error-border-red">*</b>


### PR DESCRIPTION
# Description

fixes #139 

Small PR to fix the issue raised by Paul about the "Agree to terms" label not clicking the checkbox.

## Acceptance Criteria

Clicking the label also checks/unchecks the checkbox.

## Test Instructions

1. Navigate to the signup page and click the label for the "agree to terms"

## Checklist

- [x] Strings use placeholders for translation (No hard coded strings)
- [x] Unit tests have been added/updated
