### PR TITLE
Sign up to become a participant link fix

### DIFF
--- a/components/molecules/CallToAction.js
+++ b/components/molecules/CallToAction.js
@@ -15,7 +15,7 @@ export function CallToAction(props) {
         <div className="flex flex-col lg:grid lg:grid-cols-2 lg:gap-24 gap-5">
           <p>{props.description}</p>
           <div>
-            <p className="mb-4">
+            <p className="flex mb-4 text-center">
               <ActionButton
                 id="become-a-participant-btn"
                 href={props.href}


### PR DESCRIPTION
# Description

fixes #178 

Formatted the CallToActtion.JS `Link` to look like the Figma design on small screens.

## Acceptance Criteria

- The footer should look like the Figma design.

## Test Instructions

1. Scroll to the bottom of the homepage, about page or the privacy page to see the footer like this:
![image](https://user-images.githubusercontent.com/77116011/125658193-42dc222d-4380-4811-885b-743881303585.png)

## Checklist

- [x] Strings use placeholders for translation (No hard coded strings)
- [x] Unit tests have been added/updated
