### PR TITLE
Add a .dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,23 @@
+# git stuff
+.git
+.gitignore
+.github
+
+# svn as well
+.svn
+
+# project stuff
+node_modules/
+npm-debug.log
+.DS_Store
+*.env
+coverage/
+.vscode/
+.idea
+
+# things we don't want in the container
+Dockerfile
+*.md
+.dockerignore
+
+


### PR DESCRIPTION
We want to prevent unnecessary config or documentation files that we don't anticipate from being added to the container.

# Description

Added a `.dockerignore` file so that we don't end up adding `.svn` or `.git` folders to the container unintentionally. I tested this locally by building the container, but we can't really know if it works until it's deployed to prod. But we can know that it doesn't break anything.

#inspo for the `.dockerignore` file is here: https://github.com/pcraig3/hols/blob/main/.dockerignore

Trello card for this is here: https://trello.com/c/gBRWOzvN/390-390-add-a-dockerignore-file-to-the-repo-so-that-we-dont-unintentionally-build-containers-with-git-svn-folders-in-them
