### PR TITLE
Report a problem thank you message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Changed
+
+- Status div in Report a Problem is always rendered, but the contents are updated when submitting the form
+
 ## [v1.0.3] - 2021-07-30
 
 - Modified Digital Center page content

--- a/components/organisms/ReportAProblem.js
+++ b/components/organisms/ReportAProblem.js
@@ -43,9 +43,9 @@ export function ReportAProblem(props) {
       dataCy="report-a-problem-details"
       dataTestId="report-a-problem-details"
     >
-      {submitted ? (
-        <>
-          <div role="status">
+      <div role="status">
+        {submitted ? (
+          <>
             <h2 className="text-base font-body mb-4">
               {t("reportAProblemThankYouForYourHelp", { lng: props.language })}
             </h2>
@@ -54,14 +54,19 @@ export function ReportAProblem(props) {
                 lng: props.language,
               })}
             </p>
-          </div>
-          <a
-            className="underline text-sm font-body hover:text-canada-footer-hover-font-blue text-canada-footer-font"
-            href={`mailto: ${process.env.NEXT_PUBLIC_NOTIFY_REPORT_A_PROBLEM_EMAIL}`}
-          >
-            experience@servicecanada.gc.ca
-          </a>
-        </>
+            <a
+              className="underline text-sm font-body hover:text-canada-footer-hover-font-blue text-canada-footer-font"
+              href={`mailto: ${process.env.NEXT_PUBLIC_NOTIFY_REPORT_A_PROBLEM_EMAIL}`}
+            >
+              experience@servicecanada.gc.ca
+            </a>
+          </>
+        ) : (
+          ""
+        )}
+      </div>
+      {submitted ? (
+        ""
       ) : (
         <form
           data-gc-analytics-formname="ESDC|EDSC:ServiceCanadaLabsReport-Problem"

--- a/components/organisms/ReportAProblem.test.js
+++ b/components/organisms/ReportAProblem.test.js
@@ -25,6 +25,10 @@ describe("Report A Problem", () => {
     submitButton.click();
     expect(screen.getByText("reportAProblemThankYouForYourHelp")).toBeTruthy();
   });
+  it("renders an empty status div before submitting the form", () => {
+    render(<Primary {...Primary.args} />);
+    expect(screen.getByRole("status")).toBeTruthy();
+  });
   it("no accessibility issues for form", async () => {
     const { container } = render(<Primary {...Primary.args} />);
     const results = await axe(container);


### PR DESCRIPTION
# Description

[Report a problem: Thank you message is not announced to screen readers](https://trello.com/c/G3VuRFq0)

Changed how the status section of the works. The div reporting the status of the submit is now rendered all the time, but the contents of the div will change when the form is submitted.

## Acceptance Criteria

The content of the status div is empty on page load, but populated after submitting the form.

## Test Instructions

1. Navigate to any page with the Report a Problem component
2. Inspect the html and notice there is an empty div with `role="status"`
3. Submit the report a problem form
4. Inspect that div again an notice that it displays content.

## Checklist

- [ ] Strings use placeholders for translation (No hard coded strings)
- [x] Unit tests have been added/updated

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
