### PR TITLE
Set security headers to all paths

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -38,7 +38,7 @@ module.exports = {
     return [
       {
         // Apply these headers to all routes in your application.
-        source: '/(.*)',
+        source: '/:path*{/}?',
         headers: securityHeaders,
       },
     ]


### PR DESCRIPTION
# Description

Simple fix to apply security header config to all paths (required for pages with i18n).

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
