### PR TITLE
added lang prop to links created by ActionButton

### DIFF
--- a/components/atoms/ActionButton.js
+++ b/components/atoms/ActionButton.js
@@ -55,6 +55,7 @@ export function ActionButton(props) {
         disabled={props.disabled}
         role="button"
         draggable="false"
+        lang={props.lang}
       >
         {props.icon && !props.iconEnd ? (
           <span className={props.icon} data-testid={props.dataTestId} />
@@ -125,6 +126,10 @@ ActionButton.propTypes = {
    */
   id: PropTypes.string.isRequired,
 
+  /**
+   * Lang attribute for links that do not match the language of the top level document
+   */
+  lang: PropTypes.string,
   /**
    * the type of the button
    */


### PR DESCRIPTION
This PR addresses the following:

The Francais button is also missing the `lang="fr"` attribute for [WCAG 3.1.2 compliance](https://www.w3.org/WAI/WCAG21/Understanding/language-of-parts.html)

<img width="617" alt="Screen Shot 2021-07-14 at 11 47 28 PM" src="https://user-images.githubusercontent.com/9325038/125726067-cf001a51-8b83-4889-8493-4b2e2fc08930.png">

_Originally posted by @neilmispelaar in https://github.com/DTS-STN/Alpha-Site/issues/191#issuecomment-880370126_
## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
