### PR TITLE
Fix links in unsubscribe email

### DIFF
--- a/__tests__/api/unsubscribe.test.js
+++ b/__tests__/api/unsubscribe.test.js
@@ -60,11 +60,13 @@ describe("unsubscribe api", () => {
     });
 
     await unsubscribeHandler(req, res);
+    console.log(submitEmail.mock.calls);
     expect(res._getStatusCode()).toBe(201);
     expect(res._getData()).toBe("USER UNSUBSCRIBE EMAIL SENT");
     expect(submitEmail.mock.calls[0]).toContainEqual({
       unsubscribe_url:
         "http://localhost:3000/api/unsubscribe?id=somecuid1&lang=en",
+      unsubscribe_page_url: "http://localhost:3000/unsubscribe",
     });
   });
 

--- a/pages/api/unsubscribe.js
+++ b/pages/api/unsubscribe.js
@@ -26,9 +26,12 @@ export default async function handler(req, res) {
           const unsubscribeUrl =
             origin +
             `/api/unsubscribe?id=${userObj.cuid}&lang=${userObj.language}`;
+          const unsubPageUrl =
+            origin + (userObj.language === "fr" ? "/fr" : "") + "/unsubscribe";
           const [status, json] = await submitEmail(
             {
               unsubscribe_url: unsubscribeUrl,
+              unsubscribe_page_url: unsubPageUrl,
             },
             {},
             userObj.language === "fr"


### PR DESCRIPTION
# Description

There are 2 links in the unsubscribe email, one that's personalized and will perform the unsubscribe action, and the other that is a generic link to the unsubscribe page in case you need to restart the unsubscribe flow. The second link was missing in the french email, and it was wrong in the english email, so this PR aims to fix that.

## Acceptance Criteria

Both the english and french unsubscribe emails contain 2 different links, one that's personlized and the other a generic one.

## Test Instructions

1. Sign up
2. Go to /unsubscribe and enter your email
3. Notice in the unsubscribe email that the 2 links are different

## Checklist

- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
