### PR TITLE
Remove social media references from digital center

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Modified Digital Center page content
+
 ## [v1.0.2] - 2021-07-30
 
 ## Added

--- a/public/locales/en/dc.json
+++ b/public/locales/en/dc.json
@@ -36,7 +36,7 @@
   "Concept2Img1Title": "Image 1: Sign In Method",
   "Concept2Img1": "/projects/en/dc-2.1.jpg",
   "Concept2Img1Alt": "Page where you can select the method you would like to use to create an account.",
-  "Concept2Img1Caption": "Create an account screenshot with options to continue with GCKey, your bank, your province, your email, your Facebook account, Google account or Apple account. A new browser tab will open if you click on one of the options. From top to bottom, left to right:",
+  "Concept2Img1Caption": "Create an account screenshot with options to continue with GCKey, your bank, your province, or your email. A new browser tab will open if you click on one of the options. From top to bottom, left to right:",
   "Concept2Img1CaptionList": "* A global header with just Service Canada and no menu items; we want users to focus on this specific task * Continue with GCKey * Continue with your bank * Continue with your province (Alberta and British Columbia only) * Continue with your email",
   "Concept2Img2Title": "Image 2: Choose your bank",
   "Concept2Img2": "/projects/en/dc-2.2.jpg",

--- a/public/locales/fr/dc.json
+++ b/public/locales/fr/dc.json
@@ -36,7 +36,7 @@
   "Concept2Img1Title": "Image 1 : Une méthode pour ouvrir une session",
   "Concept2Img1": "/projects/fr/dc-2.1.jpg",
   "Concept2Img1Alt": "Page vous permettant de sélectionner la méthode que vous souhaitez utiliser pour créer un compte.",
-  "Concept2Img1Caption": "Capture d’écran de la création d’un compte avec des options pour continuer avec CléGC, votre banque, votre province, votre adresse de courrier électronique, votre compte Facebook, votre compte Google ou votre compte Apple. Un nouvel onglet s’ouvrira dans votre navigateur si vous cliquez sur l’une de ces options. De haut en bas, de gauche à droite :",
+  "Concept2Img1Caption": "Capture d’écran de la création d’un compte avec des options pour continuer avec CléGC, votre banque, votre province, ou votre adresse de courrier électronique. Un nouvel onglet s’ouvrira dans votre navigateur si vous cliquez sur l’une de ces options. De haut en bas, de gauche à droite :",
   "Concept2Img1CaptionList": "* Un en-tête général avec seulement Service Canada et aucun menu; nous voulons que les utilisateurs se concentrent sur cette tâche spécifique * Continuer avec CléGC * Continuer avec votre banque * Continuer avec votre province (Alberta et Colombie-Britannique seulement) * Continuer avec votre adresse de courrier électronique",
   "Concept2Img2Title": "Image 2 : Choisir votre banque",
   "Concept2Img2": "/projects/fr/dc-2.2.jpg",


### PR DESCRIPTION
# Description

Removing last reference to social media on Digital Center page.

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
