### PR TITLE
Page load event

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -5,12 +5,28 @@ import "../styles/forms.css";
 import "../styles/fonts.css";
 import "../styles/menu.css";
 import Head from "next/head";
+import { useEffect } from "react";
+import { useRouter } from "next/router";
 
 if (process.env.NEXT_PUBLIC_API_MOCKING === "enabled") {
   require("../mocks");
 }
 
 function MyApp({ Component, pageProps }) {
+  const router = useRouter();
+
+  process.env.NEXT_PUBLIC_ADOBE_ANALYTICS_URL
+    ? useEffect(() => {
+        window.adobeDataLayer = window.adobeDataLayer || [];
+
+        const handleRouteChange = () => {
+          window.adobeDataLayer.push({ event: "pageLoad" });
+        };
+
+        router.events.on("routeChangeStart", handleRouteChange);
+      }, [])
+    : "";
+
   return (
     <>
       <Head>


### PR DESCRIPTION
# Description

[#380 Make sure page loads are being tracked after the first page load for analytics](https://trello.com/c/Z8tmWpF0/380-380-make-sure-page-loads-are-being-tracked-after-the-first-page-load-for-analytics)

I manually added a page load event to activate analytics when we switch pages, we can't really test until it's merged in.

## Acceptance Criteria

On each new page load, adobeDataLayer should push "event: pageLoad" in a array.

## Test Instructions

1. Add adobe analytics to env file
2. Run the code and open up the console (some errors will show up because of the analytics running locally) 
3. Check if each new page load pushes a page load (just write adobeDataLayer in the console)

## Checklist

- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
