### PR TITLE
Adding Phasebanner back.

### DIFF
--- a/components/atoms/PhaseBanner.js
+++ b/components/atoms/PhaseBanner.js
@@ -12,7 +12,7 @@ export const PhaseBanner = ({ phase, children }) => {
         <span className="font-body text-xs text-circle-color font-extrabold flex-shrink-0 bg-white px-4 py-1 my-auto leading-6">
           {phase}
         </span>
-        <p className="font-body text-xs mt-5 sm:mt-auto text-white sm:ml-4 pt-1 my-auto">
+        <p className="font-body text-xs mt-5 sm:mt-auto text-white sm:ml-4 pt-1 my-auto lg:pb-1">
           {children}
         </p>
       </div>

--- a/components/atoms/PhaseBanner.js
+++ b/components/atoms/PhaseBanner.js
@@ -1,0 +1,34 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+/**
+ * Displays the PhaseBanner on the page
+ */
+
+export const PhaseBanner = ({ phase, children }) => {
+  return (
+    <div className="bg-circle-color">
+      <div className="block sm:flex py-4 layout-container">
+        <span className="font-body text-xs text-circle-color font-extrabold flex-shrink-0 bg-white px-4 py-1 my-auto leading-6">
+          {phase}
+        </span>
+        <p className="font-body text-xs mt-5 sm:mt-auto text-white sm:ml-4 pt-1 my-auto">
+          {children}
+        </p>
+      </div>
+    </div>
+  );
+};
+
+PhaseBanner.propTypes = {
+  /**
+   * Phase stage in the PhaseBanner
+   */
+  phase: PropTypes.string.isRequired,
+  /**
+   * Phase stage in the PhaseBanner
+   */
+  children: PropTypes.string.isRequired,
+};
+
+export default PhaseBanner;

--- a/components/atoms/PhaseBanner.stories.js
+++ b/components/atoms/PhaseBanner.stories.js
@@ -1,0 +1,16 @@
+import React from "react";
+import PhaseBanner from "./PhaseBanner";
+
+export default {
+  title: "Components/Atoms/PhaseBanner",
+  component: PhaseBanner,
+};
+
+const Template = (args) => <PhaseBanner {...args} />;
+
+export const Primary = Template.bind({});
+
+Primary.args = {
+  phase: "PhaseBanner Phase",
+  children: "PhaseBanner Text",
+};

--- a/components/atoms/PhaseBanner.test.js
+++ b/components/atoms/PhaseBanner.test.js
@@ -1,0 +1,26 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/extend-expect";
+import { axe, toHaveNoViolations } from "jest-axe";
+import { Primary } from "./PhaseBanner.stories";
+
+expect.extend(toHaveNoViolations);
+
+describe("PhaseBanner tests", () => {
+  it("renders PhaseBanner in its primary state", () => {
+    render(<Primary {...Primary.args} />);
+    const phaseElement = screen.getByText("PhaseBanner Phase");
+    const textElement = screen.getByText("PhaseBanner Text");
+    expect(phaseElement).toBeTruthy();
+    expect(textElement).toBeTruthy();
+  });
+
+  it("has no a11y violations", async () => {
+    const { container } = render(<Primary {...Primary.args} />);
+    const results = await axe(container);
+
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/components/organisms/Layout.js
+++ b/components/organisms/Layout.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import { Banner } from "../atoms/Banner";
 import { Menu } from "../molecules/Menu";
 import { Footer } from "./Footer";
+import { PhaseBanner } from "../atoms/PhaseBanner";
 import { ReportAProblem } from "./ReportAProblem";
 import Link from "next/link";
 import { useTranslation } from "next-i18next";
@@ -43,6 +44,7 @@ export const Layout = ({
         </a>
       </nav>
       <header>
+        <PhaseBanner phase={t("BannerTag")}>{t("BannerText")}</PhaseBanner>
         <div className="layout-container flex-col flex lg:flex lg:flex-row justify-between  mt-2">
           <div className="flex flex-row justify-between items-center lg:mt-7 mt-1.5">
             <img

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1,4 +1,6 @@
 {
+  "BannerTag": "Test site",
+  "BannerText": "You cannot apply for services or benefits through this test site. Parts of this site may not work and will change.",
   "siteTitle": "Alpha Site",
   "bannerTitle": "Service Canada Labs",
   "bannerText": "Make government work for you",

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -1,4 +1,6 @@
 {
+  "BannerTag": "Site d’essai",
+  "BannerText": "Vous ne pouvez pas demander de services ou de prestations par l'intermédiaire de ce site d’essai. Certaines parties du site pourraient ne pas fonctionner et seront modifiées.",
   "siteTitle": "Site Alpha",
   "bannerTitle": "Laboratoires de Service Canada",
   "bannerText": "Faites travailler le gouvernement pour vous",


### PR DESCRIPTION
# Description

Following the QA list pre-launch and adding the Phasebanner back on all pages.
![image](https://user-images.githubusercontent.com/77116011/125815190-1ce218d7-086a-4e50-afba-36e9a0c191df.png)


## Acceptance Criteria

Phasebanner must be on all pages except the splash page.

## Test Instructions

1. Load any page and test the Phasebanner at the top of the page on any width and both languages.

## Checklist

- [x] Strings use placeholders for translation (No hard coded strings)
- [x] Unit tests have been added/updated
