### PR TITLE
Update mongo indexes

### DIFF
--- a/lib/mongodb/connect.js
+++ b/lib/mongodb/connect.js
@@ -47,11 +47,10 @@ export async function connectToDatabase(mongoURI, mongoDB) {
       key: { email: 1 },
       name: "email",
       unique: true,
-      sparse: true,
     },
     {
       key: { _ts: 1 },
-      expireAfterSeconds: 0,
+      expireAfterSeconds: 2147483648,
     },
   ]);
   return cached.conn;

--- a/lib/mongodb/connect.js
+++ b/lib/mongodb/connect.js
@@ -42,6 +42,8 @@ export async function connectToDatabase(mongoURI, mongoDB) {
   // Azure CosmoDB does not support partial indexes by default, but hopefully the do support sparse indexes
   // Similarly, the TTL index in CosmoDB is different than default Mongo so this might not work locally
   cached.conn = await cached.promise;
+  const expireAfterSeconds =
+    process.env.NODE_ENV === "production" ? 2147483648 : 0;
   await cached.conn.db.collection("users").createIndexes([
     {
       key: { email: 1 },
@@ -50,7 +52,7 @@ export async function connectToDatabase(mongoURI, mongoDB) {
     },
     {
       key: { _ts: 1 },
-      expireAfterSeconds: 2147483648,
+      expireAfterSeconds: expireAfterSeconds,
     },
   ]);
   return cached.conn;

--- a/lib/users/unsubscribeUser.js
+++ b/lib/users/unsubscribeUser.js
@@ -11,7 +11,6 @@ export async function unsubscribeUser(client, cuid) {
     { cuid },
     {
       $unset: {
-        email: "",
         verified: "",
         yearOfBirth: "",
         language: "",
@@ -26,8 +25,9 @@ export async function unsubscribeUser(client, cuid) {
         minorityGroupOther: "",
         incomeLevel: "",
         agreeToConditions: "",
-        expiryDate: "",
-        createdDate: "",
+      },
+      $set: {
+        email: cuid,
       },
     },
     {

--- a/lib/users/unsubscribeUser.test.js
+++ b/lib/users/unsubscribeUser.test.js
@@ -61,7 +61,7 @@ describe("unsubscribeUser functions", () => {
     const unsubResult = await unsubscribeUser(db, cUID1);
 
     expect(unsubResult.value.cuid).toEqual(cUID1);
-    expect(unsubResult.value.email).toEqual(undefined);
+    expect(unsubResult.value.email).toEqual(cUID1);
     expect(unsubResult.value.verified).toEqual(undefined);
     expect(unsubResult.value.yearOfBirth).toEqual(undefined);
     expect(unsubResult.value.language).toEqual(undefined);


### PR DESCRIPTION
# Description

CosmosDB does not support partial or sparse indexes, which we were using to keep a unique constraint on emails, and allow us to delete them. Without a partial or sparse index, two records with removed emails would be considered the same and fail the unique constraint. To get around this issue and keep emails unique, when a user unsubscribes, I am setting the email field to the cuid, which will be unique.

## Acceptance Criteria

When a user unsubscribes, there are no unique constraint errors.

## Test Instructions

1. Follow the signup flow with 2+ emails
2. Unsubscribe for 1 of them
3. Unsubscribe for a second and notice that no errors appear

## Checklist

- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
