### PR TITLE
remove x-powered-by header

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -33,6 +33,7 @@ module.exports = {
     NEXT_PUBLIC_BUILD_DATE: process.env.NEXT_PUBLIC_BUILD_DATE,
     NEXT_PUBLIC_TC_BUILD: process.env.NEXT_PUBLIC_TC_BUILD,
   },
+  poweredByHeader: false,
   async headers() {
     return [
       {


### PR DESCRIPTION
# Description

[Set x-powered-by header to not share information](https://trello.com/c/LLvxHYCZ/452-set-x-powered-by-header-to-not-share-information)

Typically you do not want to share what your server is running on with just anyone as it _could_ be used to look up vulnerabilities. This change sets the server to not share that information with clients requesting resources.

## Acceptance Criteria

Server should not share x-powered-by information.

## Test Instructions

1. Make any request to the site
2. See x-powered-by header is not populated

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
