### PR TITLE
remove top margin from second privacy link on signup page

### DIFF
--- a/pages/signup.js
+++ b/pages/signup.js
@@ -1027,7 +1027,7 @@ export default function Signup(props) {
               />
             </div>
             <a
-              className="block font-body hover:text-canada-footer-hover-font-blue text-canada-footer-font underline my-10 text-sm lg:text-p"
+              className="block font-body hover:text-canada-footer-hover-font-blue text-canada-footer-font underline mb-10 text-sm lg:text-p"
               href={t("privacyLink")}
             >
               {t("privacy")}


### PR DESCRIPTION
# Description

[Reduce margin on second privacy policy link on signup page](https://trello.com/c/jql5yvCs/425-sign-up-page-on-the-2nd-view-privacy-policy-link-above-the-submit-button-change-class-my-10-to-mb-10-too-much-vertical-space)

## Acceptance Criteria

Top margin on the link should be removed.

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
