### PR TITLE
Splash page heading structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Changed
+
+- Add an invisible `<h1>` and change the visible headings to both be `<h2>` on splash page
+
 ## [v1.0.3] - 2021-07-30
 
 - Modified Digital Center page content

--- a/pages/index.js
+++ b/pages/index.js
@@ -41,12 +41,12 @@ export default function Index(props) {
       <main>
         <div className="flex flex-col justify-center items-center m-auto v-xxs:h-screen">
           <div className="z-10 bg-white h-auto min-w-300px w-300px xl:w-500px">
+            <h1 className="invisible">alpha.service.canada.ca</h1>
             <img
               className="h-auto w-64 container mx-auto pt-6 xl:w-2/3 xl:mx-0 xl:px-6"
               src={"/sig-blk-en.svg"}
               alt={"Government of Canada / Gouvernement du Canada"}
             />
-            <h1 className="invisible">alpha.service.canada.ca</h1>
             <div className="flex w-max container mx-auto py-6 font-display">
               <h2
                 className="text-p text-right xl:text-h4 mr-6 w-32 xl:w-40"

--- a/pages/index.js
+++ b/pages/index.js
@@ -46,10 +46,14 @@ export default function Index(props) {
               src={"/sig-blk-en.svg"}
               alt={"Government of Canada / Gouvernement du Canada"}
             />
+            <h1 className="invisible">alpha.service.canada.ca</h1>
             <div className="flex w-max container mx-auto py-6 font-display">
-              <h1 className="text-p text-right xl:text-h4 mr-6 w-32 xl:w-40">
+              <h2
+                className="text-p text-right xl:text-h4 mr-6 w-32 xl:w-40"
+                lang="en"
+              >
                 Service Canada Labs
-              </h1>
+              </h2>
               <h2 className="text-p xl:text-h4 w-32 xl:w-40" lang="fr">
                 Laboratoires de Service Canada
               </h2>

--- a/pages/index.js
+++ b/pages/index.js
@@ -41,7 +41,7 @@ export default function Index(props) {
       <main>
         <div className="flex flex-col justify-center items-center m-auto v-xxs:h-screen">
           <div className="z-10 bg-white h-auto min-w-300px w-300px xl:w-500px">
-            <h1 className="invisible">alpha.service.canada.ca</h1>
+            <h1 className="sr-only">alpha.service.canada.ca</h1>
             <img
               className="h-auto w-64 container mx-auto pt-6 xl:w-2/3 xl:mx-0 xl:px-6"
               src={"/sig-blk-en.svg"}


### PR DESCRIPTION
# Description

[Splash page: change HTML structure for headings](https://trello.com/c/9T5lQStF)

Add an invisible `<h1>` that is the url of the site and change the visible headings to both be `<h2>`.

## Acceptance Criteria

The headings on the splash page are both `<h2>`

## Checklist

- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
