### PR TITLE
Fixed button on smaller screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Fixed infinite redirect issue when switch language and refresh the page
 - Fixed tailwind configuration so font and some css are showing properly again
 - Fixed feedback widget so it sends the proper payload to the feedback API
+- Fixed issue where the continue button and submit button on the `signup-info` and `signup` pages would go offscreen at <280px
 
 ## Changed
 

--- a/pages/signup-info.js
+++ b/pages/signup-info.js
@@ -167,7 +167,7 @@ export default function SignupInfo(props) {
           <div className="my-16 mb-36">
             <ActionButton
               id="signupInfo-continue"
-              className="text-base font-bold px-24 py-3 rounded bg-custom-blue-blue text-white border border-custom-blue-blue active:bg-custom-blue-dark hover:bg-custom-blue-light"
+              className="text-base xxs:px-16 font-bold xs:px-24 py-3 rounded bg-custom-blue-blue text-white border border-custom-blue-blue active:bg-custom-blue-dark hover:bg-custom-blue-light"
               dataCy="signupInfo-continue"
               dataTestId="signupInfo-continue"
               href={t("signupRedirect")}

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -1032,7 +1032,7 @@ export default function Signup(props) {
                 <ErrorLabel message={agreeToConditionsError} />
               ) : undefined}
               <CheckBox
-                className="h-187px sm:h-32"
+                className="h-187px sm:h-32 xxs:mb-6 xs:mb-0"
                 checked={agreeToConditions === "yes"}
                 onChange={(checked, name, value) => {
                   if (checked) {
@@ -1055,7 +1055,7 @@ export default function Signup(props) {
             </Link>
             <ActionButton
               id="signup-submit"
-              className="rounded w-72 my-6 text-base font-bold py-2"
+              className="rounded xxs:w-full xs:w-72 my-6 text-base font-bold py-2"
               type="submit"
               dataCy="signup-submit"
               dataTestId="signup-submit"


### PR DESCRIPTION
# Description

Quick PR to address @shawn320 's comment on branch #439 that was made after I merged. I adjusted padding on the Continue button on `signup-info` based on breakpoints so it no longer goes off screen. I also attempted to do this on the `signup` page but also found that a lot of text is overlapping <280px so that will have to be fixed in a separate PR. 


## Test Instructions

1. Pull in branch
2. Type `npm run dev`
3. Navigate to `/signup-info`
4. Adjust screen size to ensure button never overlaps or goes off screen
5. Do the same on `signup` page (going below 280px causes a lot of the other text on the page to start overlapping as mentioned above, I've only adding conditional sizing based on breakpoints for the button)


## Checklist

- [x] Strings use placeholders for translation (No hard coded strings)
- [x] Unit tests have been added/updated
- [x] Update CHANGELOG

## Product and Sprint Backlog

[Jira](https://jira-dev.bdm-dev.dts-stn.com/secure/RapidBoard.jspa?rapidView=96&projectKey=SCL)
