### PR TITLE
Add lang tags to language links, and update splash page lang selector for horizontal screens 

### DIFF
--- a/components/organisms/Layout.js
+++ b/components/organisms/Layout.js
@@ -80,6 +80,7 @@ export const Layout = ({
                 className="lg:visible invisible pb-0 lg:pb-2 self-end underline font-body text-canada-footer-font hover:text-canada-footer-hover-font-blue "
                 data-cy="toggle-language-link"
                 data-testid="languageLink3"
+                lang={language}
                 onClick={() => setLanguage(language)}
               >
                 {language === "en" ? "English" : "Français"}

--- a/pages/index.js
+++ b/pages/index.js
@@ -11,7 +11,7 @@ export default function Index(props) {
 
   return (
     <>
-      <div className="bg-splash-img-mobile xs:bg-splash-img bg-cover bg-center h-screen min-w-300px min-h-screen" />
+      <div className="z-0 fixed inset-0 filter blur-sm bg-splash-img-mobile xs:bg-splash-img bg-cover bg-center h-screen min-w-300px min-h-screen" />
       <Head>
         {process.env.NEXT_PUBLIC_ADOBE_ANALYTICS_URL ? (
           <script src={process.env.NEXT_PUBLIC_ADOBE_ANALYTICS_URL} />
@@ -31,8 +31,8 @@ export default function Index(props) {
         <meta name="dcterms.issued" content="2021-05-06" />
       </Head>
       <main>
-        <div className="absolute inset-0 -mt-12 xl:mb-0 flex flex-col justify-center items-center">
-          <div className="bg-footer-background-color h-auto min-w-300px w-300px xl:w-500px">
+        <div className="flex flex-col justify-center items-center m-auto v-xxs:h-screen">
+          <div className="z-10 bg-white h-auto min-w-300px w-300px xl:w-500px">
             <img
               className="h-auto w-64 container mx-auto pt-6 xl:w-2/3 xl:mx-0 xl:px-6"
               src={"/sig-blk-en.svg"}

--- a/pages/index.js
+++ b/pages/index.js
@@ -36,7 +36,7 @@ export default function Index(props) {
             <img
               className="h-auto w-64 container mx-auto pt-6 xl:w-2/3 xl:mx-0 xl:px-6"
               src={"/sig-blk-en.svg"}
-              alt={"Symbol of the Government of Canada"}
+              alt={"Government of Canada / Gouvernement du Canada"}
             />
             <div className="flex w-max container mx-auto py-6 font-bold font-display">
               <h1 className="text-p text-right xl:text-h4 mr-6 w-32 xl:w-40">
@@ -50,6 +50,7 @@ export default function Index(props) {
               <ActionButton
                 id="english-button"
                 text="English"
+                lang="en"
                 className="text-center text-sm w-7.5rem xl:w-138px py-3.5 mr-6 rounded leading-3"
                 href="/home"
               />
@@ -81,7 +82,7 @@ export default function Index(props) {
             <img
               className="h-auto w-24 xl:w-28"
               src="/wmms-blk.svg"
-              alt="Symbol of the Government of Canada"
+              alt="Symbol of the Government of Canada / Symbole du gouvernement du Canada"
             />
           </div>
         </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -47,6 +47,7 @@ module.exports = {
       lg: "768px",
       xl: "992px",
       xxl: "1200px",
+      "v-xxs": { raw: "(min-height: 300px)" },
     },
     extend: {
       backgroundImage: (theme) => ({


### PR DESCRIPTION
# Description

There's 3 things going on in this PR:

1. Adding lang link to the language link at the top of the page. This is based on feedback we've gotten from the accessibility audit.
2. Update the "alt" text for the wordmarks on the splash page. On the splash page, we don't know if someone is going to select English or French yet, so we use both.
3. Update the splash page language selector so that it is always visible on horizontal screen sizes. Resolves #191 

Here's a little gif of the splash page

![Screen Recording 2021-07-22 at 11 48 19](https://user-images.githubusercontent.com/2454380/126669055-dfed0d13-763a-460f-8909-2b4316a4821c.gif)

## Acceptance Criteria

Run the app, check that the lang tags work and the landscape splash page looks good.
