### PR TITLE
Blue menu links, dynamic signup button width, underline "signup" on privacy page

### DIFF
--- a/__tests__/pages/privacy.test.js
+++ b/__tests__/pages/privacy.test.js
@@ -1,15 +1,12 @@
 /**
  * @jest-environment jsdom
  */
- import { render, screen } from "@testing-library/react";
- import Privacy from "../../pages/privacy";
- 
- describe("Privacy Policy", () => {
-   it("renders without crashing", () => {
-     render(<Privacy />);
-     expect(
-       screen.getByText("privacyTitle")
-     ).toBeInTheDocument();
-   });
- });
- 
+import { render, screen } from "@testing-library/react";
+import Privacy from "../../pages/signup/privacy";
+
+describe("Privacy Policy", () => {
+  it("renders without crashing", () => {
+    render(<Privacy />);
+    expect(screen.getByText("privacyTitle")).toBeInTheDocument();
+  });
+});

--- a/components/molecules/CallToAction.js
+++ b/components/molecules/CallToAction.js
@@ -31,7 +31,7 @@ export function CallToAction(props) {
                 />
               </p>
               <p>
-                <Link href="/privacy">
+                <Link href="/signup/privacy">
                   <a className="text-sm underline flex xl:inline lg:mr-10">
                     {t("privacyLinkText")}
                   </a>

--- a/components/molecules/Menu.js
+++ b/components/molecules/Menu.js
@@ -49,7 +49,7 @@ export function Menu(props) {
           return (
             <li
               key={key}
-              className={`py-3 lg:py-0 cursor-pointer ${
+              className={`py-3 lg:py-0 cursor-pointer lg:text-black text-custom-blue-projects-link ${
                 includesURL ? "activePage" : "menuLink"
               }`}
               role="menuitem"

--- a/pages/home.js
+++ b/pages/home.js
@@ -56,7 +56,7 @@ export default function Home(props) {
               href="/signup"
               id="signup-home-page"
               dataCy="signup-home-page"
-              className="rounded px-6 py-4 font-bold flex text-center max-w-sm"
+              className="rounded px-6 py-4 font-bold text-center inline-block"
             >
               {t("signupHomeButton")}
             </ActionButton>

--- a/pages/signup/privacy.js
+++ b/pages/signup/privacy.js
@@ -1,9 +1,9 @@
-import { Layout } from "../components/organisms/Layout";
+import { Layout } from "../../components/organisms/Layout";
 import Head from "next/head";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { useTranslation } from "next-i18next";
 import { useRouter } from "next/router";
-import { CallToAction } from "../components/molecules/CallToAction";
+import { CallToAction } from "../../components/molecules/CallToAction";
 import { useEffect } from "react";
 
 export default function Privacy(props) {

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -118,7 +118,7 @@
   "privacyPolicyPrivacyCommissioner": "Privacy Commissioner of Canada ",
   "privacyPolicyPrivacyCommissionerURL": "https://www.priv.gc.ca/en/about-the-opc/who-we-are/the-privacy-commissioner-of-canada/",
   "privacyPolicyContent17": "regarding Employment and Social Development Canada’s handling of your personal information.",
-  "privacyLink": "/privacy",
+  "privacyLink": "/signup/privacy",
   "upcoming_projects": "Upcoming projects",
   "current_projects": "Current projects",
   "past_projects": "Past projects",

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -118,7 +118,7 @@
   "privacyPolicyPrivacyCommissioner": "Commissaire à la protection de la vie privée du Canada ",
   "privacyPolicyPrivacyCommissionerURL": "https://www.priv.gc.ca/fr/a-propos-du-commissariat/qui-nous-sommes/commissaire-a-la-protection-de-la-vie-privee-du-canada/",
   "privacyPolicyContent17": "au sujet du mode de traitement de vos renseignements personnels par Emploi et Développement social Canada.",
-  "privacyLink": "/fr/privacy",
+  "privacyLink": "/fr/signup/privacy",
   "upcoming_projects": "Projets à venir",
   "current_projects": "Projets en cours",
   "past_projects": "Projets antérieurs",

--- a/styles/menu.css
+++ b/styles/menu.css
@@ -13,6 +13,11 @@
     border-bottom: 4px solid #1d5b90;
 }
 
+.activePage:hover > a {
+    color: #0A75C6;
+    border-bottom: 4px solid #0A75C6;
+}
+
 .active {
     display: block;
 }


### PR DESCRIPTION
# Description

This PR does 3 things:

1. [Menu links are blue on mobile](https://trello.com/c/fi01rmnL/424-menu-dropdown-items-should-be-blue-like-links-to-indicate-theyre-selectable)
2. [Dynamic sizing on homepage signup button](https://trello.com/c/YSa1gRk1/423-fr-homepage-dont-wrap-first-sign-up-button-text-two-lines-max-width-issue)
3. [Underline "Sign up" on privacy page](https://trello.com/c/wwSX5Cky/426-bold-underline-for-sign-up-in-the-top-menu-when-on-the-privacy-policy-page-navigation-indicator)

## Screenshots

| before | after |
|--------|-------|
|  menu links are black      |   menu links are blue    |
|     <img width="498" alt="Screen Shot 2021-07-28 at 11 11 44" src="https://user-images.githubusercontent.com/2454380/127349524-f5782e3f-a220-4578-98cb-606f43088477.png" >  |  <img width="498" alt="Screen Shot 2021-07-28 at 11 09 17" src="https://user-images.githubusercontent.com/2454380/127349513-f929a11e-de22-49fd-80a4-727d70594110.png">  |

| before | after |
|--------|-------|
|   text on french button wraps over 2 lines   |  text of french button stays on one line     |
|  <img width="498" alt="Screen Shot 2021-07-28 at 11 11 04" src="https://user-images.githubusercontent.com/2454380/127349520-386a6e95-8079-42b2-adbb-c58481d191b5.png">   |   <img width="498" alt="Screen Shot 2021-07-28 at 11 09 50" src="https://user-images.githubusercontent.com/2454380/127349516-e8fe7a78-a43c-4ab1-95bc-a9c0100e38ac.png">  |

| before | after |
|--------|-------|
|  "sign up" is not underlined      |   "sign up" is underlined    |
|   <img width="1015" alt="Screen Shot 2021-07-28 at 11 12 05" src="https://user-images.githubusercontent.com/2454380/127349526-5dd739f6-07cc-476a-9477-beed8e4a51ce.png">   |   <img width="1015" alt="Screen Shot 2021-07-28 at 11 09 34" src="https://user-images.githubusercontent.com/2454380/127349514-a85c6591-63d8-45f8-b5be-68cd5bad4a3b.png">   |

