### PR TITLE
Fix CosmosDb ttl field

### DIFF
--- a/lib/users/createUser.js
+++ b/lib/users/createUser.js
@@ -13,7 +13,7 @@ export async function createUser(client, email, data = {}) {
     cuid: cuid(),
     email: email,
     verified: false,
-    ttl: new Date(Date.now() + 24 * 60 * 60 * 1000),
+    ttl: 24 * 60 * 60, // 24 hours in seconds
     ...data,
   });
 }

--- a/lib/users/createUser.test.js
+++ b/lib/users/createUser.test.js
@@ -60,11 +60,6 @@ describe("test user creation", () => {
       test: "hello",
       hello: "hi",
     });
-    const now = new Date();
-    const ttlDate = new Date(createdUser.ops[0].ttl);
-    expect(ttlDate.getFullYear()).toEqual(now.getFullYear());
-    expect(ttlDate.getDay()).toEqual(now.getDay() + 1);
-    expect(ttlDate.getHours()).toEqual(now.getHours());
-    expect(ttlDate.getMinutes()).toEqual(now.getMinutes());
+    expect(createdUser.ops[0].ttl).toEqual(24 * 60 * 60);
   });
 });


### PR DESCRIPTION
# Description

The ttl field in CosmosDb is a duration, in seconds, but the way I wrote it before resulted in a time for the record to be removed:
![image](https://user-images.githubusercontent.com/34345435/127384672-ca4d875b-bb85-4b44-b5f3-228d25a60493.png)

Apparently the ttl in CosmosDb doesn't work this way, so this fixes that problem and records should be deleted after 24 hours.

## Checklist

- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
