### PR TITLE
Feedback a11y fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Updated content on the experiments, about and sign up pages
 - Updated French path in French language
+- Added text to the feedback form to clearly indicate that the text area is required
+
+## Fixed
+
+- Screen reader users are now notified of the current state of the feedback form (whether it's expanded or collapsed)
+- The error message that appears when a user submits an empty feedback form is now announced to screen reader users
+- The two `<p>` tags above the feedback form textarea are now announced to screen reader users by use of `aria-describedby`
+- The feedback form close button is now before the `<h2>` in page order
 
 ## [v1.1.2] - 2021-09-27
 

--- a/components/organisms/PhaseBanner.js
+++ b/components/organisms/PhaseBanner.js
@@ -39,7 +39,7 @@ export const PhaseBanner = ({ phase, children, feedbackActive }) => {
   const [feedback, setFeedback] = useState("");
   const [feedbackError, setFeedbackError] = useState("");
 
-  let toggleSummary = async (e) => {
+  let toggleForm = async (e) => {
     if (showFeedback) {
       toggle.current = "Collapsed";
     } else {
@@ -145,7 +145,7 @@ export const PhaseBanner = ({ phase, children, feedbackActive }) => {
             {feedbackActive ? (
               <button
                 id="feedbackButton"
-                onClick={toggleSummary}
+                onClick={toggleForm}
                 className="group outline-none focus:outline-white-solid bg-circle-color font-body text-xs lg:text-sm text-white flex text-left lg:ml-4 my-2 lg:my-0"
                 data-testid="feedbackButton"
               >
@@ -191,7 +191,7 @@ export const PhaseBanner = ({ phase, children, feedbackActive }) => {
                 </span>
                 <button
                   id="feedbackClose"
-                  onClick={toggleSummary}
+                  onClick={toggleForm}
                   className="font-body text-white flex mt-2.5 lg:mt-0 outline-none focus:outline-white-solid"
                   data-testid="closeButton"
                 >
@@ -216,7 +216,7 @@ export const PhaseBanner = ({ phase, children, feedbackActive }) => {
             <div className="layout-container text-white pb-4">
               <button
                 id="feedbackClose"
-                onClick={toggleSummary}
+                onClick={toggleForm}
                 className="flex float-right pt-4 font-body text-white flex mt-2.5 lg:mt-0 outline-none focus:outline-white-solid"
                 data-testid="closeButton"
               >

--- a/components/organisms/PhaseBanner.js
+++ b/components/organisms/PhaseBanner.js
@@ -240,6 +240,7 @@ export const PhaseBanner = ({ phase, children, feedbackActive }) => {
                   className="text-xs lg:text-sm font-body font-bold"
                 >
                   {t("doBetter")}
+                  <span className="text-gray-md"> {t("required")}</span>
                 </label>
                 <p className="text-xs lg:text-sm my-2">{t("doNotInclude")}</p>
                 <p className="text-xs lg:text-sm my-2">{t("maximum2000")}</p>


### PR DESCRIPTION
# Description

[#569 Address PhaseBanner/Feedback component issues raised in the a11y audit](https://trello.com/c/qHCQE31w)

Took care of several of the a11y issues outlined in the task linked above. These include: 

- I've made it more clear that the text area is a required field
- I've added a function that makes the screen reader announce whatever phrase is passed to it. Using this, the screen reader now announces the state of the feedback form (whether it is expanded or collapsed) when clicked. The state is also announced when a keyboard user tabs to the button element
- Using the same function as in the above task, the error message that appears whenever a user submits an empty feedback form is now announced by the screen reader
- The two `<p>` tags above the feedback form textarea are now announced to screen reader users by use of `aria-describedby`
- The feedback form close button is now before the `<h2>` in page order


## Test Instructions

1. Pull in branch
2. Change `feedbackActive={feedbackActive}` to `feedbackActive={true}` in `Layout.js`
3. Type `npm run dev`
4. Use your favorite screen reader to confirm the above changes/fixes work as expected

## Checklist

- [x] Strings use placeholders for translation (No hard coded strings)
- [x] Update CHANGELOG

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
