### PR TITLE
Fix unsubscribe flow

### DIFF
--- a/lib/users/unsubscribeUser.js
+++ b/lib/users/unsubscribeUser.js
@@ -25,6 +25,7 @@ export async function unsubscribeUser(client, cuid) {
         minorityGroupOther: "",
         incomeLevel: "",
         agreeToConditions: "",
+        ttl: "",
       },
       $set: {
         email: cuid,

--- a/pages/api/unsubscribe.js
+++ b/pages/api/unsubscribe.js
@@ -72,7 +72,9 @@ export default async function handler(req, res) {
           process.env.MONGO_DB
         );
         unsubUserObj = await unsubscribeUser(conn.db, id);
-        if (Object.keys(unsubUserObj.value).length === 2) {
+        // because we can't use partial or sparse id's in CosmosDB, we need to get around the unique email problem
+        // we do this by setting the email to the cuid, so we know if these 2 value are the same, the operation was a success
+        if (unsubUserObj.value.cuid === unsubUserObj.value.email) {
           return res.redirect(
             `${lang === "fr" ? "/fr" : ""}/confirmation?ref=unsubscribe`
           );


### PR DESCRIPTION
# Description

Had to fix some logic in unsubscribe flow. The process worked, but would return the error page instead of success because of a flawed if condition.

## Acceptance Criteria

Clicking the link in the unsubscribe email returns the confirmation page, not the error page.

## Test Instructions

1. Follow user signup flow
2. Navigate to `/unsubscribe` and enter the email you used to signup
3. Click the unsubscribe link in the email and notice it returns the success page and not the error page

## Checklist

- [ ] Strings use placeholders for translation (No hard coded strings)
- [x] Unit tests have been added/updated

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
