### PR TITLE
bg-cover on banner for all screen sizes

### DIFF
--- a/components/atoms/Banner.js
+++ b/components/atoms/Banner.js
@@ -9,7 +9,7 @@ export const Banner = ({ siteTitle, headline }) => {
   return (
     <div
       title="Home banner"
-      className="bg-banner-img-mobile bg-center py-8 sm:bg-banner-img sm:bg-right sm:bg-cover"
+      className="bg-banner-img-mobile bg-center bg-cover py-8 sm:bg-banner-img sm:bg-right"
     >
       <div className="lg:container xxs:mx-0 xxs:px-0 lg:mx-auto lg:px-6 xxl:mx-auto">
         <div className=" bg-black bg-opacity-90 text-white p-4 xxs:w-screen sm:bg-opacity-30 lg:w-2/3 xl:w-1/2">


### PR DESCRIPTION
# Description

Request from design to use background-cover on screen sizes smaller than 450px. Previously, background-cover was only applied after the 450px breakpoint.

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
