### PR TITLE
Fix TTL index in CosmosDB

### DIFF
--- a/lib/mongodb/connect.js
+++ b/lib/mongodb/connect.js
@@ -53,7 +53,7 @@ export async function connectToDatabase(mongoURI, mongoDB) {
     },
     {
       key: { _ts: 1 },
-      expireAfterSeconds: 2147483647,
+      expireAfterSeconds: process.env.NODE_ENV === "test" ? 0 : 2147483647,
     },
   ]);
   return cached.conn;

--- a/lib/mongodb/connect.js
+++ b/lib/mongodb/connect.js
@@ -41,9 +41,10 @@ export async function connectToDatabase(mongoURI, mongoDB) {
   // create new connection from connection creator
   // Azure CosmoDB does not support partial indexes by default, but hopefully the do support sparse indexes
   // Similarly, the TTL index in CosmoDB is different than default Mongo so this might not work locally
+  // TTL in CosmosDB needs an end time and can store an int32. Max for int32 is 2147483647, which turns into about 68 years
+  // We are still setting a per document TTL, which gets removed when the email is verified, but after 68 years,
+  // it will still be removed from the database because CosmosDB needs the TTL index to do per document TTL.
   cached.conn = await cached.promise;
-  const expireAfterSeconds =
-    process.env.NODE_ENV === "production" ? 2147483648 : 0;
   await cached.conn.db.collection("users").createIndexes([
     {
       key: { email: 1 },
@@ -52,7 +53,7 @@ export async function connectToDatabase(mongoURI, mongoDB) {
     },
     {
       key: { _ts: 1 },
-      expireAfterSeconds: expireAfterSeconds,
+      expireAfterSeconds: 2147483647,
     },
   ]);
   return cached.conn;


### PR DESCRIPTION
# Description

Simplified the TTL index for Cosmosdb and set the correct max value. Had to add a check for when doing unit tests because, while the int32.max works in the real MongoDB, it makes the unit tests fail.

## Acceptance Criteria

The TTL index is actually created in CosmosDB.


## Checklist

- [ ] Strings use placeholders for translation (No hard coded strings)
- [x] Unit tests have been added/updated

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
