### PR TITLE
Fix Add aside element that wraps call to action

### DIFF
--- a/components/molecules/CallToAction.js
+++ b/components/molecules/CallToAction.js
@@ -9,37 +9,39 @@ import { useTranslation } from "next-i18next";
 export function CallToAction(props) {
   const { t } = useTranslation("common");
   return (
-    <div className="bg-circle-color text-white">
-      <div className="layout-container pb-10 pt-10 text-xs md:text-base">
-        <h2>{props.title}</h2>
-        <div className="flex flex-col lg:grid lg:grid-cols-2 lg:gap-24 gap-5">
-          {props.description ? (
-            <p className="whitespace-pre-line">{props.description}</p>
-          ) : (
-            <div
-              className="whitespace-pre-line"
-              dangerouslySetInnerHTML={{ __html: props.html }}
-            />
-          )}
-          <div>
-            <p className="flex mb-4 text-center">
-              <ActionButton
-                id="become-a-participant-btn"
-                href={props.href}
-                text={props.hrefText}
+    <aside>
+      <div className="bg-circle-color text-white">
+        <div className="layout-container pb-10 pt-10 text-xs md:text-base">
+          <h2>{props.title}</h2>
+          <div className="flex flex-col lg:grid lg:grid-cols-2 lg:gap-24 gap-5">
+            {props.description ? (
+              <p className="whitespace-pre-line">{props.description}</p>
+            ) : (
+              <div
+                className="whitespace-pre-line"
+                dangerouslySetInnerHTML={{ __html: props.html }}
               />
-            </p>
-            <p>
-              <Link href="/privacy">
-                <a className="text-sm underline flex xl:inline lg:mr-10">
-                  {t("privacyLinkText")}
-                </a>
-              </Link>
-            </p>
+            )}
+            <div>
+              <p className="flex mb-4 text-center">
+                <ActionButton
+                  id="become-a-participant-btn"
+                  href={props.href}
+                  text={props.hrefText}
+                />
+              </p>
+              <p>
+                <Link href="/privacy">
+                  <a className="text-sm underline flex xl:inline lg:mr-10">
+                    {t("privacyLinkText")}
+                  </a>
+                </Link>
+              </p>
+            </div>
           </div>
         </div>
       </div>
-    </div>
+    </aside>
   );
 }
 


### PR DESCRIPTION
# Description

Fix #223 

Wrap the call to action component in an aside to pass WCAG 1.3.1

## Acceptance Criteria

Unsure

## Test Instructions

1. Run project
2. Visit the virtual concierge page
3. Inspect the page
4. Confirm that there is an `aside` element wrapping the blue call to action banner

If the last test is true then the work has been completed successfully. 

## Help Requested

N/A

## Checklist

- [-] Strings use placeholders for translation (No hard coded strings)
- [-] Unit tests have been added/updated

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
