### PR TITLE
Move signup form error list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Changed
 
+- Moved error list under the signup form heading
 - Updated menu items to have an underline so they appear more like links
 - Updated CallToAction component to have a white border on hover/active state
 - Updated PhaseBanner to include Feedback component

--- a/components/molecules/ErrorBox.js
+++ b/components/molecules/ErrorBox.js
@@ -8,7 +8,7 @@ export function ErrorBox(props) {
   return (
     <div
       id="error-box"
-      className="relative border-l-4 border-error-border-red min-h-40px mb-10"
+      className="relative border-l-4 border-error-border-red min-h-40px my-10"
       data-cy="error-box"
       role="alert"
       aria-atomic="true"

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -1,7 +1,7 @@
 /* istanbul ignore file */
 
 import Head from "next/head";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Joi from "joi";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { ErrorBox } from "../components/molecules/ErrorBox";
@@ -18,7 +18,6 @@ import { SelectField } from "../components/atoms/SelectField";
 import { CheckBox } from "../components/atoms/CheckBox";
 import { OptionalListField } from "../components/molecules/OptionalListField";
 import { maskEmail } from "../lib/utils/maskEmail";
-import { useEffect } from "react";
 
 // TODO
 //  - fix bug with error messages not showing custom error message [x]
@@ -479,6 +478,7 @@ export default function Signup(props) {
           </div>
         </section>
         <section className="layout-container">
+          <h2 className="mb-5 text-h3 lg:text-h2">{t("signupTitle5")}</h2>
           {errorBoxText ? (
             <ErrorBox
               text={errorBoxText}
@@ -486,7 +486,6 @@ export default function Signup(props) {
               onClick={handleScrollToError}
             />
           ) : undefined}
-          <h2 className="mb-5 text-h3 lg:text-h2">{t("signupTitle5")}</h2>
           <form
             data-gc-analytics-formname="ESDC|EDSC:ServiceCanadaLabsSign-up"
             data-gc-analytics-collect='[{"value":"input:not(.exclude),select","emptyField":"N/A"}]'


### PR DESCRIPTION
# Description

[Move error messages on Sign Up form below "Sign up form" header](https://trello.com/c/Umd8dept)

Moved the error list underneath the form header.

![image](https://user-images.githubusercontent.com/34345435/134216465-0bfcc29f-b28a-44d6-beff-52fba696b0f8.png)


## Acceptance Criteria

The error list now appears underneath the form header

## Test Instructions

1. Submit the form without entering any information
2. Notice that the error list is below the header of the form


## Checklist

- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated
- [x] Update CHANGELOG

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
