### PR TITLE
added delete operation if GCNotify cant be reached on user signup

### DIFF
--- a/__tests__/api/sign-up.test.js
+++ b/__tests__/api/sign-up.test.js
@@ -137,6 +137,30 @@ describe("sign up api", ()  => {
         expect(responseData.reason).toBe("Notify")
     })
 
+    it("deletes the user when Notify fails", async () => {
+        process.env.USER_SIGNUP_ENABLED = true
+        submitEmail.mockImplementationOnce((...args) =>{ throw new Error("some error")})
+        const {req, res} = createMocks({
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "Origin": "http://localhost:3000"
+            },
+            body: {
+                language: "en",
+                email: "email@email.com",
+                other: "content"
+            }
+        })
+
+        await handler(req, res)
+        let user = await conn.db.collection("users").findOne({email: "email@email.com"})
+        let responseData = res._getJSONData()
+        expect(user).toBe(null)
+        expect(res._getStatusCode()).toBe(500)
+        expect(responseData.reason).toBe("Notify")
+    })
+
     it("returns 200 when USER_SIGNUP_ENABLED is false", async () => {
         submitEmail.mockImplementationOnce((...args) =>{ throw new Error("some error")})
         const {req, res} = createMocks({

--- a/pages/api/sign-up.js
+++ b/pages/api/sign-up.js
@@ -62,6 +62,9 @@ async function handler(req, res) {
 
       // non okay status code return 500
       if (status >= 300) {
+        await conn.db.collection("users").deleteOne({
+          cuid: userCuid,
+        });
         return res.status(500).json({
           reason: "Notify",
           explanation:
@@ -70,6 +73,9 @@ async function handler(req, res) {
         });
       }
     } catch (e) {
+      await conn.db.collection("users").deleteOne({
+        cuid: userCuid,
+      });
       return res.status(500).json({
         reason: "Notify",
         explanation: e.message,


### PR DESCRIPTION
# Description

[Ensure user's are not added to the db if GCNotify is down or unavailable](https://trello.com/c/kFnCeu3e/273-273-ensure-that-users-are-not-registered-to-the-database-if-the-gcnotify-service-is-down-connection-is-unavailable)

If there is an error in sending the email, user will be deleted from the db.

## Acceptance Criteria

Users should not be registered to the database if a confirmation email cannot be sent.

## Test Instructions

1. Remove GCNotify template IDs from your environment (this breaks the request to GCNotify)
2. Submit signup form
3. Inspect error to ensure GCNotify is returning the error
4. See that user is not registered in the database

## Checklist

- [x] Strings use placeholders for translation (No hard coded strings)
- [x] Unit tests have been added/updated

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
