### PR TITLE
Fix unit tests

### DIFF
--- a/__tests__/pages/error.test.js
+++ b/__tests__/pages/error.test.js
@@ -5,6 +5,7 @@ import React from "react";
 import { screen } from "@testing-library/react";
 import "@testing-library/jest-dom/extend-expect";
 import { getPage } from "next-page-tester";
+import { act } from "react-dom/test-utils";
 
 import router from "next/router";
 
@@ -12,18 +13,22 @@ jest.mock("next/router", () => require("next-router-mock"));
 
 describe("Error page", () => {
   it("renders the page", async () => {
-    const { render } = await getPage({
-      route: "/error",
+    await act(async () => {
+      const { render } = await getPage({
+        route: "/error",
+      });
+      render();
     });
-    render();
     expect(screen.getByRole("main")).toBeInTheDocument();
   });
 
   it("renders default title and message", async () => {
-    const { render } = await getPage({
-      route: "/error",
+    await act(async () => {
+      const { render } = await getPage({
+        route: "/error",
+      });
+      render();
     });
-    render();
 
     const titleEn = screen.getByTestId("heading-en");
     const titleFr = screen.getByTestId("heading-fr");
@@ -41,9 +46,11 @@ describe("Error page", () => {
   });
 
   it("renders custom title", () => {
-    router.push({
-      pathname: "/error",
-      query: { errorTitle: "custom title", errorTitleFr: "custom title fr" },
+    act(() => {
+      router.push({
+        pathname: "/error",
+        query: { errorTitle: "custom title", errorTitleFr: "custom title fr" },
+      });
     });
     expect(router).toMatchObject({
       asPath:
@@ -54,13 +61,16 @@ describe("Error page", () => {
   });
 
   it("renders custom message", () => {
-    router.push({
-      pathname: "/error",
-      query: {
-        errorMessage: "custom error message",
-        errorMessageFr: "custom error message fr",
-      },
+    act(() => {
+      router.push({
+        pathname: "/error",
+        query: {
+          errorMessage: "custom error message",
+          errorMessageFr: "custom error message fr",
+        },
+      });
     });
+
     expect(router).toMatchObject({
       asPath:
         "/error?errorMessage=custom%20error%20message&errorMessageFr=custom%20error%20message%20fr",
@@ -73,27 +83,17 @@ describe("Error page", () => {
   });
 
   it("renders the status code if it's passed in", () => {
-    router.push({
-      pathname: "/error",
-      query: { statusCode: "404" },
+    act(() => {
+      router.push({
+        pathname: "/error",
+        query: { statusCode: "404" },
+      });
     });
+
     expect(router).toMatchObject({
       asPath: "/error?statusCode=404",
       pathname: "/error",
       query: { statusCode: "404" },
     });
   });
-
-  // it("renders the status code if it's passed in", async () => {
-  //   const { render } = await getPage({
-  //     route: "/error?statusCode=404",
-  //   });
-  //   render();
-
-  //   const statusCode = screen.getByTestId("statuscode-en");
-  //   const statusCodeFr = screen.getByTestId("statuscode-fr");
-
-  //   expect(statusCode.textContent).toEqual("Error 404");
-  //   expect(statusCodeFr.textContent).toEqual("Erreur 404");
-  // });
 });

--- a/__tests__/pages/home.test.js
+++ b/__tests__/pages/home.test.js
@@ -7,8 +7,6 @@ import Home from "../../pages/home";
 describe("Home", () => {
   it("renders without crashing", () => {
     render(<Home />);
-    expect(
-      screen.getByText("experimentsAndExplorationTitle")
-    ).toBeInTheDocument();
+    expect(screen.getByText("projectsAndExplorationTitle")).toBeInTheDocument();
   });
 });

--- a/__tests__/pages/projects.test.js
+++ b/__tests__/pages/projects.test.js
@@ -5,7 +5,11 @@ import { getPage } from "next-page-tester";
 import { screen } from "@testing-library/react";
 import fetchMock from "fetch-mock";
 const experiments = require("../../cypress/fixtures/experiments.json");
-
+jest.mock("next/link", () => {
+  return ({ children }) => {
+    return children;
+  };
+});
 describe("Projects", () => {
   beforeEach(() => {
     fetchMock.getOnce(`${process.env.STRAPI_API_BACKEND_URL}/experiments`, {

--- a/components/molecules/CallToAction.test.js
+++ b/components/molecules/CallToAction.test.js
@@ -8,6 +8,12 @@ import { axe, toHaveNoViolations } from "jest-axe";
 
 expect.extend(toHaveNoViolations);
 
+jest.mock("next/link", () => {
+  return ({ children }) => {
+    return children;
+  };
+});
+
 describe("CallToAction", () => {
   it("renders component correctly", () => {
     render(<Primary {...Primary.args} />);

--- a/components/molecules/OptionalListField.stories.js
+++ b/components/molecules/OptionalListField.stories.js
@@ -29,12 +29,14 @@ UnOpened.args = {
   listLabel: "Please check all the reasons why you are wrong.",
   children: [
     <CheckBox
+      key="key1"
       label="I don't like fake chocolate spread"
       name="reasons"
       value="dislike"
       id="reasons-dislike"
     />,
     <CheckBox
+      key="key2"
       label="I make poor choices"
       name="reasons"
       value="poor-choice"
@@ -53,6 +55,7 @@ Opened_Checkboxes.args = {
   listLabel: "Please check all the reasons why you are wrong.",
   children: [
     <CheckBox
+      key="key1"
       label="I don't like fake chocolate spread"
       name="reasons"
       value="dislike"
@@ -60,6 +63,7 @@ Opened_Checkboxes.args = {
       dataTestId="reasons-dislike"
     />,
     <CheckBox
+      key="key2"
       label="I make poor choices"
       name="reasons"
       value="poor-choice"
@@ -79,6 +83,7 @@ Opened_Radiofields.args = {
   listLabel: "Please check all the reasons why you are wrong.",
   children: [
     <RadioField
+      key="key1"
       label="I don't like fake chocolate spread"
       name="reasons"
       value="dislike"
@@ -86,6 +91,7 @@ Opened_Radiofields.args = {
       dataTestId="reasons-dislike"
     />,
     <RadioField
+      key="key2"
       label="I make poor choices"
       name="reasons"
       value="poor-choice"
@@ -106,6 +112,7 @@ Radio.args = {
   listLabel: "Please check all the reasons why you are wrong.",
   children: [
     <CheckBox
+      key="key1"
       label="I don't like fake chocolate spread"
       name="reasons"
       value="dislike"
@@ -113,6 +120,7 @@ Radio.args = {
       dataTestId="reasons-dislike"
     />,
     <CheckBox
+      key="key2"
       label="I make poor choices"
       name="reasons"
       value="poor-choice"
@@ -132,6 +140,7 @@ UnControlled.args = {
   listLabel: "Please check all the reasons why you are wrong.",
   children: [
     <CheckBox
+      key="key1"
       label="I don't like fake chocolate spread"
       name="reasons"
       value="dislike"
@@ -139,6 +148,7 @@ UnControlled.args = {
       dataTestId="reasons-dislike"
     />,
     <CheckBox
+      key="key2"
       label="I make poor choices"
       name="reasons"
       value="poor-choice"

--- a/components/organisms/VirtualConcierge.test.js
+++ b/components/organisms/VirtualConcierge.test.js
@@ -9,13 +9,13 @@ import { Primary } from "./VirtualConcierge.stories";
 expect.extend(toHaveNoViolations);
 
 describe("Virtual Concierge", () => {
-  it("renders the page with some text", () => {
+  it("renders the page with some text", async () => {
     render(<Primary {...Primary.args} />);
-    screen.findByText(Primary.args.vcImageAltText);
-    screen.findByText(Primary.args.description);
-    screen.findByText(Primary.args.description1);
-    screen.findByText(Primary.args.description2);
-    screen.findByText(Primary.args.dataTestId);
+    await screen.findAllByAltText(Primary.args.vcImageAltText);
+    await screen.findByText(Primary.args.description);
+    await screen.findByText(Primary.args.description1);
+    await screen.findByText(Primary.args.description2);
+    await screen.findAllByTestId(Primary.args.dataTestId);
   });
 
   //   it("renders the page with some items", () => {


### PR DESCRIPTION
# Description

I noticed that there were a lot of errors in the unit tests that didn't necessarily cause the tests to fail, but they were there anyways. I fixed most of them because they were easy, but the `report-a-problem` is still logging errors and I'm not sure why. The tests are still passing, but errors are logged. Maybe this will help with the PRs that are all failing as well.

## Acceptance Criteria

Unit tests, except for `report-a-problem`, no longer log errors.

## Test Instructions

1. Run `npm run test:unit`
2. See that only `report-a-problem` logs errors


## Checklist

- [ ] Strings use placeholders for translation (No hard coded strings)
- [x] Unit tests have been added/updated

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
