### PR TITLE
Added default function for middleware conflicts

### DIFF
--- a/pages/api/feedback.js
+++ b/pages/api/feedback.js
@@ -8,15 +8,11 @@ import initMiddleware from "../../middlewares/initMiddleware";
 const cors = initMiddleware(
   // You can read more about the available options here: https://github.com/expressjs/cors#configuration-options
   Cors({
-    // Only allow requests with POST
     methods: ["POST"],
   })
 );
 
 async function handler(req, res) {
-  // Run cors
-  await cors(req, res);
-
   // this route only accepts a POST method
   if (req.method === "POST") {
     let data = req.body;
@@ -65,7 +61,10 @@ const schema = Joi.object({
   feedback: Joi.string().required(),
 });
 
-export default validate(schema, handler, {
-  abortEarly: false,
-  allowUnknown: true,
-});
+export default async function enableMiddleware(req, res) {
+  await cors(req, res);
+  return validate(schema, handler, {
+    abortEarly: false,
+    allowUnknown: true,
+  })(req, res);
+}


### PR DESCRIPTION
# Description

Joi middleware was interfering with Cors middleware.

A new default function was added to /api/feedback to allow them to play nice together

## Test Instructions

1. Run Alpha and a separate project. (I ran Alpha on port 3000 and Virtual Assistant on port 3001)
2. Make post request to Alpha/api/feedback from separate project
3. Response should now be "Feedback Submitted" instead of CORS error

## Help Requested

- Please checkout the enableMiddleware function and how it handles two middlewares. I couldn't think of a better naming convention or structure. Ideally there shouldn't be a function written for this so ideas are more than welcome

## Checklist

- [x] Strings use placeholders for translation (No hard coded strings)
- [x] Unit tests have been added/updated
- [x] Update CHANGELOG

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
