### PR TITLE
updated tag colours to support new tags

### DIFF
--- a/components/molecules/Experiment.js
+++ b/components/molecules/Experiment.js
@@ -8,9 +8,9 @@ import Link from "next/link";
 
 export const Experiment = (props) => {
   const tagColours = {
-    active: "custom-blue-experiment-blue",
-    coming_soon: "gray-experiment",
-    alpha: "custom-blue-experiment-blue",
+    current_projects: "custom-blue-experiment-blue",
+    past_projects: "gray-experiment",
+    upcoming_projects: "custom-blue-experiment-blue",
   };
   return (
     <div


### PR DESCRIPTION
# Description

Tag colours are based on the expected tag values received from the CMS, so I updated the names of expected tags to what we now have in the CMS which are:

- upcoming_projects
- current_projects
- past_projects

## Acceptance Criteria

Correct tag colours should display for the new tags.

## Test Instructions

1. set NEXT_PUBLIC_API_MOCKING=enabled
2. npm run dev
3. go to /projects
4. see upcoming projects and current projects are blue, past projects are gray

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
