### PR TITLE
Move banner main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Changed
 
+- Skip to main content button on home page links to banner
+- Moved banner on home page in main
 - Add an invisible `<h1>` and change the visible headings to both be `<h2>` on splash page
 - Status div in Report a Problem is always rendered, but the contents are updated when submitting the form
 - Update `<title>` tag on splash page to be more meaningful

--- a/components/atoms/Banner.js
+++ b/components/atoms/Banner.js
@@ -13,7 +13,11 @@ export const Banner = ({ siteTitle, headline }) => {
     >
       <div className="lg:container xxs:mx-0 xxs:px-0 lg:mx-auto lg:px-6 xxl:mx-auto">
         <div className=" bg-black bg-opacity-90 text-white p-4 xxs:w-screen sm:bg-opacity-30 lg:w-2/3 xl:w-1/2">
-          <h1 className="text-h1 font-medium pt-4 pb-2 break-words">
+          <h1
+            className="text-h1 font-medium pt-4 pb-2 break-words"
+            id="pageMainTitle"
+            tabIndex="-1"
+          >
             {siteTitle}
           </h1>
           <hr className="border-2 border-hr-red-bar bg-hr-red-bar bg-opacity-90 border-opacity-90 w-3/4" />

--- a/components/organisms/Layout.js
+++ b/components/organisms/Layout.js
@@ -112,12 +112,12 @@ export const Layout = ({
         <div className="layout-container mt-2 mb-8">
           <Breadcrumb items={breadcrumbItems} />
         </div>
-        {bannerText && bannerTitle ? (
-          <Banner siteTitle={bannerTitle} headline={bannerText} />
-        ) : null}
       </header>
 
       <main>
+        {bannerText && bannerTitle ? (
+          <Banner siteTitle={bannerTitle} headline={bannerText} />
+        ) : null}
         <div>{children}</div>
       </main>
 

--- a/pages/home.js
+++ b/pages/home.js
@@ -60,9 +60,7 @@ export default function Home(props) {
             >
               {t("signupHomeButton")}
             </ActionButton>
-            <h2 className="my-10" tabIndex="-1" id="pageMainTitle">
-              {t("projectsAndExplorationTitle")}
-            </h2>
+            <h2 className="my-10">{t("projectsAndExplorationTitle")}</h2>
             <p className="mb-4 whitespace-pre-line">
               {t("experimentsAndExploration-1/3")}
             </p>


### PR DESCRIPTION
# Description

[Home page: Move banner into the main region of the page](https://trello.com/c/yseuDVPp/439-home-page-move-banner-into-the-main-region-of-the-page)

Move heading "Service Canada Labs" to the main region and have the skip link point to it

## Acceptance Criteria

Move the Banner into the <main> (instead of the header) and then point the skip link at it

## Test Instructions

1. Inspect the banner and check if it's inside main
2. Tab to the "Skip to main content"  on the home page and see if it links to the banner's title

## Checklist

- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated
- [x] Update CHANGELOG

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
