### PR TITLE
Update purge safelist in tailwind config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   translates properly
 - WCAG issue: Text overlap when user increase the text size to 200% in firefox
 - Filters on the project page no longer wrap to a newline in mobile view
+- Project status label colours now appear properly
 
 ## Changed
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,6 +16,7 @@ module.exports = {
         "opacity-80",
         "opacity-90",
         "opacity-100",
+        /(bg|border)-(custom-blue|custom-red|custom-green)-(lighter|darker)/,
       ],
     },
   },


### PR DESCRIPTION
# Description

Since the project status label colours are being added dynamically, the purge function that tailwind uses didn't capture those classes and removed them, resulting in colourless status labels:

![image](https://user-images.githubusercontent.com/34345435/134372601-c6fa220a-b18e-45b7-837e-9fe41b4a35b0.png)

This PR adds those css classes to the safelist so that they aren't removed when building the application, ensuring that the colours remain:

![image](https://user-images.githubusercontent.com/34345435/134372832-d0c6dac1-3aa5-490f-842b-b6642f59d98b.png)

## Checklist

- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated
- [x] Update CHANGELOG

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
