### PR TITLE
Add aside to call to action markup

### DIFF
--- a/components/molecules/CallToAction.js
+++ b/components/molecules/CallToAction.js
@@ -9,37 +9,39 @@ import { useTranslation } from "next-i18next";
 export function CallToAction(props) {
   const { t } = useTranslation("common");
   return (
-    <div className="bg-circle-color text-white">
-      <div className="layout-container pb-10 pt-10 text-xs md:text-base">
-        <h2>{props.title}</h2>
-        <div className="flex flex-col lg:grid lg:grid-cols-2 lg:gap-24 gap-5">
-          {props.description ? (
-            <p className="whitespace-pre-line">{props.description}</p>
-          ) : (
-            <div
-              className="whitespace-pre-line"
-              dangerouslySetInnerHTML={{ __html: props.html }}
-            />
-          )}
-          <div>
-            <p className="flex mb-4 text-center">
-              <ActionButton
-                id="become-a-participant-btn"
-                href={props.href}
-                text={props.hrefText}
+    <aside>
+      <div className="bg-circle-color text-white">
+        <div className="layout-container pb-10 pt-10 text-xs md:text-base">
+          <h2>{props.title}</h2>
+          <div className="flex flex-col lg:grid lg:grid-cols-2 lg:gap-24 gap-5">
+            {props.description ? (
+              <p className="whitespace-pre-line">{props.description}</p>
+            ) : (
+              <div
+                className="whitespace-pre-line"
+                dangerouslySetInnerHTML={{ __html: props.html }}
               />
-            </p>
-            <p>
-              <Link href="/privacy">
-                <a className="text-sm underline flex xl:inline lg:mr-10">
-                  {t("privacyLinkText")}
-                </a>
-              </Link>
-            </p>
+            )}
+            <div>
+              <p className="flex mb-4 text-center">
+                <ActionButton
+                  id="become-a-participant-btn"
+                  href={props.href}
+                  text={props.hrefText}
+                />
+              </p>
+              <p>
+                <Link href="/privacy">
+                  <a className="text-sm underline flex xl:inline lg:mr-10">
+                    {t("privacyLinkText")}
+                  </a>
+                </Link>
+              </p>
+            </div>
           </div>
         </div>
       </div>
-    </div>
+    </aside>
   );
 }
 


### PR DESCRIPTION
# Description

This pull request will add an `<aside>` wrapper element to the call to action component. 

The purpose of this is to address the `1.3.1` WCAG fail from conveying information through presentation without conveying the same information through markup. 

## Acceptance Criteria

- Check if there is an `<aside>` wrapper element around call to action markup. 

## Test Instructions

1. Run `npm run dev`
2. Visit any page that uses the call to action component 
3. Inspect the call to action
4. Check that the call to action is wrapped in an `<aside>`

## Help Requested

- In the future the markup could benefit from an aria-labelledby doing something like
- We would need a unique ID that is generated when the component is setup to cover the case of a user adding two or more CallToActions components on one page

```
<aside role="complimentary" aria-labelledby="[uniqueID]">
   <h2 id="[uniqueID]">{props.title}</h2>
   Strong winds expand fires ignited by high temperatures ...
</aside>
```

## Checklist

- [-] Strings use placeholders for translation (No hard coded strings)
- [-] Unit tests have been added/updated

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
