### PR TITLE
Update font sizes

### DIFF
--- a/components/molecules/Experiment.js
+++ b/components/molecules/Experiment.js
@@ -14,7 +14,7 @@ export const Experiment = (props) => {
   };
   return (
     <div
-      className={`shadow-experiment-shadow p-4 border-b-4 xl:min-h-250px ${
+      className={`shadow-experiment-shadow p-6 border-b-4 xl:min-h-250px ${
         "border-" + (tagColours[props.tag] || "gray-experiment")
       }`}
       data-testid={props.dataTestId}
@@ -35,7 +35,7 @@ export const Experiment = (props) => {
       >
         {props.tagLabel}
       </span>
-      <p className="mt-2 leading-30px text-sm">{props.description}</p>
+      <p className="mt-2 leading-30px text-lg">{props.description}</p>
     </div>
   );
 };

--- a/pages/projects/digital-center.js
+++ b/pages/projects/digital-center.js
@@ -36,7 +36,7 @@ function ThumbnailWithCaption({
       <h3 className=" mt-3">{title}</h3>
       <figure className="shadow-experiment-shadow">
         <img src={src} alt={alt} className="border-b-2" />
-        <figcaption className="text-base p-8">{children}</figcaption>
+        <figcaption className="text-base p-6">{children}</figcaption>
       </figure>
     </div>
   );

--- a/pages/projects/life-journeys.js
+++ b/pages/projects/life-journeys.js
@@ -91,7 +91,7 @@ export default function LifeJourneys(props) {
               src={t("lj:lifeJourneysImg1")}
               alt={t("lj:lifeJourneysImgAltText1")}
             ></img>
-            <figcaption className="p-2.5 text-sm font-display border-t">
+            <figcaption className="p-6 text-sm font-display border-t">
               {t("lj:lifeJourneysImgCaption1")}
             </figcaption>
           </figure>
@@ -111,7 +111,7 @@ export default function LifeJourneys(props) {
               src="/life-journey-map.png"
               alt={t("lj:lifeJourneysImgAltText2")}
             ></img>
-            <figcaption className="p-2.5 text-sm font-display border-t">
+            <figcaption className="p-6 text-sm font-display border-t">
               {t("lj:lifeJourneysImgCaption2")}
             </figcaption>
           </figure>


### PR DESCRIPTION
# Description

This PR does 3 things:

1. Updates "Project" cards so they have more padding and a larger font size
2. Updates Digital Channel image caption components to have more padding
3. Updates the Live Journeys image caption components to have more padding

Trello cards: https://trello.com/c/GoCAUcfG/422-update-font-sizes-for-projects-pages

## Screenshots

| before | after |
|--------|-------|
|   Less padding, smaller text     |   More padding, larger text    |
|    <img width="581" alt="Screen Shot 2021-07-28 at 12 55 03" src="https://user-images.githubusercontent.com/2454380/127365087-8c4a39df-1cbd-4067-be95-a187c6a29a3f.png">    |    <img width="581" alt="Screen Shot 2021-07-28 at 12 55 08" src="https://user-images.githubusercontent.com/2454380/127365090-27e74f5f-efa6-40dd-b374-57c6966132f3.png">   |

| before | after |
|--------|-------|
|  slightly less padding for text       |  slightly more padding for text     |
|   <img width="536" alt="Screen Shot 2021-07-28 at 12 55 34" src="https://user-images.githubusercontent.com/2454380/127365092-743912b0-4ec8-498b-82d4-eb64afbabb09.png">   |  <img width="536" alt="Screen Shot 2021-07-28 at 12 55 39" src="https://user-images.githubusercontent.com/2454380/127365097-aa62fc13-16d5-405c-ae20-7ec6eb0891de.png">   |

| before | after |
|--------|-------|
|   less padding for text   |  slightly more padding for text   |
|   <img width="725" alt="Screen Shot 2021-07-28 at 12 56 07" src="https://user-images.githubusercontent.com/2454380/127365098-747664bb-1fee-40f3-8c6b-a1f35564a89e.png">    |  <img width="725" alt="Screen Shot 2021-07-28 at 12 56 13" src="https://user-images.githubusercontent.com/2454380/127365100-a6a80951-cbbc-4e98-961a-125306b4b4a0.png">   |

