### PR TITLE
Remove bg blur on splash page

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -11,7 +11,7 @@ export default function Index(props) {
 
   return (
     <>
-      <div className="z-0 fixed inset-0 filter blur-sm bg-splash-img-mobile xs:bg-splash-img bg-cover bg-center h-screen min-w-300px min-h-screen" />
+      <div className="z-0 fixed inset-0 bg-splash-img-mobile xs:bg-splash-img bg-cover bg-center h-screen min-w-300px min-h-screen" />
       <Head>
         {process.env.NEXT_PUBLIC_ADOBE_ANALYTICS_URL ? (
           <script src={process.env.NEXT_PUBLIC_ADOBE_ANALYTICS_URL} />


### PR DESCRIPTION
# Description

My bad, I copied some CSS for #239 and it included blurring the background image. Removing the background blur on the splash page.

### Screenshot

| before | after |
|--------|-------|
|    <img width="1396" alt="Screen Shot 2021-07-27 at 11 21 22" src="https://user-images.githubusercontent.com/2454380/127181328-a3b1e09b-7f63-46be-ab5b-8cb4eb28496b.png">    |  <img width="1396" alt="Screen Shot 2021-07-27 at 11 21 02" src="https://user-images.githubusercontent.com/2454380/127181319-59229498-0a77-4cb5-9780-97ea3855059f.png">  |

