### PR TITLE
increase font size of call to action description to 16px on mobile

### DIFF
--- a/components/molecules/CallToAction.js
+++ b/components/molecules/CallToAction.js
@@ -11,7 +11,7 @@ export function CallToAction(props) {
   return (
     <aside>
       <div className="bg-circle-color text-white">
-        <div className="layout-container pb-10 pt-10 text-xs md:text-base">
+        <div className="layout-container pb-10 pt-10 text-sm md:text-base">
           <h2>{props.title}</h2>
           <div className="flex flex-col lg:grid lg:grid-cols-2 lg:gap-24 gap-5">
             {props.description ? (


### PR DESCRIPTION
# Description

[Inrease call to action font size on mobile for legibility and consistency](https://trello.com/c/0nHykrpP/404-increase-font-size-of-calltoaction-description-on-mobile-to-be-consistent-with-font-size-of-other-text-content-elements-on-the-p)

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
