### PR TITLE
give footer a dark background color

### DIFF
--- a/components/organisms/Footer.js
+++ b/components/organisms/Footer.js
@@ -7,7 +7,7 @@ import PropTypes from "prop-types";
 export function Footer(props) {
   return (
     <div className="w-full">
-      <div className="w-full h-auto footerBackground">
+      <div className="w-full h-auto footerBackground bg-custom-blue-dark">
         <div
           className="py-7 layout-container"
           role="navigation"


### PR DESCRIPTION
# Description

Footer passed contrast checks but give a dark bg color to .footerBackground so it doesn’t get flagged by automatic contrast checkers (the image there passes but it’ll get flagged)

## Acceptance Criteria

Give footer a dark background so it doesn't get flagged by automatic contrast checker
