### PR TITLE
Styling fixes

### DIFF
--- a/components/molecules/Experiment.js
+++ b/components/molecules/Experiment.js
@@ -27,7 +27,7 @@ export const Experiment = (props) => {
         {props.title}
       </a>
       <span
-        className={`block w-max py-2 px-2 uppercase font-body text-xxs text-white font-bold rounded ${
+        className={`mt-2 block w-max py-2 px-2 uppercase font-body text-xxs text-white font-bold rounded ${
           "bg-" + (tagColours[props.tag] || "gray-experiment")
         }`}
       >

--- a/pages/home.js
+++ b/pages/home.js
@@ -41,7 +41,7 @@ export default function Home(props) {
             href="/signup"
             id="signup-home-page"
             dataCy="signup-home-page"
-            className="rounded px-6 py-4 font-bold"
+            className="rounded px-6 py-4 font-bold flex text-center max-w-sm"
           >
             {t("signupHomeButton")}
           </ActionButton>


### PR DESCRIPTION
# Description

[Add more spacing between project card titles and tag](https://trello.com/c/WpAaPvVa/400-add-more-spacing-between-project-card-titles-and-tag)
[Fix homepage Signup button on mobile](https://trello.com/c/EwlU1J2F/405-fix-homepage-signup-button-on-mobile)

I added some spacing between the title and the tag in the project card.
![image](https://user-images.githubusercontent.com/72703030/126556823-4eacc8b2-8201-48b2-9352-d3d3c59237d8.png)

I also fixed the signup button bug on small screens
![image](https://user-images.githubusercontent.com/72703030/126556987-cd0c0ebc-6b20-4e57-9cba-1ada4ee3554e.png)

## Acceptance Criteria

The signup button needs to fit correctly on small screens and not split in half.
The projects cards should also have some spacing between the tag and title

## Test Instructions

1. Go on the home page and go on mobile view to test the signup button
2. Go on the project page and look at the experiment card to see if the spacing is okay

## Help Requested

- Things that you (the submitter)...
- want reviewers to pay very close...
- attention to when they review this PR.

## Checklist

- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
