### PR TITLE
Analytics fix

### DIFF
--- a/pages/404.js
+++ b/pages/404.js
@@ -4,9 +4,17 @@ import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import Link from "next/link";
 import { ReportAProblem } from "../components/organisms/ReportAProblem";
 import { ActionButton } from "../components/atoms/ActionButton";
+import { useEffect } from "react";
 
 export default function error404(props) {
   const { t } = useTranslation("common");
+
+  useEffect(() => {
+    if (process.env.NEXT_PUBLIC_ADOBE_ANALYTICS_URL) {
+      window.adobeDataLayer = window.adobeDataLayer || [];
+      window.adobeDataLayer.push({ event: "pageLoad" });
+    }
+  }, []);
 
   return (
     <>

--- a/pages/500.js
+++ b/pages/500.js
@@ -4,9 +4,17 @@ import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import Link from "next/link";
 import { ReportAProblem } from "../components/organisms/ReportAProblem";
 import { ActionButton } from "../components/atoms/ActionButton";
+import { useEffect } from "react";
 
 export default function error500(props) {
   const { t } = useTranslation("common");
+
+  useEffect(() => {
+    if (process.env.NEXT_PUBLIC_ADOBE_ANALYTICS_URL) {
+      window.adobeDataLayer = window.adobeDataLayer || [];
+      window.adobeDataLayer.push({ event: "pageLoad" });
+    }
+  }, []);
 
   return (
     <>

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -5,28 +5,12 @@ import "../styles/forms.css";
 import "../styles/fonts.css";
 import "../styles/menu.css";
 import Head from "next/head";
-import { useEffect } from "react";
-import { useRouter } from "next/router";
 
 if (process.env.NEXT_PUBLIC_API_MOCKING === "enabled") {
   require("../mocks");
 }
 
 function MyApp({ Component, pageProps }) {
-  const router = useRouter();
-
-  process.env.NEXT_PUBLIC_ADOBE_ANALYTICS_URL
-    ? useEffect(() => {
-        window.adobeDataLayer = window.adobeDataLayer || [];
-
-        const handleRouteChange = () => {
-          window.adobeDataLayer.push({ event: "pageLoad" });
-        };
-
-        router.events.on("routeChangeStart", handleRouteChange);
-      }, [])
-    : "";
-
   return (
     <>
       <Head>

--- a/pages/about.js
+++ b/pages/about.js
@@ -5,10 +5,18 @@ import { useTranslation } from "next-i18next";
 import { useRouter } from "next/router";
 import { List } from "../components/molecules/List";
 import { CallToAction } from "../components/molecules/CallToAction";
+import { useEffect } from "react";
 
 export default function About(props) {
   const { t } = useTranslation("common");
   const { asPath } = useRouter();
+
+  useEffect(() => {
+    if (process.env.NEXT_PUBLIC_ADOBE_ANALYTICS_URL) {
+      window.adobeDataLayer = window.adobeDataLayer || [];
+      window.adobeDataLayer.push({ event: "pageLoad" });
+    }
+  }, []);
 
   return (
     <>

--- a/pages/confirmation.js
+++ b/pages/confirmation.js
@@ -4,11 +4,19 @@ import { useRouter } from "next/router";
 import { Layout } from "../components/organisms/Layout";
 import Head from "next/head";
 import { TextButtonField } from "../components/molecules/TextButtonField";
+import { useEffect } from "react";
 
 export default function Confirmation(props) {
   const { t } = useTranslation("common");
   const { asPath, query } = useRouter();
   const referrer = query.ref || "";
+
+  useEffect(() => {
+    if (process.env.NEXT_PUBLIC_ADOBE_ANALYTICS_URL) {
+      window.adobeDataLayer = window.adobeDataLayer || [];
+      window.adobeDataLayer.push({ event: "pageLoad" });
+    }
+  }, []);
 
   return (
     <>

--- a/pages/error.js
+++ b/pages/error.js
@@ -5,6 +5,7 @@ import { ActionButton } from "../components/atoms/ActionButton";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { useTranslation } from "next-i18next";
 import { useRouter } from "next/router";
+import { useEffect } from "react";
 
 export default function ErrorPage(props) {
   const { t } = useTranslation("common");
@@ -19,6 +20,13 @@ export default function ErrorPage(props) {
   const errorMessageFr =
     query.errorMessageFr ||
     "Si le problème persiste, veuillez signaler le problème.";
+
+  useEffect(() => {
+    if (process.env.NEXT_PUBLIC_ADOBE_ANALYTICS_URL) {
+      window.adobeDataLayer = window.adobeDataLayer || [];
+      window.adobeDataLayer.push({ event: "pageLoad" });
+    }
+  }, []);
 
   return (
     <>

--- a/pages/home.js
+++ b/pages/home.js
@@ -6,10 +6,18 @@ import { useRouter } from "next/router";
 import { CallToAction } from "../components/molecules/CallToAction";
 import { ActionButton } from "../components/atoms/ActionButton";
 import { HTMList } from "../components/atoms/HTMList";
+import { useEffect } from "react";
 
 export default function Home(props) {
   const { t } = useTranslation("common");
   const { asPath } = useRouter();
+
+  useEffect(() => {
+    if (process.env.NEXT_PUBLIC_ADOBE_ANALYTICS_URL) {
+      window.adobeDataLayer = window.adobeDataLayer || [];
+      window.adobeDataLayer.push({ event: "pageLoad" });
+    }
+  }, []);
 
   return (
     <>

--- a/pages/index.js
+++ b/pages/index.js
@@ -26,7 +26,10 @@ export default function Index(props) {
         )}
         <title>Service Canada Labs | Laboratoires de Service Canada</title>
         <link rel="icon" href="/favicon.ico" />
-        <meta name="dcterms.title" content={t("scLabsSplash")} />
+        <meta
+          name="dcterms.title"
+          content={`${t("scLabsSplash")} — ${t("siteTitle")}`}
+        />
         <meta
           name="dcterms.language"
           content={props.locale === "en" ? "eng" : "fra"}

--- a/pages/index.js
+++ b/pages/index.js
@@ -3,9 +3,17 @@ import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { useTranslation } from "next-i18next";
 import { ActionButton } from "../components/atoms/ActionButton";
 import Link from "next/link";
+import { useEffect } from "react";
 
 export default function Index(props) {
   const { t } = useTranslation("common");
+
+  useEffect(() => {
+    if (process.env.NEXT_PUBLIC_ADOBE_ANALYTICS_URL) {
+      window.adobeDataLayer = window.adobeDataLayer || [];
+      window.adobeDataLayer.push({ event: "pageLoad" });
+    }
+  }, []);
 
   return (
     <>

--- a/pages/projects.js
+++ b/pages/projects.js
@@ -7,6 +7,7 @@ import { Experiment } from "../components/molecules/Experiment";
 import { useRouter } from "next/router";
 import { Filter } from "../components/molecules/Filter";
 import { CallToAction } from "../components/molecules/CallToAction";
+import { useEffect } from "react";
 
 export default function Projects(props) {
   const { t } = useTranslation("common");
@@ -64,6 +65,13 @@ export default function Projects(props) {
       );
     }
   };
+
+  useEffect(() => {
+    if (process.env.NEXT_PUBLIC_ADOBE_ANALYTICS_URL) {
+      window.adobeDataLayer = window.adobeDataLayer || [];
+      window.adobeDataLayer.push({ event: "pageLoad" });
+    }
+  }, []);
 
   return (
     <>

--- a/pages/projects/digital-center.js
+++ b/pages/projects/digital-center.js
@@ -6,6 +6,7 @@ import { HTMList } from "../../components/atoms/HTMList";
 import { Layout } from "../../components/organisms/Layout";
 import { useRouter } from "next/router";
 import { CallToAction } from "../../components/molecules/CallToAction";
+import { useEffect } from "react";
 
 function ThumbnailWithCaption({
   title = "Image 1",
@@ -33,6 +34,13 @@ ThumbnailWithCaption.propTypes = {
 export default function DigitalCenter(props) {
   const { t } = useTranslation(["common", "dc"]);
   const { asPath } = useRouter();
+
+  useEffect(() => {
+    if (process.env.NEXT_PUBLIC_ADOBE_ANALYTICS_URL) {
+      window.adobeDataLayer = window.adobeDataLayer || [];
+      window.adobeDataLayer.push({ event: "pageLoad" });
+    }
+  }, []);
 
   return (
     <>

--- a/pages/projects/life-journeys.js
+++ b/pages/projects/life-journeys.js
@@ -5,10 +5,18 @@ import { useTranslation } from "next-i18next";
 import { useRouter } from "next/router";
 import { HTMList } from "../../components/atoms/HTMList";
 import { CallToAction } from "../../components/molecules/CallToAction";
+import { useEffect } from "react";
 
 export default function LifeJourneys(props) {
   const { t } = useTranslation("common", "lj");
   const { asPath } = useRouter();
+
+  useEffect(() => {
+    if (process.env.NEXT_PUBLIC_ADOBE_ANALYTICS_URL) {
+      window.adobeDataLayer = window.adobeDataLayer || [];
+      window.adobeDataLayer.push({ event: "pageLoad" });
+    }
+  }, []);
 
   return (
     <>

--- a/pages/projects/virtual-assistant/index.js
+++ b/pages/projects/virtual-assistant/index.js
@@ -5,10 +5,18 @@ import { Layout } from "../../../components/organisms/Layout";
 import { useRouter } from "next/router";
 import { VirtualConcierge } from "../../../components/organisms/VirtualConcierge";
 import { CallToAction } from "../../../components/molecules/CallToAction";
+import { useEffect } from "react";
 
 export default function Home(props) {
   const { t } = useTranslation(["common", "vc"]);
   const { asPath } = useRouter();
+
+  useEffect(() => {
+    if (process.env.NEXT_PUBLIC_ADOBE_ANALYTICS_URL) {
+      window.adobeDataLayer = window.adobeDataLayer || [];
+      window.adobeDataLayer.push({ event: "pageLoad" });
+    }
+  }, []);
 
   return (
     <>

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -18,6 +18,7 @@ import { SelectField } from "../components/atoms/SelectField";
 import { CheckBox } from "../components/atoms/CheckBox";
 import { OptionalListField } from "../components/molecules/OptionalListField";
 import { maskEmail } from "../lib/utils/maskEmail";
+import { useEffect } from "react";
 
 // TODO
 //  - fix bug with error messages not showing custom error message [x]
@@ -386,6 +387,13 @@ export default function Signup(props) {
       behavior: "smooth",
     });
   };
+
+  useEffect(() => {
+    if (process.env.NEXT_PUBLIC_ADOBE_ANALYTICS_URL) {
+      window.adobeDataLayer = window.adobeDataLayer || [];
+      window.adobeDataLayer.push({ event: "pageLoad" });
+    }
+  }, []);
 
   return (
     <>

--- a/pages/signup/privacy.js
+++ b/pages/signup/privacy.js
@@ -5,10 +5,18 @@ import { useTranslation } from "next-i18next";
 import { useRouter } from "next/router";
 import { HTMList } from "../../components/atoms/HTMList";
 import { CallToAction } from "../../components/molecules/CallToAction";
+import { useEffect } from "react";
 
 export default function Privacy(props) {
   const { t } = useTranslation("common");
   const { asPath } = useRouter();
+
+  useEffect(() => {
+    if (process.env.NEXT_PUBLIC_ADOBE_ANALYTICS_URL) {
+      window.adobeDataLayer = window.adobeDataLayer || [];
+      window.adobeDataLayer.push({ event: "pageLoad" });
+    }
+  }, []);
 
   return (
     <>

--- a/pages/thankyou.js
+++ b/pages/thankyou.js
@@ -3,12 +3,20 @@ import Head from "next/head";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { useTranslation } from "next-i18next";
 import { useRouter } from "next/router";
+import { useEffect } from "react";
 
 export default function Confirmation(props) {
   const { t } = useTranslation("common");
   const { asPath, query } = useRouter();
   const maskedEmail = String(query.e);
   const referrer = query.ref || "";
+
+  useEffect(() => {
+    if (process.env.NEXT_PUBLIC_ADOBE_ANALYTICS_URL) {
+      window.adobeDataLayer = window.adobeDataLayer || [];
+      window.adobeDataLayer.push({ event: "pageLoad" });
+    }
+  }, []);
 
   return (
     <>

--- a/pages/unsubscribe.js
+++ b/pages/unsubscribe.js
@@ -11,6 +11,7 @@ import { Layout } from "../components/organisms/Layout";
 import { ActionButton } from "../components/atoms/ActionButton";
 import { TextField } from "../components/atoms/TextField";
 import { maskEmail } from "../lib/utils/maskEmail";
+import { useEffect } from "react";
 
 export default function Unsubscribe(props) {
   const { t } = useTranslation("common");
@@ -162,6 +163,13 @@ export default function Unsubscribe(props) {
       behavior: "smooth",
     });
   };
+
+  useEffect(() => {
+    if (process.env.NEXT_PUBLIC_ADOBE_ANALYTICS_URL) {
+      window.adobeDataLayer = window.adobeDataLayer || [];
+      window.adobeDataLayer.push({ event: "pageLoad" });
+    }
+  }, []);
 
   return (
     <>

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -221,7 +221,7 @@
   "emailConfirmationP1": "We’ll invite you to take part in experiments and research activities as they come up to make Service Canada better for everyone.",
   "emailConfirmationP2": "In the meantime, explore our experiments.",
   "creator": "Employment and Social Development Canada",
-  "scLabsSplash": "Service Canada Labs - Splash",
+  "scLabsSplash": "Splash",
   "scLabsHome": "Home",
   "doNotInclude": "Do not include any personal, medical or financial details, such as your name, social insurance number (SIN), home or business address, phone number or any case or file numbers.",
   "getInTouch": "If you have any questions or comments and would like to get in touch with us, please email",

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -221,7 +221,7 @@
   "emailConfirmationP1": "Nous vous inviterons à participer à des expériences et à des activités de recherche au fur et à mesure qu’elles se présenteront afin d’améliorer Service Canada pour tous.",
   "emailConfirmationP2": "En attendant, explorez nos projets et dites-nous ce que vous en pensez.",
   "creator": "Emploi et Développement social Canada",
-  "scLabsSplash": "Laboratoires de Service Canada - Splash",
+  "scLabsSplash": "Splash",
   "scLabsHome": "Accueil",
   "doNotInclude": "Ne pas inclure de renseignements personnels, médicaux ou financiers, comme par exemple, un numéro d’assurance sociale (NAS), une adresse de domicile ou de lieu de travail, un numéro de téléphone ou numéro de dossier.",
   "getInTouch": "Si vous avez des questions ou des commentaires et que vous souhaitez communiquer avec nous, veuillez nous envoyer un courriel à",


### PR DESCRIPTION
# Description

[#465 Fix small analytics issues](https://trello.com/c/xzGBglDR/465-465-fix-small-analytics-issues)

Fix incorrect page titles and adjust the timing of when the beacon is called so that the current page title is captured from the metadata and not the previous page. The change I made for the page load seems to have caused another issue so I'm reverting it to what it was.

## Test Instructions

- 1. Go on the splash page
- 2. Select a language to go on the home page
- 3. Write "adobeDataLayer" in the console, and the array should have only two objects.
- 4. The meta tag with the name "dcterms.title" should all be in this order (Name of the page - Service Canada Labs)

## Checklist

- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated
- [ ] Update CHANGELOG

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
