### PR TITLE
Signup for required field fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+## Fixed
+
+- Fix the year of birth question on signup for to indicate it's a required field
+
 ## [v1.1.1] - 2021-09-24
 
 ## Changed

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -538,6 +538,7 @@ export default function Signup(props) {
                 id="yearOfBirthRange"
                 boldLabel
                 ignoreSort
+                required
                 name="yearOfBirthRange"
                 value={yearOfBirthRange}
                 error={yearOfBirthRangeError}


### PR DESCRIPTION
# Description

Missed the required field for the year of birth question, this PR adds the required label

![image](https://user-images.githubusercontent.com/34345435/134922277-d28f71ac-3630-47ce-8237-e923b443b8ff.png)

## Acceptance Criteria

Year of birth question on signup form properly shows the required label


## Checklist

- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated
- [x] Update CHANGELOG

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
