### PR TITLE
Add more Adobe Analytics sources into the CSP whitelist

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -14,6 +14,7 @@ function getCsp() {
       ? "'unsafe-eval'"
       : ""
   } https://ajax.googleapis.com https://assets.adobedtm.com;`; // NextJS requires 'unsafe-eval' in dev (faster source maps)
+  csp += `connect-src *.demdex.net *.omtrdc.net;`;
   csp += `style-src 'self' 'unsafe-inline' https://fonts.googleapis.com data:;`; // NextJS requires 'unsafe-inline'
   csp += `img-src 'self';`;
   csp += `font-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com;`;

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -14,7 +14,7 @@ function getCsp() {
       ? "'unsafe-eval'"
       : ""
   } https://ajax.googleapis.com https://assets.adobedtm.com;`; // NextJS requires 'unsafe-eval' in dev (faster source maps)
-  csp += `connect-src *.demdex.net *.omtrdc.net;`;
+  csp += `connect-src 'self' *.demdex.net *.omtrdc.net;`;
   csp += `style-src 'self' 'unsafe-inline' https://fonts.googleapis.com data:;`; // NextJS requires 'unsafe-inline'
   csp += `img-src 'self';`;
   csp += `font-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com;`;


### PR DESCRIPTION
# Description

Adds Adobe Analytics sources to the CSP whitelist

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
