### PR TITLE
fix storybook-addon-next-router configuration

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -12,6 +12,7 @@ module.exports = {
     "@storybook/addon-essentials",
     "@storybook/addon-a11y",
     "@storybook/addon-postcss",
+    "storybook-addon-next-router"
   ],
   webpackFinal: (config) => {
     // useTranslation() hook in next-i18next is looking for a server environment and storybooks

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -7,9 +7,7 @@ import "../styles/menu.css";
 
 import i18n from "./i18n.js";
 import { I18nProviderWrapper } from "./i18nextProviderWrapper";
-
-import { withNextRouter } from "storybook-addon-next-router";
-import { addDecorator } from "@storybook/react";
+import { RouterContext } from "next/dist/shared/lib/router-context"
 
 export const globalTypes = {
   locale: {
@@ -25,16 +23,6 @@ export const globalTypes = {
     },
   },
 };
-
-//Adding next-router compatibility with storybbok
-addDecorator(
-  withNextRouter({
-    path: "/",
-    asPath: "/",
-    query: {},
-    push() {},
-  })
-);
 
 // override next js image component to make it work with storybook
 // https://github.com/vercel/next.js/issues/18393#issuecomment-750910068
@@ -159,6 +147,9 @@ Object.defineProperty(nextImage, "default", {
 
 export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },
+  nextRouter: {
+    Provider: RouterContext.Provider,
+  },
 };
 
 export const decorators = [


### PR DESCRIPTION
# Description

[Fix issue where storybook hangs on load](https://trello.com/c/Y7636Tz3/490-490-fix-issue-where-storybooks-hangs-during-initial-load)

Config for storybook-addon-next-router was broken after Next 11 update. This config fixes the issue and storybook should work now.

## Acceptance Criteria

`npm run storybook` should properly build the storybook without errors.

## Test Instructions

1. `npm run storybook`
2. See that it loads without errors.

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
