### PR TITLE
Add CHANGELOG.md and SECURITY.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+## [v1.0.1] - 2021-07-29
+
+## Changed
+
+- Compressed all images over 150kb
+- Various small content and design changes
+
+## [v1.0.0] - 2021-07-28
+
+[First release of Service Canada Labs](https://github.com/DTS-STN/Alpha-Site/releases/tag/v1.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Added
+
 - Added CHANGELOG.md
 - Added SECURITY.md
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Changed
 
-- Compressed all images over 150kb
+- Compressed all images
 - Various small content and design changes
 
 ## [v1.0.0] - 2021-07-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Added CHANGELOG.md
+- Added SECURITY.md
+
 ## [v1.0.1] - 2021-07-29
 
 ## Changed

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+# Security
+
+**Do not post security issues to our public repositories.** Security issues must be reported by email to <experience@servicecanada.gc.ca>.
+
+______________________
+
+# Sécurité
+
+**Ne publiez pas de problèmes de sécurité dans nos dépôts publics.** Les problèmes de sécurité doivent être signalés par courriel à <securite@cds-snc.ca>.


### PR DESCRIPTION
# Description

Hey everyone, Paul was kind enough to share with us an example of a CHANGELOG.md and a SECURITY.md that we can use for SCLabs.

## CHANGELOG.md

This is the changelog CDS has: https://github.com/cds-snc/covid-alert-portal/blob/main/CHANGELOG.md

The CDS changelog is based on the principles laid out here: [keepachangelog.com](https://keepachangelog.com/en/1.0.0/)

From that site:

What is a changelog?
A changelog is a file which contains a curated, chronologically ordered list of notable changes for each version of a project.

Why keep a changelog?
To make it easier for users and contributors to see precisely what notable changes have been made between each release (or version) of the project.

Who needs a changelog?
People do. Whether consumers or developers, the end users of software are human beings who care about what's in the software. When the software changes, people want to know why and how.

More information is available on that site for how this document should be used and formatted. I encourage everyone to take a look at it. Essentially, during development, when developers make **notable** additions, changes or fixes to the code, you add them to the CHANGELOG.md under the **Unreleased** heading. The relevant unreleased changes will be gathered during the next release and placed under a release heading for that release.

## SECURITY.md

Here is the CDS SECURITY.md: https://github.com/cds-snc/covid-alert-portal/blob/main/SECURITY.md

This is a kind of disclaimer document that asks individuals to send security-related issues to a secure email rather than posting them here on Github.

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
