### PR TITLE
Update IE button states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Added
 
+- Added copied state for IE error
 - Added `/notsupported` which IE users are redirected to by making use of the next.js redirects function
 - Added the `CopyToClickboard` component as part of the `/notsupported` page
 - Added IE specific styling to `globals.css` for the `/notsupported` page

--- a/components/molecules/CopyToClipboard.js
+++ b/components/molecules/CopyToClipboard.js
@@ -27,6 +27,7 @@ export function CopyToClipboard(props) {
         <ActionButton
           id={props.buttonId}
           className={`w-full ${props.buttonStyle}`}
+          onClick={props.onClick}
         >
           {props.buttonText}
         </ActionButton>
@@ -75,6 +76,11 @@ CopyToClipboard.propTypes = {
    * call back for when the value of the text field changes
    */
   onChange: PropTypes.func,
+
+  /**
+   * call back for when the link has been copied
+   */
+  onClick: PropTypes.func,
 
   /**
    * message to display if there is an error

--- a/pages/notsupported.js
+++ b/pages/notsupported.js
@@ -4,9 +4,12 @@ import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { ActionButton } from "../components/atoms/ActionButton";
 import { useEffect } from "react";
 import { CopyToClipboard } from "../components/molecules/CopyToClipboard";
+import { useState } from "react";
 
 export default function error404(props) {
   const { t } = useTranslation("common");
+  const [enCopied, setEnCopied] = useState(false);
+  const [frCopied, setFrCopied] = useState(false);
 
   useEffect(() => {
     if (process.env.NEXT_PUBLIC_ADOBE_ANALYTICS_URL) {
@@ -15,6 +18,15 @@ export default function error404(props) {
     }
   }, []);
 
+  function onClickEn() {
+    setEnCopied(true);
+    setFrCopied(false);
+  }
+
+  function onClickFr() {
+    setFrCopied(true);
+    setEnCopied(false);
+  }
   return (
     <>
       <div className="min-h-screen relative">
@@ -178,9 +190,10 @@ export default function error404(props) {
               </p>
               <CopyToClipboard
                 buttonId="enClipboardButton"
-                buttonText="Copy link"
-                buttonStyle="ieButton"
+                buttonText={enCopied ? "Copied!" : "Copy link"}
+                buttonStyle={enCopied ? "ieButtonCopied" : "ieButton"}
                 value="http://alpha.service.canada.ca/home"
+                onClick={onClickEn}
                 id="enClipboard"
                 name="clipboard_en"
                 textFieldStyle="ieTextField"
@@ -215,10 +228,11 @@ export default function error404(props) {
                   ce navigateur.
                 </p>
                 <CopyToClipboard
-                  buttonText="Copier lien"
+                  buttonText={frCopied ? "Copié!" : "Copier lien"}
                   buttonId="frClipboardButton"
-                  buttonStyle="ieButton"
+                  buttonStyle={frCopied ? "ieButtonCopied" : "ieButton"}
                   value="http://alpha.service.canada.ca/fr/home"
+                  onClick={onClickFr}
                   id="frClipboard"
                   name="clipboard_fr"
                   textFieldStyle="ieTextField"

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -214,6 +214,7 @@ html {
     border-color: #1D5B90;
     border-width: 1px;
   }
+
   .ieButton:focus {
     box-shadow: 0 0 0 1pt black;
   }
@@ -223,6 +224,23 @@ html {
   .ieButton:active {
     background-color: #26374a;
   }
+
+  .ieButtonCopied {
+    background-color: #278400;
+    color: white;
+    border-radius: 7px;
+    border-color: #278400;
+    border-width: 1px;
+  }
+
+  .ieButtonCopied:hover {
+    background-color: #237600;
+  }
+
+  .ieButtonCopied:active {
+    background-color: #278400;
+  }
+
   .ieTextField {
     border-width: 2px;
     border-color: #D1D5DB;


### PR DESCRIPTION
# Description

[New Copied State for IE Error](https://jira-dev.bdm-dev.dts-stn.com/secure/RapidBoard.jspa?rapidView=96&projectKey=SCL&view=planning&selectedIssue=SCL-553&quickFilter=277&issueLimit=100)

Add a copied state once a button is clicked on IE error page
![image](https://user-images.githubusercontent.com/72703030/143328121-85db925b-ab8e-4a3d-a935-d59c741d455f.png)

## Test Instructions

1. Run the code and open Internet explorer or simply add "/notsupported" at the end of the url
2. Check to see if the button states match with the figma design

## Checklist

- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated
- [ ] Update CHANGELOG

## Product and Sprint Backlog

[Jira](https://jira-dev.bdm-dev.dts-stn.com/secure/RapidBoard.jspa?rapidView=96&projectKey=SCL)
