### PR TITLE
Set CORS origin header for feedback api

### DIFF
--- a/__tests__/api/feedback.test.js
+++ b/__tests__/api/feedback.test.js
@@ -50,7 +50,7 @@ describe("feedback api", () => {
     await feedbackHandler(req, res);
     expect(res._getStatusCode()).toBe(405);
     expect(res._getHeaders()).toStrictEqual({
-      "access-control-allow-origin": "*",
+      vary: "Origin",
       allow: ["POST"],
     });
   });

--- a/pages/api/feedback.js
+++ b/pages/api/feedback.js
@@ -4,11 +4,16 @@ import validate from "../../middlewares/joi";
 import Cors from "cors";
 import initMiddleware from "../../middlewares/initMiddleware";
 
+const origins = {
+  development: "*",
+  production: /alpha\.service\.canada\.ca/,
+};
+
 // Initialize the cors middleware
 const cors = initMiddleware(
   // You can read more about the available options here: https://github.com/expressjs/cors#configuration-options
   Cors({
-    origin: [/alpha\.service\.canada\.ca/],
+    origin: [origins[process.env.ENVIRONMENT]],
     methods: ["POST"],
   })
 );

--- a/pages/api/feedback.js
+++ b/pages/api/feedback.js
@@ -8,10 +8,10 @@ import initMiddleware from "../../middlewares/initMiddleware";
 const cors = initMiddleware(
   // You can read more about the available options here: https://github.com/expressjs/cors#configuration-options
   Cors({
+    origin: [/alpha\.service\.canada\.ca/],
     methods: ["POST"],
   })
 );
-
 async function handler(req, res) {
   // this route only accepts a POST method
   if (req.method === "POST") {


### PR DESCRIPTION
# Description

Set CORS origin to alpha.service.canada.ca domain so it can't be spammed.

## Acceptance Criteria

Feedback api is accessible to any subdomain of alpha.service.canada.ca

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
