### PR TITLE
Fip language

### DIFF
--- a/components/atoms/CheckBox.js
+++ b/components/atoms/CheckBox.js
@@ -15,7 +15,7 @@ export function CheckBox(props) {
   return (
     <div
       className={`block leading-tight relative pl-40px h-46px clear-left${
-        props.className ? " " + props.className : " mb-8 lg:mb-10px"
+        props.className ? " " + props.className : " mb-4"
       }`}
     >
       <input

--- a/components/atoms/MultiTextField.js
+++ b/components/atoms/MultiTextField.js
@@ -11,7 +11,7 @@ export function MultiTextField(props) {
   return (
     <div
       className={`block leading-tight${
-        props.className ? " " + props.className : " mb-10px"
+        props.className ? " " + props.className : " mb-12"
       }`}
     >
       <label

--- a/components/molecules/Details.js
+++ b/components/molecules/Details.js
@@ -6,7 +6,7 @@ import PropTypes from "prop-types";
 export function Details(props) {
   return (
     <details data-testid={props.dataTestId} data-cy={props.dataCy}>
-      <summary className="h-auto xl:h-46px max-w-450px w-full bg-details-button-gray focus:ring-inset focus:ring-2 focus:ring-black active:bg-details-button-active-gray hover:bg-details-button-hover-gray rounded py-12px px-5px font-body text-sm text-center text-canada-footer-font cursor-pointer border border-outset border-details-button-gray">
+      <summary className="max-w-450px w-full bg-details-button-gray focus:ring-inset focus:ring-2 focus:ring-black active:bg-details-button-active-gray hover:bg-details-button-hover-gray rounded py-12px px-5px font-body text-sm text-center text-canada-footer-font cursor-pointer border border-outset border-details-button-gray">
         {props.label}
       </summary>
       <div className="max-w-450px w-full min-h-200px bg-gray-light-200 mt-1 p-15px border border-details-border-gray rounded ring-inset ring-1 ring-gray-light-200">

--- a/components/organisms/Layout.js
+++ b/components/organisms/Layout.js
@@ -52,7 +52,7 @@ export const Layout = ({
             <img
               className="h-5 w-auto xs:h-6 sm:h-8 md:h-8 lg:h-7 xl:h-8"
               src={language === "en" ? "/sig-blk-en.svg" : "/sig-blk-fr.svg"}
-              alt="Symbol of the Government of Canada"
+              alt={t("symbol")}
             />
             <Link
               key={language}

--- a/components/organisms/Layout.js
+++ b/components/organisms/Layout.js
@@ -51,7 +51,7 @@ export const Layout = ({
           <div className="flex flex-row justify-between items-center lg:mt-7 mt-1.5">
             <img
               className="h-5 w-auto xs:h-6 sm:h-8 md:h-8 lg:h-7 xl:h-8"
-              src={language === "en" ? "/sig-blk-en.svg" : "/sig-blk-fr.svg"}
+              src={language === "en" ? "/sig-blk-fr.svg" : "/sig-blk-en.svg"}
               alt={t("symbol")}
             />
             <Link
@@ -127,7 +127,7 @@ export const Layout = ({
           <DateModified date={process.env.NEXT_PUBLIC_BUILD_DATE} />
         </div>
         <Footer
-          footerLogoAltText="Symbol of the Government of Canada"
+          footerLogoAltText={t("symbol")}
           footerLogoImage="/wmms-blk.svg"
           links={[
             {

--- a/components/organisms/Layout.js
+++ b/components/organisms/Layout.js
@@ -127,7 +127,7 @@ export const Layout = ({
           <DateModified date={process.env.NEXT_PUBLIC_BUILD_DATE} />
         </div>
         <Footer
-          footerLogoAltText={t("symbol")}
+          footerLogoAltText={t("symbol2")}
           footerLogoImage="/wmms-blk.svg"
           links={[
             {

--- a/components/organisms/ReportAProblem.js
+++ b/components/organisms/ReportAProblem.js
@@ -52,7 +52,7 @@ export function ReportAProblem(props) {
             {t("reportAProblemYouWillNotBeContacted", { lng: props.language })}
           </p>
           <a
-            className="block text-sm font-body hover:text-canada-footer-hover-font-blue text-canada-footer-font"
+            className="underline block text-sm font-body hover:text-canada-footer-hover-font-blue text-canada-footer-font"
             href={`mailto: ${process.env.NEXT_PUBLIC_NOTIFY_REPORT_A_PROBLEM_EMAIL}`}
           >
             experience@servicecanada.gc.ca
@@ -244,7 +244,7 @@ export function ReportAProblem(props) {
               <b>{t("reportAProblemNoReply", { lng: props.language })}</b>
               {t("reportAProblemEnquiries", { lng: props.language })}
               <a
-                className="block text-xxs sm:text-sm font-body hover:text-canada-footer-hover-font-blue text-canada-footer-font"
+                className="underline block text-xxs sm:text-sm font-body hover:text-canada-footer-hover-font-blue text-canada-footer-font"
                 href="mailto:experience@servicecanada.gc.ca"
               >
                 experience@servicecanada.gc.ca
@@ -265,7 +265,7 @@ export function ReportAProblem(props) {
               {t("reportAProblemMoreInfoDetails", { lng: props.language })}
               &nbsp;
               <a
-                className="text-xxs sm:text-sm font-body hover:text-canada-footer-hover-font-blue text-canada-footer-font"
+                className="underline text-xxs sm:text-sm font-body hover:text-canada-footer-hover-font-blue text-canada-footer-font"
                 href={t("reportAProblemMoreInfoLink", { lng: props.language })}
               >
                 {t("reportAProblemMoreInfoLinkText", { lng: props.language })}
@@ -273,7 +273,7 @@ export function ReportAProblem(props) {
             </li>
           </ul>
           <a
-            className="block text-xs sm:text-sm font-body hover:text-canada-footer-hover-font-blue text-canada-footer-font my-4 underline"
+            className="underline block text-xs sm:text-sm font-body hover:text-canada-footer-hover-font-blue text-canada-footer-font my-4 underline"
             href={t("reportAProblemPrivacyStatementLink", {
               lng: props.language,
             })}

--- a/components/organisms/ReportAProblem.js
+++ b/components/organisms/ReportAProblem.js
@@ -137,7 +137,7 @@ export function ReportAProblem(props) {
               textFieldDataCy="incorrectInformation-text"
               describedby="incorrectInformation"
               OptionalTextField
-              checkBoxStyle="mb-8"
+              checkBoxStyle="mb-4"
             />
             <OptionalTextField
               controlId="unclearInformationCheckBox"
@@ -160,7 +160,7 @@ export function ReportAProblem(props) {
               controlDataCy="unclearInformation-checkbox"
               textFieldDataCy="unclearInformation-text"
               describedby="unclearInformation"
-              checkBoxStyle="mb-8"
+              checkBoxStyle="mb-4"
             />
             <OptionalTextField
               controlId="infoNotFoundCheckBox"
@@ -183,7 +183,7 @@ export function ReportAProblem(props) {
               controlDataCy="infoNotFound-checkbox"
               textFieldDataCy="infoNotFound-text"
               describedby="infoNotFound"
-              checkBoxStyle="mb-8"
+              checkBoxStyle="mb-4"
             />
             <OptionalTextField
               controlId="adaptiveTechnologyCheckBox"
@@ -230,7 +230,7 @@ export function ReportAProblem(props) {
               controlDataCy="privacyIssues-checkbox"
               textFieldDataCy="privacyIssues-text"
               describedby="privacyIssues"
-              checkBoxStyle="mb-8"
+              checkBoxStyle="mb-4"
             />
             <OptionalTextField
               controlId="noWhereElseToGoCheckBox"
@@ -253,7 +253,7 @@ export function ReportAProblem(props) {
               controlDataCy="noWhereElseToGo-checkbox"
               textFieldDataCy="noWhereElseToGo-text"
               describedby="noWhereElseToGo"
-              checkBoxStyle="mb-8"
+              checkBoxStyle="mb-4"
             />
             <OptionalTextField
               controlId="otherCheckBox"

--- a/components/organisms/ReportAProblem.js
+++ b/components/organisms/ReportAProblem.js
@@ -45,10 +45,10 @@ export function ReportAProblem(props) {
     >
       {submitted ? (
         <>
-          <h2 role="status" className="text-base font-body mb-4">
+          <h2 className="text-base font-body mb-4">
             {t("reportAProblemThankYouForYourHelp", { lng: props.language })}
           </h2>
-          <p className="text-sm font-body mb-4">
+          <p role="status" className="text-sm font-body mb-4">
             {t("reportAProblemYouWillNotBeContacted", { lng: props.language })}
           </p>
           <a

--- a/components/organisms/ReportAProblem.js
+++ b/components/organisms/ReportAProblem.js
@@ -45,7 +45,7 @@ export function ReportAProblem(props) {
     >
       {submitted ? (
         <>
-          <h2 className="text-base font-body mb-4">
+          <h2 role="status" className="text-base font-body mb-4">
             {t("reportAProblemThankYouForYourHelp", { lng: props.language })}
           </h2>
           <p className="text-sm font-body mb-4">
@@ -73,9 +73,44 @@ export function ReportAProblem(props) {
             value={i18n.language}
           />
           <fieldset>
-            <legend className="text-base sm:text-p font-body font-normal mb-6">
+            <legend className="text-base sm:text-p font-body font-normal">
               {t("reportAProblemCheckAllThatApply", { lng: props.language })}
             </legend>
+            <ul className="list-outside list-disc px-6 py-2">
+              <li className="text-xxs sm:text-sm font-body my-4 leading-tight sm:leading-6">
+                <b>{t("reportAProblemNoReply", { lng: props.language })}</b>
+                {t("reportAProblemEnquiries", { lng: props.language })}
+                <a
+                  className="underline block text-xxs sm:text-sm font-body hover:text-canada-footer-hover-font-blue text-canada-footer-font"
+                  href="mailto:experience@servicecanada.gc.ca"
+                >
+                  experience@servicecanada.gc.ca
+                </a>
+              </li>
+              <li className="text-xxs sm:text-sm font-body my-4 leading-tight sm:leading-6">
+                <b>
+                  {t("reportAProblemNoPersonalInfo", { lng: props.language })}
+                </b>
+                ,&nbsp;
+                {t("reportAProblemNoPersonalInfoDetails", {
+                  lng: props.language,
+                })}
+              </li>
+              <li className="text-xxs sm:text-sm font-body my-4 leading-tight sm:leading-6">
+                <b>{t("reportAProblemMoreInfo", { lng: props.language })}</b>
+                ,&nbsp;
+                {t("reportAProblemMoreInfoDetails", { lng: props.language })}
+                &nbsp;
+                <a
+                  className="underline text-xxs sm:text-sm font-body hover:text-canada-footer-hover-font-blue text-canada-footer-font"
+                  href={t("reportAProblemMoreInfoLink", {
+                    lng: props.language,
+                  })}
+                >
+                  {t("reportAProblemMoreInfoLinkText", { lng: props.language })}
+                </a>
+              </li>
+            </ul>
             <OptionalTextField
               controlId="incorrectInformationCheckBox"
               textFieldId="incorrectInformationTextField"
@@ -235,43 +270,10 @@ export function ReportAProblem(props) {
               controlDataCy="other-checkbox"
               textFieldDataCy="other-text"
               describedby="other"
-              checkBoxStyle="mb-8"
+              checkBoxStyle="mb-4"
             />
           </fieldset>
 
-          <ul className="list-outside list-disc px-6 py-2">
-            <li className="text-xxs sm:text-sm font-body my-4 leading-tight sm:leading-6">
-              <b>{t("reportAProblemNoReply", { lng: props.language })}</b>
-              {t("reportAProblemEnquiries", { lng: props.language })}
-              <a
-                className="underline block text-xxs sm:text-sm font-body hover:text-canada-footer-hover-font-blue text-canada-footer-font"
-                href="mailto:experience@servicecanada.gc.ca"
-              >
-                experience@servicecanada.gc.ca
-              </a>
-            </li>
-            <li className="text-xxs sm:text-sm font-body my-4 leading-tight sm:leading-6">
-              <b>
-                {t("reportAProblemNoPersonalInfo", { lng: props.language })}
-              </b>
-              ,&nbsp;
-              {t("reportAProblemNoPersonalInfoDetails", {
-                lng: props.language,
-              })}
-            </li>
-            <li className="text-xxs sm:text-sm font-body my-4 leading-tight sm:leading-6">
-              <b>{t("reportAProblemMoreInfo", { lng: props.language })}</b>
-              ,&nbsp;
-              {t("reportAProblemMoreInfoDetails", { lng: props.language })}
-              &nbsp;
-              <a
-                className="underline text-xxs sm:text-sm font-body hover:text-canada-footer-hover-font-blue text-canada-footer-font"
-                href={t("reportAProblemMoreInfoLink", { lng: props.language })}
-              >
-                {t("reportAProblemMoreInfoLinkText", { lng: props.language })}
-              </a>
-            </li>
-          </ul>
           <a
             className="underline block text-xs sm:text-sm font-body hover:text-canada-footer-hover-font-blue text-canada-footer-font my-4 underline"
             href={t("reportAProblemPrivacyStatementLink", {

--- a/components/organisms/ReportAProblem.js
+++ b/components/organisms/ReportAProblem.js
@@ -83,7 +83,7 @@ export function ReportAProblem(props) {
             <ul className="list-outside list-disc px-6 py-2">
               <li className="text-xxs sm:text-sm font-body my-4 leading-tight sm:leading-6">
                 <b>{t("reportAProblemNoReply", { lng: props.language })}</b>{" "}
-                {t("reportAProblemEnquiries", { lng: props.language })}
+                {t("reportAProblemEnquiries", { lng: props.language })}{" "}
                 <a
                   className="underline text-xxs sm:text-sm font-body hover:text-canada-footer-hover-font-blue text-canada-footer-font"
                   href="mailto:experience@servicecanada.gc.ca"

--- a/components/organisms/ReportAProblem.js
+++ b/components/organisms/ReportAProblem.js
@@ -45,14 +45,18 @@ export function ReportAProblem(props) {
     >
       {submitted ? (
         <>
-          <h2 className="text-base font-body mb-4">
-            {t("reportAProblemThankYouForYourHelp", { lng: props.language })}
-          </h2>
-          <p role="status" className="text-sm font-body mb-4">
-            {t("reportAProblemYouWillNotBeContacted", { lng: props.language })}
-          </p>
+          <div role="status">
+            <h2 className="text-base font-body mb-4">
+              {t("reportAProblemThankYouForYourHelp", { lng: props.language })}
+            </h2>
+            <p className="text-sm font-body mb-4">
+              {t("reportAProblemYouWillNotBeContacted", {
+                lng: props.language,
+              })}
+            </p>
+          </div>
           <a
-            className="underline block text-sm font-body hover:text-canada-footer-hover-font-blue text-canada-footer-font"
+            className="underline text-sm font-body hover:text-canada-footer-hover-font-blue text-canada-footer-font"
             href={`mailto: ${process.env.NEXT_PUBLIC_NOTIFY_REPORT_A_PROBLEM_EMAIL}`}
           >
             experience@servicecanada.gc.ca

--- a/components/organisms/ReportAProblem.js
+++ b/components/organisms/ReportAProblem.js
@@ -82,10 +82,10 @@ export function ReportAProblem(props) {
             </legend>
             <ul className="list-outside list-disc px-6 py-2">
               <li className="text-xxs sm:text-sm font-body my-4 leading-tight sm:leading-6">
-                <b>{t("reportAProblemNoReply", { lng: props.language })}</b>
+                <b>{t("reportAProblemNoReply", { lng: props.language })}</b>{" "}
                 {t("reportAProblemEnquiries", { lng: props.language })}
                 <a
-                  className="underline block text-xxs sm:text-sm font-body hover:text-canada-footer-hover-font-blue text-canada-footer-font"
+                  className="underline text-xxs sm:text-sm font-body hover:text-canada-footer-hover-font-blue text-canada-footer-font"
                   href="mailto:experience@servicecanada.gc.ca"
                 >
                   experience@servicecanada.gc.ca
@@ -279,7 +279,7 @@ export function ReportAProblem(props) {
           </fieldset>
 
           <a
-            className="underline block text-xs sm:text-sm font-body hover:text-canada-footer-hover-font-blue text-canada-footer-font my-4 underline"
+            className="underline text-xs sm:text-sm font-body hover:text-canada-footer-hover-font-blue text-canada-footer-font my-4 underline"
             href={t("reportAProblemPrivacyStatementLink", {
               lng: props.language,
             })}

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -272,5 +272,6 @@
   "signupBtn": "Sign up to get invited to research sessions",
   "breadCrumbsHref1": "/home",
   "breadCrumbsHref2": "/projects",
-  "symbol": "Symbol of the Government of Canada"
+  "symbol": "Government of Canada",
+  "symbol2": "Symbol of the Government of Canada"
 }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -271,5 +271,6 @@
   "signupTitleCallToAction": "Sign up to get invited to research sessions",
   "signupBtn": "Sign up to get invited to research sessions",
   "breadCrumbsHref1": "/home",
-  "breadCrumbsHref2": "/projects"
+  "breadCrumbsHref2": "/projects",
+  "symbol": "Symbol of the Government of Canada"
 }

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -273,5 +273,6 @@
   "signupBtn": "S’inscrire pour être invité aux séances de recherche",
   "breadCrumbsHref1": "/fr/home",
   "breadCrumbsHref2": "/fr/projects",
-  "symbol": "Symbole du gouvernement du Canada"
+  "symbol": "Gouvernement du Canada",
+  "symbol2": "Symbole du gouvernement du Canada"
 }

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -272,5 +272,6 @@
   "signupTitleCallToAction": "Inscrivez-vous pour être invité aux séances de recherche",
   "signupBtn": "S’inscrire pour être invité aux séances de recherche",
   "breadCrumbsHref1": "/fr/home",
-  "breadCrumbsHref2": "/fr/projects"
+  "breadCrumbsHref2": "/fr/projects",
+  "symbol": "Symbole du gouvernement du Canada"
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -179,6 +179,7 @@ module.exports = {
     extend: {
       backgroundColor: ["active"],
       textColor: ["visited"],
+      margin: ["checked"],
     },
   },
   plugins: [


### PR DESCRIPTION
# Description

[Fix a11y issues in "Report a problem" component](https://trello.com/c/9uQ6MbDx/406-fix-a11y-issues-in-report-a-problem-component)
[First language in the FIP should reflect the currently selected locale](https://trello.com/c/5SE8f61x/403-first-language-in-the-fip-should-reflect-the-currently-selected-locale)

I fixed some a11y issues related to the report a problem button. I also made the FIP images show the correct language first based on the locale. (If the locale is french, the government image should have french first).

## Acceptance Criteria

First language in the FIP should reflect the currently selected locale
Underline links in body text in the report a problem dropdown
Alert "thank you" message to users who submit  (The thank-you message should have a role="status" attribute)
Ensure alt text changes on GoC wordmark when we move between english and french 
Remove fixed button height on "report a problem" button
Move the bullet points above the list items in Report a problem.

## Test Instructions

1. Change language and see if the government of Canada pictures show in the correct order (french first if locale is in french or opposite for english)
2. Change language and see if the government of Canada alt text also changes
3. The links in the report a problem dropdown should be underlined
4. The thank-you message should have a role="status" attribute
5. The report a problem button shouldn't have a fixed height
6. The bullet list should be above the checkboxes

## Checklist

- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
