### PR TITLE
fixed link that was pointing to /experiments

### DIFF
--- a/pages/confirmation.js
+++ b/pages/confirmation.js
@@ -96,7 +96,7 @@ export default function Confirmation(props) {
                   {t("emailConfirmationP2")}
                 </p>
                 <TextButtonField
-                  href="/experiments"
+                  href="/projects"
                   buttonText={t("experimentsBtnTxt")}
                   idButton="ExperimentsButton"
                   dataCyButton="ExperimentsButton"


### PR DESCRIPTION
# Description

Button link on user confirmation page was pointing to /experiments. It now points to /projects.

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
