### PR TITLE
changed SCLabs breadcrumb route to "/home"

### DIFF
--- a/pages/about.js
+++ b/pages/about.js
@@ -14,7 +14,7 @@ export default function About(props) {
     <Layout
       locale={props.locale}
       langUrl={asPath}
-      breadcrumbItems={[{ text: "Service Canada Labs", link: "/" }]}
+      breadcrumbItems={[{ text: "Service Canada Labs", link: "/home" }]}
     >
       <Head>
         {process.env.NEXT_PUBLIC_ADOBE_ANALYTICS_URL ? (

--- a/pages/confirmation.js
+++ b/pages/confirmation.js
@@ -14,7 +14,7 @@ export default function Confirmation(props) {
     <Layout
       locale={props.locale}
       langUrl={asPath}
-      breadcrumbItems={[{ text: "Service Canada Labs", link: "/" }]}
+      breadcrumbItems={[{ text: "Service Canada Labs", link: "/home" }]}
     >
       <Head>
         <title>

--- a/pages/experiments.js
+++ b/pages/experiments.js
@@ -69,7 +69,7 @@ export default function Experiments(props) {
     <Layout
       locale={props.locale}
       langUrl={asPath}
-      breadcrumbItems={[{ text: "Service Canada Labs", link: "/" }]}
+      breadcrumbItems={[{ text: "Service Canada Labs", link: "/home" }]}
     >
       <Head>
         {process.env.NEXT_PUBLIC_ADOBE_ANALYTICS_URL ? (

--- a/pages/privacy.js
+++ b/pages/privacy.js
@@ -13,7 +13,7 @@ export default function Privacy(props) {
     <Layout
       locale={props.locale}
       langUrl={asPath}
-      breadcrumbItems={[{ text: "Service Canada Labs", link: "/" }]}
+      breadcrumbItems={[{ text: "Service Canada Labs", link: "/home" }]}
     >
       <Head>
         {process.env.NEXT_PUBLIC_ADOBE_ANALYTICS_URL ? (

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -383,7 +383,7 @@ export default function Signup(props) {
     <Layout
       locale={props.locale}
       langUrl={asPath}
-      breadcrumbItems={[{ text: "Service Canada Labs", link: "/" }]}
+      breadcrumbItems={[{ text: "Service Canada Labs", link: "/home" }]}
     >
       <Head>
         {process.env.NEXT_PUBLIC_ADOBE_ANALYTICS_URL ? (

--- a/pages/thankyou.js
+++ b/pages/thankyou.js
@@ -15,7 +15,7 @@ export default function Confirmation(props) {
     <Layout
       locale={props.locale}
       langUrl={asPath}
-      breadcrumbItems={[{ text: "Service Canada Labs", link: "/" }]}
+      breadcrumbItems={[{ text: "Service Canada Labs", link: "/home" }]}
     >
       <Head>
         {process.env.NEXT_PUBLIC_ADOBE_ANALYTICS_URL ? (

--- a/pages/unsubscribe.js
+++ b/pages/unsubscribe.js
@@ -167,7 +167,7 @@ export default function Unsubscribe(props) {
     <Layout
       locale={props.locale}
       langUrl={asPath}
-      breadcrumbItems={[{ text: "Service Canada Labs", link: "/" }]}
+      breadcrumbItems={[{ text: "Service Canada Labs", link: "/home" }]}
     >
       <Head>
         {process.env.NEXT_PUBLIC_ADOBE_ANALYTICS_URL ? (


### PR DESCRIPTION
# Description

[changed SCLabs breadcrumb route to "/home"](https://trello.com/c/gFHafWSd/395-change-service-canada-labs-link-in-breadcrumbs-to-link-to-home-instead-of)

## Acceptance Criteria

Service Canada Labs breadcrumb should take the user to the homepage, not the splash page.

## Test Instructions

1. Try breadcrumb link to make sure it is going to the homepage

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
