### PR TITLE
Fix page title max width + image alt text

### DIFF
--- a/pages/about.js
+++ b/pages/about.js
@@ -51,11 +51,7 @@ export default function About(props) {
           <meta name="dcterms.issued" content="2021-05-11" />
         </Head>
         <section className="layout-container relative mb-10">
-          <h1
-            id="pageMainTitle"
-            className="mb-10 text-h1l font-bold sm:w-max"
-            tabIndex="-1"
-          >
+          <h1 id="pageMainTitle" className="mb-10 text-h1l" tabIndex="-1">
             {t("aboutTitle")}
           </h1>
           <div className="xl:w-2/3">
@@ -66,9 +62,7 @@ export default function About(props) {
         </section>
         <section className="bg-gray-light-200 pb-14">
           <div className="layout-container">
-            <h2 className="mb-5 pt-10 text-h1l font-bold sm:w-max">
-              {t("howWeWork")}
-            </h2>
+            <h2 className="mb-5 pt-10 text-h1l">{t("howWeWork")}</h2>
             <div className="flex flex-col-reverse pt-8 xl:grid xl:grid-cols-2 xl:gap-8">
               <List
                 items={[
@@ -82,9 +76,7 @@ export default function About(props) {
           </div>
         </section>
         <section className="layout-container" id="contact-us">
-          <h2 className="mb-5 pt-10 text-h1l font-bold sm:w-max">
-            {t("contactUsHeading")}
-          </h2>
+          <h2 className="mb-5 pt-10 text-h1l">{t("contactUsHeading")}</h2>
           <p className="mb-12 mt-10 xl:w-2/3">
             {t("getInTouch")}&nbsp;
             <a

--- a/pages/confirmation.js
+++ b/pages/confirmation.js
@@ -63,7 +63,7 @@ export default function Confirmation(props) {
         <section className="layout-container mb-12">
           <h1
             id="pageMainTitle"
-            className="mb-10 text-p xl:text-h1l font-bold sm:w-max"
+            className="mb-10 text-p xl:text-h1l"
             tabIndex="-1"
           >
             {referrer === "unsubscribe"

--- a/pages/index.js
+++ b/pages/index.js
@@ -46,7 +46,7 @@ export default function Index(props) {
               src={"/sig-blk-en.svg"}
               alt={"Government of Canada / Gouvernement du Canada"}
             />
-            <div className="flex w-max container mx-auto py-6 font-bold font-display">
+            <div className="flex w-max container mx-auto py-6 font-display">
               <h1 className="text-p text-right xl:text-h4 mr-6 w-32 xl:w-40">
                 Service Canada Labs
               </h1>

--- a/pages/projects/digital-center.js
+++ b/pages/projects/digital-center.js
@@ -95,11 +95,7 @@ export default function DigitalCenter(props) {
         </Head>
 
         <section className="layout-container mb-10 text-lg">
-          <h1
-            id="pageMainTitle"
-            className="mb-10 text-h1l font-bold sm:w-max"
-            tabIndex="-1"
-          >
+          <h1 id="pageMainTitle" className="mb-10 text-h1l" tabIndex="-1">
             {t("dc:OverviewTitle")}
           </h1>
           <p className="mt-3">{t("dc:ProductGoal1")}</p>

--- a/pages/thankyou.js
+++ b/pages/thankyou.js
@@ -52,11 +52,7 @@ export default function Confirmation(props) {
           <meta name="dcterms.issued" content="2021-06-15" />
         </Head>
         <section className="layout-container mb-12">
-          <h1
-            id="pageMainTitle"
-            className="mb-10 text-h1l font-bold lg:w-max"
-            tabIndex="-1"
-          >
+          <h1 id="pageMainTitle" className="mb-10 text-h1l" tabIndex="-1">
             {t("pleaseCheckYourEmail")}
           </h1>
           <div className="lg:flex lg:flex-row-reverse">

--- a/public/locales/fr/dc.json
+++ b/public/locales/fr/dc.json
@@ -40,7 +40,7 @@
   "Concept2Img1CaptionList": "* Un en-tête général avec seulement Service Canada et aucun menu; nous voulons que les utilisateurs se concentrent sur cette tâche spécifique * Continuer avec CléGC * Continuer avec votre banque * Continuer avec votre province (Alberta et Colombie-Britannique seulement) * Continuer avec votre adresse de courrier électronique * Continuer avec Facebook * Continuer avec Google * Continuer avec Apple",
   "Concept2Img2Title": "Image 2 : Choisir votre banque",
   "Concept2Img2": "/projects/fr/dc-2.2.jpg",
-  "Concept2Img2Alt": "Page permettant de choisir votre province pour ouvrir une session.",
+  "Concept2Img2Alt": "Page permettant de choisir votre banque pour ouvrir une session.",
   "Concept2Img2Caption": "Choisissez votre banque pour ouvrir une session et créer un compte avec Service Canada par l’intermédiaire du Centre numérique. Aucun renseignement personnel n’est partagé. De haut en bas, de gauche à droite :",
   "Concept2Img2CaptionList": "* Un en-tête général avec seulement Service Canada et aucun menu; nous voulons que les utilisateurs se concentrent sur cette tâche spécifique * Une liste de logos cliquables des différentes banques avec laquelle l’utilisateur peut choisir d’ouvrir une session",
   "Concept2Img3Title": "Image 3 : Choisir votre province",


### PR DESCRIPTION
# Description

This PR does 2 things:
 1. Removes `w-max` classes for all the headings, which fixes how page titles are displayed
 2. Changes an alt-text in French that was the wrong alt-text

## Removes `w-max` classes for all the headings

By setting a max-width, we are forcing the h1s to be a certain width, and then long page titles go off the screen. Removing the class entirely fixes that. 

| before | after |
|--------|-------|
|   <img width="649" alt="Screen Shot 2021-07-29 at 10 59 03" src="https://user-images.githubusercontent.com/2454380/127517341-0b85b542-f39a-4fea-b9e4-1f763450fb9d.png">   |   <img width="649" alt="Screen Shot 2021-07-29 at 10 59 05" src="https://user-images.githubusercontent.com/2454380/127517349-5423b817-2a59-446d-a2a1-f2afb638856d.png">  |



