### PR TITLE
Using <strong> instead of CSS to bold

### DIFF
--- a/pages/projects/digital-center.js
+++ b/pages/projects/digital-center.js
@@ -300,7 +300,9 @@ export default function DigitalCenter(props) {
             </div>
           </div>
 
-          <p className="my-6 font-bold">{t("projectsDisclaimer")}</p>
+          <p className="my-6">
+            <strong>{t("projectsDisclaimer")}</strong>
+          </p>
         </section>
 
         <CallToAction

--- a/pages/projects/life-journeys.js
+++ b/pages/projects/life-journeys.js
@@ -71,21 +71,17 @@ export default function LifeJourneys(props) {
         <section className="layout-container relative mb-10">
           <h1
             id="pageMainTitle"
-            className="mb-8 text-h1l font-bold flex-wrap"
+            className="mb-8 text-h1l flex-wrap"
             tabIndex="-1"
           >
             {t("lj:lifeJourneysTitle")}
           </h1>
-          <h2 className="mb-6 font-bold leading-10">
-            {t("lj:lifeJourneysHeading1")}
-          </h2>
+          <h2 className="mb-6 leading-10">{t("lj:lifeJourneysHeading1")}</h2>
           <p className="mb-6">{t("lj:lifeJourneysContent1")}</p>
           <p className="mb-6">{t("lj:lifeJourneysContent2")}</p>
           <p className="mb-6">{t("lj:lifeJourneysContent3")}</p>
           <p className="mb-6">{t("lj:lifeJourneysContent4")}</p>
-          <h2 className="mb-6 font-bold leading-10">
-            {t("lj:lifeJourneysHeading2")}
-          </h2>
+          <h2 className="mb-6 leading-10">{t("lj:lifeJourneysHeading2")}</h2>
           <figure className="mb-6 lg:w-2/3 border shadow-experiment-shadow">
             <img
               src={t("lj:lifeJourneysImg1")}
@@ -103,9 +99,7 @@ export default function LifeJourneys(props) {
             listClassName={"ml-9 mb-6 text-p list-disc"}
             content={t("lj:lifeJourneysListItems1")}
           />
-          <h2 className="mb-6 font-bold leading-10">
-            {t("lj:lifeJourneysHeading3")}
-          </h2>
+          <h2 className="mb-6 leading-10">{t("lj:lifeJourneysHeading3")}</h2>
           <figure className="mb-6 lg:w-2/3 border shadow-experiment-shadow">
             <img
               src="/life-journey-map.png"
@@ -124,11 +118,11 @@ export default function LifeJourneys(props) {
             content={t("lj:lifeJourneysListItems2")}
           />
           <p className="mb-6">{t("lj:lifeJourneysContent11")}</p>
-          <h2 className="mb-6 font-bold leading-10">
-            {t("lj:lifeJourneysHeading4")}
-          </h2>
+          <h2 className="mb-6 leading-10">{t("lj:lifeJourneysHeading4")}</h2>
           <p className="mb-6">{t("lj:lifeJourneysContent12")}</p>
-          <p className="my-6 font-bold">{t("projectsDisclaimer")}</p>
+          <p className="my-6">
+            <strong>{t("projectsDisclaimer")}</strong>
+          </p>
         </section>
 
         <CallToAction

--- a/pages/projects/virtual-assistant/index.js
+++ b/pages/projects/virtual-assistant/index.js
@@ -122,8 +122,8 @@ export default function Home(props) {
             />
             <p className="pb-2 xl:w-3/4">{t("vc:scenarioPart4")}</p>
             <p className="pb-2 xl:w-3/4">{t("vc:scenarioPart4-1")}</p>
-            <p className="pb-2 my-6 font-bold xl:w-3/4">
-              {t("projectsDisclaimer")}
+            <p className="my-6">
+              <strong>{t("projectsDisclaimer")}</strong>
             </p>
           </div>
         </section>


### PR DESCRIPTION
# Description

I removed every use of `font-bold` (only one `p` element but all the headings had it, which isn't necessary since they're bold by default) and replaced with `<strong>` as per the below message from the re-audit:

```
Using changes in text presentation to convey information without using the appropriate markup or text

Bold text on the pages is styled using CSS to visually appear as bold and not using the appropriate HTML code.

Source code:
<p class="mb-6 font-bold">You cannot apply for services or benefits through this test site. Parts of this site may not work and will change.</p>
<p class="mb-6 font-bold">Vous ne pouvez pas demander de services ou de prestations par l’intermédiaire de ce site d’essai. Certaines parties du site pourraient ne pas fonctionner et seront modifiées.</p>
To fix this, use the HTML <strong> element to code bold text.
Please check all content.
```

## Test Instructions

1. Pull in branch
2. Type `npm run dev`
3. Navigate to `/projects/life-journeys`

## Checklist

- [x] Strings use placeholders for translation (No hard coded strings)
- [x] Unit tests have been added/updated