### PR TITLE
Menu links are underlined for child pages

### DIFF
--- a/components/molecules/Menu.js
+++ b/components/molecules/Menu.js
@@ -43,16 +43,18 @@ export function Menu(props) {
 
       <ul id="menuDropdown" className="menuDropdown" role="menu">
         {props.items.map((item, key) => {
-          var itemClass = "py-3 lg:py-0 cursor-pointer menuLink";
-
-          {
-            asPath === item.link
-              ? (itemClass = "py-3 lg:py-0 cursor-pointer activePage")
-              : null;
-          }
+          const exactURL = asPath === item.link; // it's exactly this url
+          const includesURL = asPath.includes(item.link); // it's a child of this url (eg, "/projects/app" includes "/projects")
 
           return (
-            <li key={key} className={itemClass} role="menuitem">
+            <li
+              key={key}
+              className={`py-3 lg:py-0 cursor-pointer ${
+                includesURL ? "activePage" : "menuLink"
+              }`}
+              role="menuitem"
+              aria-current={exactURL ? "page" : null}
+            >
               <Link href={item.link}>
                 <a className="font-body text-base">{item.text}</a>
               </Link>


### PR DESCRIPTION
We still want the "Explore our projects" link underlined when someone is looking at a project.

From Xiaopu:
> Could you make sure that in the top menu, “Explore our projects” is underlined to indicate to user that they are in the projects section of the site?

Also, added an `aria-current="page"` attribute based on what Bootstrap does for its active nav items. Because it only seems to indicate the current page, not the current section, I am only including it if the URL is an exact match. It seems like it would be better to provide screen reader descriptions ("Current page: ", "Current section: "), but we can do this at a later time.
