### PR TITLE
Scenario tag changed to comply with accessibility

### DIFF
--- a/pages/projects/virtual-assistant/index.js
+++ b/pages/projects/virtual-assistant/index.js
@@ -57,13 +57,13 @@ export default function Home(props) {
         </div>
         {/* the scenario section */}
         <div>
-          <h2
-            className="mb-6 mt-8 text-h1"
+          <p
+            className="mb-6 mt-8 text-h1 font-display font-bold"
             tabIndex="-1"
             id="virtualAssistantTitle"
           >
             {t("vc:sectionTitle")}
-          </h2>
+          </p>
           <VirtualConcierge
             dataTestId="scenario1"
             dataCy="scenario1"


### PR DESCRIPTION
# Description

h2 tag for Scenario changed to a p tag as it is more suited as content than a heading. This was done to comply with accessibility requirements.

## Test Instructions

1. Navigate to virtual-assistant page
2. "Scenario" should now be in a p tag with same styling
