### PR TITLE
Descriptive label for close button

### DIFF
--- a/components/organisms/PhaseBanner.js
+++ b/components/organisms/PhaseBanner.js
@@ -163,13 +163,13 @@ export const PhaseBanner = ({ phase, children, feedbackActive }) => {
                   onClick={() => setShowFeedback(!showFeedback)}
                   className="font-body text-white flex mt-2.5 lg:mt-0 outline-none focus:outline-white-solid"
                   data-testid="closeButton"
+                  aria-label="Close the expanded feedback section"
                 >
-                  <span
-                    id="close"
-                    className="text-h2 lg:text-h1 leading-4 lg:leading-10"
-                  >
-                    &times;
-                  </span>
+                  <img
+                    src="/close-x.svg"
+                    alt="Close button"
+                    className="mt-0.5 lg:mt-3.5"
+                  />
                   <span className="text-xs leading-4 lg:text-sm underline ml-1 lg:ml-2 lg:leading-10">
                     {t("close")}
                   </span>
@@ -192,13 +192,13 @@ export const PhaseBanner = ({ phase, children, feedbackActive }) => {
                   onClick={() => setShowFeedback(!showFeedback)}
                   className="font-body text-white flex mt-2.5 lg:mt-0 outline-none focus:outline-white-solid"
                   data-testid="closeButton"
+                  aria-label="Close the expanded feedback section"
                 >
-                  <span
-                    id="close"
-                    className="text-h3 lg:text-h2 leading-4 lg:leading-10"
-                  >
-                    &times;
-                  </span>
+                  <img
+                    src="/close-x.svg"
+                    alt="Close button"
+                    className="mt-0.5 lg:mt-3.5"
+                  />
                   <span className="text-xs leading-4 lg:text-sm underline ml-2 lg:leading-10">
                     {t("close")}
                   </span>

--- a/public/close-x.svg
+++ b/public/close-x.svg
@@ -1,0 +1,3 @@
+<svg width="12" height="12" viewBox="0 0 12 12" fill="white" xmlns="http://www.w3.org/2000/svg">
+<path d="M12 1.05L10.95 0L6 4.95L1.05 0L0 1.05L4.95 6L0 10.95L1.05 12L6 7.05L10.95 12L12 10.95L7.05 6L12 1.05Z" fill="white"/>
+</svg>


### PR DESCRIPTION
# Description

[ Address PhaseBanner/Feedback component issues raised in the a11y audit](https://trello.com/c/qHCQE31w/569-569-address-phasebanner-feedback-component-issues-raised-in-the-a11y-audit)

Added an aria-label to the close button and removed "times" to put an image instead.

## Acceptance Criteria

Close button should have a descriptive label (aria-label) and should not read times.

## Test Instructions

1. Run the code
2. Check to see if the close button has a descriptive aria label
3. You can use a screen reader to check it out

## Checklist

- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated
- [ ] Update CHANGELOG

## Product and Sprint Backlog

[Trello](https://trello.com/b/ZqWtJSyh/alpha-site-board)
