### PR TITLE
Added breadcrumb to the privacy page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Updated Home page banner contrast for medium screen size
 - Updated signup button color to have sufficient contrast with the blue background
 - Changed Digital Center URL from 'projects/digital-center' to 'projects/digital-centre'
+- Updated breadcrumbs on the privacy page
 
 ## [v1.0.6] - 2021-08-13
 

--- a/pages/signup/privacy.js
+++ b/pages/signup/privacy.js
@@ -25,6 +25,7 @@ export default function Privacy(props) {
         langUrl={asPath}
         breadcrumbItems={[
           { text: t("siteTitle"), link: t("breadCrumbsHref1") },
+          { text: t("signupHomeButton"), link: t("breadCrumbsHref3") },
         ]}
       >
         <Head>

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -246,6 +246,7 @@
   "signupBtn": "Sign up to get invited to research sessions",
   "breadCrumbsHref1": "/home",
   "breadCrumbsHref2": "/projects",
+  "breadCrumbsHref3": "/signup",
   "symbol": "Government of Canada",
   "symbol2": "Symbol of the Government of Canada",
   "projectsDisclaimer": "You cannot apply for services or benefits through this test site. Parts of this site may not work and will change.",

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -246,6 +246,7 @@
   "signupBtn": "S’inscrire pour être invité aux séances de recherche",
   "breadCrumbsHref1": "/fr/home",
   "breadCrumbsHref2": "/fr/projects",
+  "breadCrumbsHref3": "/fr/signup",
   "symbol": "Gouvernement du Canada",
   "symbol2": "Symbole du gouvernement du Canada",
   "projectsDisclaimer": "Vous ne pouvez pas demander de services ou de prestations par l’intermédiaire de ce site d’essai. Certaines parties du site pourraient ne pas fonctionner et seront modifiées.",


### PR DESCRIPTION
# Description

[Add breadcrumb to Privacy Page](https://trello.com/c/wzAiZiAV)

Added a breadcrumb link on the privacy page back to the signup page.

![image](https://user-images.githubusercontent.com/34345435/134217902-0dc06a63-a256-4d43-8856-3df7955036ea.png)

## Acceptance Criteria

A breadcrumb that links back to the signup page appears on the privacy page.

## Test Instructions

1. Navigate to the signup page
2. Scroll down and click the link to the privacy policy
3. Notice the breadcrumb that links back to the signup page

## Checklist

- [x] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated
- [x] Update CHANGELOG

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
