### PR TITLE
Update breadcrumb items focus

### DIFF
--- a/components/atoms/Breadcrumb.js
+++ b/components/atoms/Breadcrumb.js
@@ -8,7 +8,7 @@ export function Breadcrumb(props) {
   return (
     <nav aria-label="breadcrumbs">
       <ul className="block text-custom-blue-dark text-base font-body">
-        <li className="inline-block min-w-0 max-w-full truncate">
+        <li className="inline-block min-w-0 max-w-full truncate px-2">
           <Link href="https://www.canada.ca/">
             <a className="text-sm hover:text-custom-blue-link visited:text-purple-700 underline">
               Canada.ca
@@ -21,7 +21,7 @@ export function Breadcrumb(props) {
               return (
                 <li
                   key={key}
-                  className="inline-block min-w-0 max-w-full truncate"
+                  className="inline-block min-w-0 max-w-full truncate px-2"
                 >
                   <span className="inline-block align-middle text-gray-breadcrumb icon-cheveron-right mx-4" />
                   <Link href={item.link}>


### PR DESCRIPTION
# Description

The focus on breadcrumb items was off a bit, so this PR is for fixing that.

Picture from the deployed site:
![image](https://user-images.githubusercontent.com/72703030/129402201-713a030e-3bde-4c73-a7e8-131ef981ce0e.png)

Picture from this PR:
![image](https://user-images.githubusercontent.com/72703030/129402621-9a98ff11-653a-4de8-93e1-ad5a1b171e1a.png)

## Test Instructions

1. Go on any page with breadcrumbs and tab to the breadcrumb items
2. Check to see if the focus rectangle is completely visible

## Checklist

- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated
- [ ] Update CHANGELOG

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
