### PR TITLE
report a problem email fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add robots.txt
 
+## Fixes
+
+- Fixed bug with Report a Problem not sending along certain selection options
+
 ## [v1.0.3] - 2021-07-30
 
 - Modified Digital Center page content

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add robots.txt
 
-## Fixes
+## Fixed
 
 - Fixed bug with Report a Problem not sending along certain selection options
 

--- a/components/organisms/ReportAProblem.js
+++ b/components/organisms/ReportAProblem.js
@@ -209,9 +209,9 @@ export function ReportAProblem(props) {
             />
             <OptionalTextField
               controlId="noWhereElseToGoCheckBox"
-              textFieldId="no_where_else_to_go"
-              controlName="no_where_else_to_go_details"
-              textFieldName="noWhereElseToGoTextField"
+              textFieldId="noWhereElseToGoTextField"
+              controlName="no_where_else_to_go"
+              textFieldName="no_where_else_to_go_details"
               controlLabel={t("reportAProblemNoWhereElseToGo", {
                 lng: props.language,
               })}

--- a/components/organisms/ReportAProblem.js
+++ b/components/organisms/ReportAProblem.js
@@ -108,7 +108,7 @@ export function ReportAProblem(props) {
               describedby="incorrectInformation"
               OptionalTextField
               checkBoxStyle="mb-4"
-              controlValue="Incorrect Information"
+              controlValue="yes"
             />
             <OptionalTextField
               controlId="unclearInformationCheckBox"
@@ -132,7 +132,7 @@ export function ReportAProblem(props) {
               textFieldDataCy="unclearInformation-text"
               describedby="unclearInformation"
               checkBoxStyle="mb-4"
-              controlValue="Unclear Information"
+              controlValue="yes"
             />
             <OptionalTextField
               controlId="infoNotFoundCheckBox"
@@ -156,7 +156,7 @@ export function ReportAProblem(props) {
               textFieldDataCy="infoNotFound-text"
               describedby="infoNotFound"
               checkBoxStyle="lg:mb-8 mb-4"
-              controlValue="You didn't find what you were looking for"
+              controlValue="yes"
             />
             <OptionalTextField
               controlId="adaptiveTechnologyCheckBox"
@@ -181,7 +181,7 @@ export function ReportAProblem(props) {
               textFieldDataCy="adaptiveTechnology-text"
               describedby="adaptiveTechnology"
               checkBoxStyle="mb-8"
-              controlValue="Page does not work with your adaptive technologies"
+              controlValue="yes"
             />
             <OptionalTextField
               controlId="privacyIssuesCheckBox"
@@ -205,7 +205,7 @@ export function ReportAProblem(props) {
               textFieldDataCy="privacyIssues-text"
               describedby="privacyIssues"
               checkBoxStyle="mb-4"
-              controlValue="You're worried about your privacy"
+              controlValue="yes"
             />
             <OptionalTextField
               controlId="noWhereElseToGoCheckBox"
@@ -229,7 +229,7 @@ export function ReportAProblem(props) {
               textFieldDataCy="noWhereElseToGo-text"
               describedby="noWhereElseToGo"
               checkBoxStyle="lg:mb-8 mb-4"
-              controlValue="You don't know where else to go for help"
+              controlValue="yes"
             />
             <OptionalTextField
               controlId="otherCheckBox"
@@ -251,7 +251,7 @@ export function ReportAProblem(props) {
               textFieldDataCy="other-text"
               describedby="other"
               checkBoxStyle="mb-4"
-              controlValue="Other"
+              controlValue="yes"
             />
           </fieldset>
 

--- a/next.config.js
+++ b/next.config.js
@@ -19,7 +19,7 @@ securityHeaders = [
   // Only allow secure origin to be delivered over HTTPS
   {
     key: "Referrer-Policy",
-    value: "strict-origin",
+    value: "same-origin",
   },
   {
     key: "Content-Security-Policy",


### PR DESCRIPTION
# Description

[#462 Report a problem should indicate the type of problem submitted](https://trello.com/c/yOdOOCCD/462-462-report-a-problem-should-indicate-the-type-of-problem-submitted)

[#461 Report a Problem feedback should indicate which page the user was on when they submitted the feedback](https://trello.com/c/M756GpH9/461-461-report-a-problem-feedback-should-indicate-which-page-the-user-was-on-when-they-submitted-the-feedback)

There were two issues with the format of the Report a Problem feedback emails:

1. Ashley Evans requested that the issue type be indicated in the subject line of the email. The app has been configured to pass the values that GCNotify expects to be able to render these conditionally.

2. The Report a Problem emails only indicated the root of the page from which the feedback is being sent when it should include the subpath. Our referrer-policy has been changed to be able to pass the URL with subpath into the report a problem API call.

## Acceptance Criteria

- Problem-type should be indicated in the subject line of the email.
- The specific page that the user sends the feedback from should be indicated in the email.

## Test Instructions

1. Use an email you have access to as the value for `NEXT_PUBLIC_NOTIFY_REPORT_A_PROBLEM_EMAIL` 
2. Try different selections in the Report a Problem component
3. See that specific page and problem type are included in the email

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
