### PR TITLE
Move "Report a Problem" bullets

### DIFF
--- a/components/organisms/Layout.js
+++ b/components/organisms/Layout.js
@@ -1,5 +1,4 @@
 import PropTypes from "prop-types";
-// import Head from "next/head";
 import { Banner } from "../atoms/Banner";
 import { Menu } from "../molecules/Menu";
 import { Footer } from "./Footer";
@@ -121,10 +120,10 @@ export const Layout = ({
       </main>
 
       <footer>
-        <div className="layout-container my-3">
+        <div className="layout-container mt-5">
           <ReportAProblem />
         </div>
-        <div className="layout-container">
+        <div className="layout-container mb-2">
           <DateModified date={process.env.NEXT_PUBLIC_BUILD_DATE} />
         </div>
         <Footer

--- a/components/organisms/ReportAProblem.js
+++ b/components/organisms/ReportAProblem.js
@@ -185,7 +185,7 @@ export function ReportAProblem(props) {
               controlDataCy="infoNotFound-checkbox"
               textFieldDataCy="infoNotFound-text"
               describedby="infoNotFound"
-              checkBoxStyle="mb-4"
+              checkBoxStyle="lg:mb-8 mb-4"
               controlValue="You didn't find what you were looking for"
             />
             <OptionalTextField
@@ -210,7 +210,7 @@ export function ReportAProblem(props) {
               controlDataCy="adaptiveTechnology-checkbox"
               textFieldDataCy="adaptiveTechnology-text"
               describedby="adaptiveTechnology"
-              checkBoxStyle="mb-10"
+              checkBoxStyle="mb-8"
               controlValue="Page does not work with your adaptive technologies"
             />
             <OptionalTextField
@@ -258,7 +258,7 @@ export function ReportAProblem(props) {
               controlDataCy="noWhereElseToGo-checkbox"
               textFieldDataCy="noWhereElseToGo-text"
               describedby="noWhereElseToGo"
-              checkBoxStyle="mb-4"
+              checkBoxStyle="lg:mb-8 mb-4"
               controlValue="You don't know where else to go for help"
             />
             <OptionalTextField

--- a/components/organisms/ReportAProblem.js
+++ b/components/organisms/ReportAProblem.js
@@ -77,44 +77,9 @@ export function ReportAProblem(props) {
             value={i18n.language}
           />
           <fieldset>
-            <legend className="text-base sm:text-p font-body font-normal">
+            <legend className="text-base sm:text-p font-body font-normal mb-6">
               {t("reportAProblemCheckAllThatApply", { lng: props.language })}
             </legend>
-            <ul className="list-outside list-disc px-6 py-2">
-              <li className="text-xxs sm:text-sm font-body my-4 leading-tight sm:leading-6">
-                <b>{t("reportAProblemNoReply", { lng: props.language })}</b>{" "}
-                {t("reportAProblemEnquiries", { lng: props.language })}{" "}
-                <a
-                  className="underline text-xxs sm:text-sm font-body hover:text-canada-footer-hover-font-blue text-canada-footer-font"
-                  href="mailto:experience@servicecanada.gc.ca"
-                >
-                  experience@servicecanada.gc.ca
-                </a>
-              </li>
-              <li className="text-xxs sm:text-sm font-body my-4 leading-tight sm:leading-6">
-                <b>
-                  {t("reportAProblemNoPersonalInfo", { lng: props.language })}
-                </b>
-                ,&nbsp;
-                {t("reportAProblemNoPersonalInfoDetails", {
-                  lng: props.language,
-                })}
-              </li>
-              <li className="text-xxs sm:text-sm font-body my-4 leading-tight sm:leading-6">
-                <b>{t("reportAProblemMoreInfo", { lng: props.language })}</b>
-                ,&nbsp;
-                {t("reportAProblemMoreInfoDetails", { lng: props.language })}
-                &nbsp;
-                <a
-                  className="underline text-xxs sm:text-sm font-body hover:text-canada-footer-hover-font-blue text-canada-footer-font"
-                  href={t("reportAProblemMoreInfoLink", {
-                    lng: props.language,
-                  })}
-                >
-                  {t("reportAProblemMoreInfoLinkText", { lng: props.language })}
-                </a>
-              </li>
-            </ul>
             <OptionalTextField
               controlId="incorrectInformationCheckBox"
               textFieldId="incorrectInformationTextField"
@@ -284,6 +249,42 @@ export function ReportAProblem(props) {
               controlValue="Other"
             />
           </fieldset>
+
+          <ul className="list-outside list-disc px-6 py-2">
+            <li className="text-xxs sm:text-sm font-body my-4 leading-tight sm:leading-6">
+              <b>{t("reportAProblemNoReply", { lng: props.language })}</b>{" "}
+              {t("reportAProblemEnquiries", { lng: props.language })}{" "}
+              <a
+                className="underline text-xxs sm:text-sm font-body hover:text-canada-footer-hover-font-blue text-canada-footer-font"
+                href="mailto:experience@servicecanada.gc.ca"
+              >
+                experience@servicecanada.gc.ca
+              </a>
+            </li>
+            <li className="text-xxs sm:text-sm font-body my-4 leading-tight sm:leading-6">
+              <b>
+                {t("reportAProblemNoPersonalInfo", { lng: props.language })}
+              </b>
+              ,&nbsp;
+              {t("reportAProblemNoPersonalInfoDetails", {
+                lng: props.language,
+              })}
+            </li>
+            <li className="text-xxs sm:text-sm font-body my-4 leading-tight sm:leading-6">
+              <b>{t("reportAProblemMoreInfo", { lng: props.language })}</b>
+              ,&nbsp;
+              {t("reportAProblemMoreInfoDetails", { lng: props.language })}
+              &nbsp;
+              <a
+                className="underline text-xxs sm:text-sm font-body hover:text-canada-footer-hover-font-blue text-canada-footer-font"
+                href={t("reportAProblemMoreInfoLink", {
+                  lng: props.language,
+                })}
+              >
+                {t("reportAProblemMoreInfoLinkText", { lng: props.language })}
+              </a>
+            </li>
+          </ul>
 
           <a
             className="underline text-xs sm:text-sm font-body hover:text-canada-footer-hover-font-blue text-canada-footer-font my-4 underline"


### PR DESCRIPTION
## Description

On our first go-around with the a11y group, they recommended we move the bullets in the Report a Problem widget _above_ the checkboxes, so that users could see what they were agreeing to before submitting. That was a "suggestion", not a "fail".

Then we moved them above the checkboxes, and they raised **2 issues** about them, and both are "fails".

1. the list items are not part of the form, so they should be outside the form.
2. a screen reader in “form” mode, would miss them

“Don’t have them in the form at all”, seems pretty illogical to me. It doesn't make sense to put them after the submit button or before the legend. So I'm moving them back to where they were before, when they weren't failing.

### Screenshots

| before | after |
|--------|-------|
| The bullets are above the checkboxes       |  The bullets are below the checkboxes     |
|   <img width="315" alt="Screen Shot 2021-07-26 at 13 19 17" src="https://user-images.githubusercontent.com/2454380/127031613-378afa4a-e34f-4edf-a6ce-8fdc655a0692.png"  >   |    <img width="315" alt="Screen Shot 2021-07-26 at 13 18 42" src="https://user-images.githubusercontent.com/2454380/127031609-91f6ead1-ceb9-4b2c-b99c-c22398077f90.png">   |

