### PR TITLE
Remove highlight on Signup link when in Privacy page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Changed
 
+- Remove underline on the signup link when privacy page is active
 - Updated menu items to have an underline so they appear more like links
 - Updated CallToAction component to have a white border on hover/active state
 - Updated PhaseBanner to include Feedback component

--- a/components/molecules/Menu.js
+++ b/components/molecules/Menu.js
@@ -8,6 +8,7 @@ import { useRouter } from "next/router";
 export function Menu(props) {
   //Router
   const { asPath } = useRouter();
+  const router = useRouter();
 
   //Function for changing menu state
   function onMenuClick() {
@@ -61,7 +62,11 @@ export function Menu(props) {
               <Link href={item.link}>
                 <a
                   className={`font-body text-base ${
-                    includesURL ? "activePage" : "menuLink underline"
+                    includesURL
+                      ? router.pathname !== "/signup/privacy"
+                        ? "activePage"
+                        : "menuLink underline"
+                      : "menuLink underline"
                   }`}
                 >
                   {item.text}


### PR DESCRIPTION
# Description

[#546 DESIGN: Remove Highlight of Sign Up in menu on Privacy Page](https://trello.com/c/XQhfvSq4/546-546-design-remove-highlight-of-sign-up-in-menu-on-privacy-page)

`Signup` link in the menu should not be in active state on `Privacy` page 

<img width="400" alt="Screen Shot 2021-09-21 at 2 28 05 PM" src="https://user-images.githubusercontent.com/64853947/134227585-d04bc293-51a8-4379-9b13-08e0cdd64b66.png">
<img width="400" alt="Screen Shot 2021-09-21 at 2 27 56 PM" src="https://user-images.githubusercontent.com/64853947/134227568-d6834a93-5051-4539-a1d7-0dab5037fc5c.png">

## Acceptance Criteria

Signup link in the menu is not higlighted on privacy page

## Test Instructions

Go to `/signup/privacy`, check `Signup` link in the menu to see if it's highlighted or not.

## Checklist

- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated
- [ ] Update CHANGELOG

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
