### PR TITLE
Removed babel config so Next uses swc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["next/babel"]
-}


### PR DESCRIPTION
# Description

Small PR that removes the babel config file. NextJS was recently updated to version 12 and with that they replaced Babel with SWC, a Rust-based compiler that is up to 17x faster than Babel when compiling individual files and up to 5x faster Fast Refresh. 

Since Babel is still supported through backwards compatibility, the config needed to be removed so that NextJS uses SWC by default. 

You can read more about this change and everything else that was added in NextJS 12 [here](https://nextjs.org/blog/next-12#faster-builds-and-fast-refresh-with-rust-compiler).

## Test Instructions

1. Pull in branch
2. Build locally to compare speed and that everything works as expected
