### PR TITLE
Update alt text for French image 2.3 on Digital Centre page

### DIFF
--- a/public/locales/fr/dc.json
+++ b/public/locales/fr/dc.json
@@ -45,7 +45,7 @@
   "Concept2Img2CaptionList": "* Un en-tête général avec seulement Service Canada et aucun menu; nous voulons que les utilisateurs se concentrent sur cette tâche spécifique * Une liste de logos cliquables des différentes banques avec laquelle l’utilisateur peut choisir d’ouvrir une session",
   "Concept2Img3Title": "Image 3 : Choisir votre province",
   "Concept2Img3": "/projects/fr/dc-2.3.jpg",
-  "Concept2Img3Alt": "Une page de prestations avec les détails du programme.",
+  "Concept2Img3Alt": "Page permettant de choisir votre province pour ouvrir une session.",
   "Concept2Img3Caption": "Choisissez votre province pour ouvrir une session avec Service Canada par l’intermédiaire du Centre numérique. Cette option n’est disponible que pour les résidents de l’Alberta et de la Colombie-Britannique. De haut en bas, de gauche à droite :",
   "Concept2Img3CaptionList": "* Un en-tête général avec seulement Service Canada et aucun menu; nous voulons que les utilisateurs se concentrent sur cette tâche spécifique * Une boîte arborant le logo de MyAlberta ID sur laquelle on peut cliquer pour aller à la page d’ouverture de session avec MyAlberta ID * Une boîte arborant le logo de la Colombie-Britannique sur laquelle on peut cliquer pour aller à la page d’ouverture de session avec le gouvernement de la Colombie-Britannique",
   "Concept3Heading": "Idée 3 : Confirmer votre identité",


### PR DESCRIPTION
# Description

Very small change. It looks like I didn't update the alt text for this one image, and instead copy+pasted alt text from an earlier image.