### PR TITLE
Error page fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Fixed
+
+- [Bug #344](https://github.com/DTS-STN/Alpha-Site/issues/344) issue with ReportAProblem component on `/error` now translates properly
+
 ## [v1.0.6] - 2021-08-13
 
 ## Changed

--- a/pages/error.js
+++ b/pages/error.js
@@ -306,7 +306,8 @@ export const getStaticProps = async ({ locale }) => {
   return {
     props: {
       locale: locale,
-      ...(await serverSideTranslations(locale, ["common"])),
+      ...(await serverSideTranslations("en", ["common"])),
+      ...(await serverSideTranslations("fr", ["common"])),
     },
   };
 };


### PR DESCRIPTION
# Description

[ReportAProblem component doesn't render in the language specified](https://trello.com/c/aEh70BGI)
Closes #344 

Fixes the issue with the ReportAProblem component not translating on the `/error` page. Turns out that the french wasn't being loaded in and all that was necessary was adding
```
export const getStaticProps = async ({ locale }) => {
  return {
    props: {
      locale: locale,
      ...(await serverSideTranslations("en", ["common"])),
      ...(await serverSideTranslations("fr", ["common"])),
    },
  };
};
```

## Acceptance Criteria

The ReportAProblem component shows both english and french properly on the `/error` page.

## Test Instructions

1. Visit `/error`
2. Notice that the ReportAProblem component renders in english and french properly


## Checklist

- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated
- [x] Update CHANGELOG

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
