### PR TITLE
Remove redirect splash

### DIFF
--- a/components/organisms/Layout.js
+++ b/components/organisms/Layout.js
@@ -91,7 +91,7 @@ export const Layout = ({
           signUpText={t("signupBtn")}
           items={[
             {
-              link: "/",
+              link: "/home",
               text: t("menuLink1"),
             },
             {

--- a/pages/index.js
+++ b/pages/index.js
@@ -4,25 +4,11 @@ import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { useTranslation } from "next-i18next";
 import { ActionButton } from "../components/atoms/ActionButton";
 import Link from "next/link";
-import { useEffect } from "react";
-
-const setLanguage = (event) => {
-  event.target.id === "french-button"
-    ? window.localStorage.setItem("lang", "fr")
-    : window.localStorage.setItem("lang", "en");
-};
 
 export default function Index(props) {
   const { t } = useTranslation("common");
   const router = useRouter();
-  useEffect(() => {
-    if (typeof window !== "undefined") {
-      const lang = window.localStorage.getItem("lang");
-      if (lang) {
-        router.push(`${lang === "en" ? "" : "/fr"}/home`);
-      }
-    }
-  }, []);
+
   return (
     <>
       <div className="bg-splash-img h-screen min-w-300px min-h-screen blur" />
@@ -60,7 +46,6 @@ export default function Index(props) {
                 text="English"
                 className="text-center text-sm w-7.5rem xl:w-138px py-3.5 mr-6 rounded leading-3"
                 href="/home"
-                onClick={setLanguage}
               />
               <ActionButton
                 id="french-button"
@@ -68,7 +53,6 @@ export default function Index(props) {
                 className="text-center w-7.5rem xl:w-138px text-sm py-3.5 rounded leading-3"
                 href="/fr/home"
                 lang="fr"
-                onClick={setLanguage}
               />
             </div>
           </div>


### PR DESCRIPTION
# Description

The splash page doesn't store now the lang attribute and just links with the buttons directly to either french or the english home page.

## Acceptance Criteria

The splash page should not redirect automatically to the home page. It should only after clicking the french or english button.

## Test Instructions

1. Go on the splash page
2. Click the french and english buttons to see if they go to the right language
3. Try going back to the splash page, it shouldn't redirect to the home page straight away.

## Checklist

- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
