### PR TITLE
Update splash page title

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,6 +26,7 @@ Get the acceptance criteria for the story and/or task you are working on and put
 
 - [ ] Strings use placeholders for translation (No hard coded strings)
 - [ ] Unit tests have been added/updated
+- [ ] Update CHANGELOG
 
 ## Product and Sprint Backlog
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Changed
 
-- Update <title> tag on splash page to be more meaningful
+- Update `<title>` tag on splash page to be more meaningful
 
 ## [v1.0.3] - 2021-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Changed
+
+- Update <title> tag on splash page to be more meaningful
+
 ## [v1.0.3] - 2021-07-30
 
 - Modified Digital Center page content

--- a/pages/index.js
+++ b/pages/index.js
@@ -26,7 +26,7 @@ export default function Index(props) {
         ) : (
           ""
         )}
-        <title>alpha.service.canada.ca</title>
+        <title>Service Canada Labs | Laboratoires de Service Canada</title>
         <link rel="icon" href="/favicon.ico" />
         <meta name="dcterms.title" content={t("scLabsSplash")} />
         <meta


### PR DESCRIPTION
# Description

[Update splash page title](https://trello.com/c/CYqnO5mM)

Change the splash page title from `alpha.service.canada.ca` to `Service Canada Labs | Laboratoires de Service Canada` so it's more meaningful.

## Acceptance Criteria

The title of the splash page is more descriptive of the pages content.

## Test Instructions

1. Navigate to the splash page
2. Notice the title of the tab is now `Service Canada Labs | Laboratoires de Service Canada`

## Checklist

- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated
- [x] Update CHANGELOG

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
