### PR TITLE
Added smooth scroll to top on form submit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - WCAG issue: Text overlap when user increase the text size to 200% in firefox
 - Filters on the project page no longer wrap to a newline in mobile view
 - Project status label colours now appear properly
+- User is now scrolled to top after submitting the feedback form
 
 ## Changed
 

--- a/components/organisms/PhaseBanner.js
+++ b/components/organisms/PhaseBanner.js
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { useTranslation } from "next-i18next";
 import { ActionButton } from "../atoms/ActionButton";
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import Joi from "joi";
 import { ErrorLabel } from "../atoms/ErrorLabel";
 

--- a/components/organisms/PhaseBanner.js
+++ b/components/organisms/PhaseBanner.js
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { useTranslation } from "next-i18next";
 import { ActionButton } from "../atoms/ActionButton";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import Joi from "joi";
 import { ErrorLabel } from "../atoms/ErrorLabel";
 
@@ -73,6 +73,11 @@ export const PhaseBanner = ({ phase, children, feedbackActive }) => {
     } else {
       setFeedbackError(error.message);
     }
+
+    window.scrollTo({
+      top: 0,
+      behavior: "smooth",
+    });
   };
 
   return (

--- a/components/organisms/PhaseBanner.js
+++ b/components/organisms/PhaseBanner.js
@@ -125,7 +125,7 @@ export const PhaseBanner = ({ phase, children, feedbackActive }) => {
                     showFeedback ? "text-sm" : "text-p"
                   } leading-7 lg:leading-5`}
                   dangerouslySetInnerHTML={{
-                    __html: showFeedback ? "&#9660;" : "&#9656;",
+                    __html: showFeedback ? "&#9660;" : "&#11208;",
                   }}
                 />
                 <strong className="mt-2 lg:mt-0 ml-2 group-hover:underline">


### PR DESCRIPTION
# Description

[#574 Submitting feedback with the Feedback component does not scroll user back to the top of the page](https://trello.com/c/rlFtdTBe)

Added functionality to Feedback component's `onSubmitHandler` that smooth scrolls back to the top of the screen upon submitting the form. I changed the html code for the right facing arrow so it is the same size as the downwards facing arrow as they were two different sizes before.

## Test Instructions

1. Pull in branch
2. Type `npm run dev`
3. Set `feedbackActive` to true in `Layout` 
4. View the page on a mobile resolution (I used iPhone 5 to test)
5. Type something into the feedback text field and click submit to verify that it scrolls back to the top


## Checklist

- [x] Update CHANGELOG

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
