### PR TITLE
French breadcrumb links

### DIFF
--- a/pages/about.js
+++ b/pages/about.js
@@ -14,7 +14,12 @@ export default function About(props) {
     <Layout
       locale={props.locale}
       langUrl={asPath}
-      breadcrumbItems={[{ text: "Service Canada Labs", link: "/home" }]}
+      breadcrumbItems={[
+        {
+          text: t("bannerTitle"),
+          link: props.locale === "en" ? "/home" : "/fr/home",
+        },
+      ]}
     >
       <Head>
         {process.env.NEXT_PUBLIC_ADOBE_ANALYTICS_URL ? (

--- a/pages/confirmation.js
+++ b/pages/confirmation.js
@@ -14,7 +14,12 @@ export default function Confirmation(props) {
     <Layout
       locale={props.locale}
       langUrl={asPath}
-      breadcrumbItems={[{ text: "Service Canada Labs", link: "/home" }]}
+      breadcrumbItems={[
+        {
+          text: t("bannerTitle"),
+          link: props.locale === "en" ? "/home" : "/fr/home",
+        },
+      ]}
     >
       <Head>
         <title>

--- a/pages/privacy.js
+++ b/pages/privacy.js
@@ -13,7 +13,12 @@ export default function Privacy(props) {
     <Layout
       locale={props.locale}
       langUrl={asPath}
-      breadcrumbItems={[{ text: "Service Canada Labs", link: "/home" }]}
+      breadcrumbItems={[
+        {
+          text: t("bannerTitle"),
+          link: props.locale === "en" ? "/home" : "/fr/home",
+        },
+      ]}
     >
       <Head>
         {process.env.NEXT_PUBLIC_ADOBE_ANALYTICS_URL ? (

--- a/pages/projects.js
+++ b/pages/projects.js
@@ -69,7 +69,12 @@ export default function Projects(props) {
     <Layout
       locale={props.locale}
       langUrl={asPath}
-      breadcrumbItems={[{ text: "Service Canada Labs", link: "/home" }]}
+      breadcrumbItems={[
+        {
+          text: t("bannerTitle"),
+          link: props.locale === "en" ? "/home" : "/fr/home",
+        },
+      ]}
     >
       <Head>
         {process.env.NEXT_PUBLIC_ADOBE_ANALYTICS_URL ? (

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -383,7 +383,7 @@ export default function Signup(props) {
     <Layout
       locale={props.locale}
       langUrl={asPath}
-      breadcrumbItems={[{ text: "Service Canada Labs", link: "/home" }]}
+      breadcrumbItems={[{ text: t("bannerTitle"), link: props.locale === "en" ? "/home" : "/fr/home"}]}
     >
       <Head>
         {process.env.NEXT_PUBLIC_ADOBE_ANALYTICS_URL ? (

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -383,7 +383,12 @@ export default function Signup(props) {
     <Layout
       locale={props.locale}
       langUrl={asPath}
-      breadcrumbItems={[{ text: t("bannerTitle"), link: props.locale === "en" ? "/home" : "/fr/home"}]}
+      breadcrumbItems={[
+        {
+          text: t("bannerTitle"),
+          link: props.locale === "en" ? "/home" : "/fr/home",
+        },
+      ]}
     >
       <Head>
         {process.env.NEXT_PUBLIC_ADOBE_ANALYTICS_URL ? (

--- a/pages/thankyou.js
+++ b/pages/thankyou.js
@@ -14,7 +14,12 @@ export default function Confirmation(props) {
     <Layout
       locale={props.locale}
       langUrl={asPath}
-      breadcrumbItems={[{ text: "Service Canada Labs", link: "/home" }]}
+      breadcrumbItems={[
+        {
+          text: t("bannerTitle"),
+          link: props.locale === "en" ? "/home" : "/fr/home",
+        },
+      ]}
     >
       <Head>
         {process.env.NEXT_PUBLIC_ADOBE_ANALYTICS_URL ? (

--- a/pages/unsubscribe.js
+++ b/pages/unsubscribe.js
@@ -167,7 +167,12 @@ export default function Unsubscribe(props) {
     <Layout
       locale={props.locale}
       langUrl={asPath}
-      breadcrumbItems={[{ text: "Service Canada Labs", link: "/home" }]}
+      breadcrumbItems={[
+        {
+          text: t("bannerTitle"),
+          link: props.locale === "en" ? "/home" : "/fr/home",
+        },
+      ]}
     >
       <Head>
         {process.env.NEXT_PUBLIC_ADOBE_ANALYTICS_URL ? (


### PR DESCRIPTION
# Description

[Breadcrumbs should be in French when on French pages](https://trello.com/c/rjrSGclJ/402-breadcrumbs-should-be-in-french-when-on-french-pages)

I updated the breadcrumb to have french text and french links.

## Acceptance Criteria

The breadcumb items must be translated in french and send to to french pages as well

## Test Instructions

1. Test the breadcrumb on each page to see if it's working.

## Checklist

- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
