### PR TITLE
Breadcrumb lang fix

### DIFF
--- a/pages/about.js
+++ b/pages/about.js
@@ -15,10 +15,7 @@ export default function About(props) {
       locale={props.locale}
       langUrl={asPath}
       breadcrumbItems={[
-        {
-          text: t("bannerTitle"),
-          link: props.locale === "en" ? "/home" : "/fr/home",
-        },
+        { text: t("bannerTitle"), link: t("breadCrumbsHref1") },
       ]}
     >
       <Head>

--- a/pages/about.js
+++ b/pages/about.js
@@ -14,7 +14,12 @@ export default function About(props) {
     <Layout
       locale={props.locale}
       langUrl={asPath}
-      breadcrumbItems={[{ text: "Service Canada Labs", link: "/home" }]}
+      breadcrumbItems={[
+        {
+          text: t("bannerTitle"),
+          link: props.locale === "en" ? "/home" : "/fr/home",
+        },
+      ]}
     >
       <Head>
         {process.env.NEXT_PUBLIC_ADOBE_ANALYTICS_URL ? (

--- a/pages/confirmation.js
+++ b/pages/confirmation.js
@@ -14,7 +14,12 @@ export default function Confirmation(props) {
     <Layout
       locale={props.locale}
       langUrl={asPath}
-      breadcrumbItems={[{ text: "Service Canada Labs", link: "/home" }]}
+      breadcrumbItems={[
+        {
+          text: t("bannerTitle"),
+          link: props.locale === "en" ? "/home" : "/fr/home",
+        },
+      ]}
     >
       <Head>
         <title>

--- a/pages/confirmation.js
+++ b/pages/confirmation.js
@@ -15,10 +15,7 @@ export default function Confirmation(props) {
       locale={props.locale}
       langUrl={asPath}
       breadcrumbItems={[
-        {
-          text: t("bannerTitle"),
-          link: props.locale === "en" ? "/home" : "/fr/home",
-        },
+        { text: t("bannerTitle"), link: t("breadCrumbsHref1") },
       ]}
     >
       <Head>

--- a/pages/privacy.js
+++ b/pages/privacy.js
@@ -14,10 +14,7 @@ export default function Privacy(props) {
       locale={props.locale}
       langUrl={asPath}
       breadcrumbItems={[
-        {
-          text: t("bannerTitle"),
-          link: props.locale === "en" ? "/home" : "/fr/home",
-        },
+        { text: t("bannerTitle"), link: t("breadCrumbsHref1") },
       ]}
     >
       <Head>

--- a/pages/privacy.js
+++ b/pages/privacy.js
@@ -13,7 +13,12 @@ export default function Privacy(props) {
     <Layout
       locale={props.locale}
       langUrl={asPath}
-      breadcrumbItems={[{ text: "Service Canada Labs", link: "/home" }]}
+      breadcrumbItems={[
+        {
+          text: t("bannerTitle"),
+          link: props.locale === "en" ? "/home" : "/fr/home",
+        },
+      ]}
     >
       <Head>
         {process.env.NEXT_PUBLIC_ADOBE_ANALYTICS_URL ? (

--- a/pages/projects.js
+++ b/pages/projects.js
@@ -69,7 +69,12 @@ export default function Projects(props) {
     <Layout
       locale={props.locale}
       langUrl={asPath}
-      breadcrumbItems={[{ text: "Service Canada Labs", link: "/home" }]}
+      breadcrumbItems={[
+        {
+          text: t("bannerTitle"),
+          link: props.locale === "en" ? "/home" : "/fr/home",
+        },
+      ]}
     >
       <Head>
         {process.env.NEXT_PUBLIC_ADOBE_ANALYTICS_URL ? (

--- a/pages/projects.js
+++ b/pages/projects.js
@@ -70,10 +70,7 @@ export default function Projects(props) {
       locale={props.locale}
       langUrl={asPath}
       breadcrumbItems={[
-        {
-          text: t("bannerTitle"),
-          link: props.locale === "en" ? "/home" : "/fr/home",
-        },
+        { text: t("bannerTitle"), link: t("breadCrumbsHref1") },
       ]}
     >
       <Head>

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -383,7 +383,7 @@ export default function Signup(props) {
     <Layout
       locale={props.locale}
       langUrl={asPath}
-      breadcrumbItems={[{ text: "Service Canada Labs", link: "/home" }]}
+      breadcrumbItems={[{ text: t("bannerTitle"), link: props.locale === "en" ? "/home" : "/fr/home"}]}
     >
       <Head>
         {process.env.NEXT_PUBLIC_ADOBE_ANALYTICS_URL ? (

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -384,10 +384,7 @@ export default function Signup(props) {
       locale={props.locale}
       langUrl={asPath}
       breadcrumbItems={[
-        {
-          text: t("bannerTitle"),
-          link: props.locale === "en" ? "/home" : "/fr/home",
-        },
+        { text: t("bannerTitle"), link: t("breadCrumbsHref1") },
       ]}
     >
       <Head>

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -383,7 +383,12 @@ export default function Signup(props) {
     <Layout
       locale={props.locale}
       langUrl={asPath}
-      breadcrumbItems={[{ text: t("bannerTitle"), link: props.locale === "en" ? "/home" : "/fr/home"}]}
+      breadcrumbItems={[
+        {
+          text: t("bannerTitle"),
+          link: props.locale === "en" ? "/home" : "/fr/home",
+        },
+      ]}
     >
       <Head>
         {process.env.NEXT_PUBLIC_ADOBE_ANALYTICS_URL ? (

--- a/pages/thankyou.js
+++ b/pages/thankyou.js
@@ -15,10 +15,7 @@ export default function Confirmation(props) {
       locale={props.locale}
       langUrl={asPath}
       breadcrumbItems={[
-        {
-          text: t("bannerTitle"),
-          link: props.locale === "en" ? "/home" : "/fr/home",
-        },
+        { text: t("bannerTitle"), link: t("breadCrumbsHref1") },
       ]}
     >
       <Head>

--- a/pages/thankyou.js
+++ b/pages/thankyou.js
@@ -14,7 +14,12 @@ export default function Confirmation(props) {
     <Layout
       locale={props.locale}
       langUrl={asPath}
-      breadcrumbItems={[{ text: "Service Canada Labs", link: "/home" }]}
+      breadcrumbItems={[
+        {
+          text: t("bannerTitle"),
+          link: props.locale === "en" ? "/home" : "/fr/home",
+        },
+      ]}
     >
       <Head>
         {process.env.NEXT_PUBLIC_ADOBE_ANALYTICS_URL ? (

--- a/pages/unsubscribe.js
+++ b/pages/unsubscribe.js
@@ -167,7 +167,12 @@ export default function Unsubscribe(props) {
     <Layout
       locale={props.locale}
       langUrl={asPath}
-      breadcrumbItems={[{ text: "Service Canada Labs", link: "/home" }]}
+      breadcrumbItems={[
+        {
+          text: t("bannerTitle"),
+          link: props.locale === "en" ? "/home" : "/fr/home",
+        },
+      ]}
     >
       <Head>
         {process.env.NEXT_PUBLIC_ADOBE_ANALYTICS_URL ? (

--- a/pages/unsubscribe.js
+++ b/pages/unsubscribe.js
@@ -168,10 +168,7 @@ export default function Unsubscribe(props) {
       locale={props.locale}
       langUrl={asPath}
       breadcrumbItems={[
-        {
-          text: t("bannerTitle"),
-          link: props.locale === "en" ? "/home" : "/fr/home",
-        },
+        { text: t("bannerTitle"), link: t("breadCrumbsHref1") },
       ]}
     >
       <Head>

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -271,6 +271,6 @@
   "unsubscribeWord": "vous désinscrire",
   "signupTitleCallToAction": "Inscrivez-vous pour être invité aux séances de recherche",
   "signupBtn": "S’inscrire pour être invité aux séances de recherche",
-  "breadCrumbsHref1": "/home",
-  "breadCrumbsHref2": "/projects"
+  "breadCrumbsHref1": "/fr/home",
+  "breadCrumbsHref2": "/fr/projects"
 }


### PR DESCRIPTION
# Description

[Breadcrumbs should be in French when on French pages](https://trello.com/c/rjrSGclJ/402-breadcrumbs-should-be-in-french-when-on-french-pages)

I updated the breadcrumb to be consistent with what was in the projects folder.

## Acceptance Criteria

Breadcrumb should link to french pages if the locale is french

## Test Instructions

1. Make sure that it links to french pages when the page is in french

## Checklist

- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
