### PR TITLE
A11y - Menu items and CallToAction component corrections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Changed
+
+- Updated menu items to have an underline so they appear more like links
+- Updated CallToAction component to have a white border on hover/active state
+
 ## [v1.0.6] - 2021-08-13
 
 ## Changed

--- a/components/molecules/CallToAction.js
+++ b/components/molecules/CallToAction.js
@@ -26,6 +26,10 @@ export function CallToAction(props) {
               <p className="flex mb-4 text-center">
                 <ActionButton
                   id="become-a-participant-btn"
+                  custom={
+                    "py-2 px-4 bg-custom-blue-blue text-white border border-custom-blue-blue active:bg-custom-blue-dark active:border-2 active:border-white hover:border-2 hover:border-white hover:bg-custom-blue-light"
+                  }
+                  className=""
                   href={props.href}
                   text={props.hrefText}
                 />

--- a/components/molecules/Menu.js
+++ b/components/molecules/Menu.js
@@ -49,14 +49,18 @@ export function Menu(props) {
           return (
             <li
               key={key}
-              className={`py-3 lg:py-0 cursor-pointer text-custom-blue-projects-link ${
-                includesURL ? "activePage" : "menuLink"
-              }`}
+              className={`py-3 lg:py-0 cursor-pointer text-custom-blue-projects-link `}
               role="menuitem"
               aria-current={exactURL ? "page" : null}
             >
               <Link href={item.link}>
-                <a className="font-body text-base">{item.text}</a>
+                <a
+                  className={`font-body text-base ${
+                    includesURL ? "activePage" : "menuLink underline"
+                  }`}
+                >
+                  {item.text}
+                </a>
               </Link>
             </li>
           );

--- a/styles/menu.css
+++ b/styles/menu.css
@@ -5,15 +5,15 @@
     background-color: white;
 }
 
-.menuLink:hover > a {
+.menuLink:hover {
     color: #0A75C6;
 }
 
-.activePage > a {
+.activePage {
     border-bottom: 4px solid #1d5b90;
 }
 
-.activePage:hover > a {
+.activePage:hover{
     color: #0A75C6;
     border-bottom: 4px solid #0A75C6;
 }


### PR DESCRIPTION
# Description

Fixes from #228:

- I think the menu links need to be underlined because they look a lot like normal text
- The "Sign up to get invited to research sessions" button doesn’t pass contrast check - can we switch the active state to a white outline (2px thick)?

Updated menu:
![image](https://user-images.githubusercontent.com/34345435/129751362-5585de76-5704-46c4-9a7d-04be3303f1c2.png)

Updated CallToAction button:
![image](https://user-images.githubusercontent.com/34345435/129751468-84aa5a41-3bf7-4d4b-9a9e-f847e91957ee.png)


## Acceptance Criteria

The menu items have underlines to indicate they are links, with a larger underline indicating the page you're on. The CallToAction button has a white border on active/hover state.

## Test Instructions

1. Navigate around the app and notice the menu items are all underline, with a thicker underline for the page you are on
2. In the "Sign up to get invited to research sessions" section, either tab over, or hover the mouse over the "Sign up to get invited..." button and notice a white border around the button.

## Checklist

- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated
- [x] Update CHANGELOG

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
