### PR TITLE
Scenario tag changed to h2 to comply with accessibility

### DIFF
--- a/pages/projects/virtual-assistant/index.js
+++ b/pages/projects/virtual-assistant/index.js
@@ -57,13 +57,9 @@ export default function Home(props) {
         </div>
         {/* the scenario section */}
         <div>
-          <p
-            className="mb-6 mt-8 text-h1 font-display font-bold"
-            tabIndex="-1"
-            id="virtualAssistantTitle"
-          >
+          <h2 className="mb-6 mt-8 text-h1" id="virtualAssistantTitle">
             {t("vc:sectionTitle")}
-          </p>
+          </h2>
           <VirtualConcierge
             dataTestId="scenario1"
             dataCy="scenario1"


### PR DESCRIPTION
# Description

p tag for Scenario changed back to h2 tag as accessibility information was outdated and misinterpreted 

## Test Instructions

1. Navigate to virtual-assistant page
2. "Scenario" should now be in a h2 tag with same styling

