### PR TITLE
removed space preceding email address in mailto

### DIFF
--- a/pages/about.js
+++ b/pages/about.js
@@ -81,7 +81,7 @@ export default function About(props) {
             {t("getInTouch")}&nbsp;
             <a
               className="underline hover:text-canada-footer-hover-font-blue text-canada-footer-font break-words"
-              href={`mailto: ${process.env.NEXT_PUBLIC_NOTIFY_REPORT_A_PROBLEM_EMAIL}`}
+              href={`mailto:${process.env.NEXT_PUBLIC_NOTIFY_REPORT_A_PROBLEM_EMAIL}`}
             >
               {process.env.NEXT_PUBLIC_NOTIFY_REPORT_A_PROBLEM_EMAIL}
             </a>


### PR DESCRIPTION
# Description

[#460 Copy email address does not work it gives %20experience@servicecanada.gc.ca](https://trello.com/c/PMc28pWA/460-460-copy-email-address-does-not-work-it-gives-20experienceservicecanadagcca)

When right-clicking and selecting "copy email address" on the email before the CallToAction on the About page, the pasted value would be preceded by %20. This is because of a space preceding the email in the mailto attribute of the <a> tag. Removing that space fixes the issue.

## Acceptance Criteria

Copying the email address should only copy the address.

## Test Instructions

1. Rick-click email on About page and select "copy email address"
2. Paste it anywhere
3. See that pasted value only includes email

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
