### PR TITLE
Add h2

### DIFF
--- a/components/molecules/Experiment.js
+++ b/components/molecules/Experiment.js
@@ -20,17 +20,19 @@ export const Experiment = (props) => {
       data-testid={props.dataTestId}
       data-cy={props.dataCy}
     >
-      <Link href={props.href}>
-        <a
-          className="flex block text-p text-custom-blue-projects-link underline hover:opacity-70"
-          tabIndex="0"
-        >
-          {props.title}
-          {props.href.substring(0, 8) === "https://" ? (
-            <img src="/external-link.svg" className="px-1 py-2" />
-          ) : undefined}
-        </a>
-      </Link>
+      <h2>
+        <Link href={props.href}>
+          <a
+            className="flex block text-p text-custom-blue-projects-link underline hover:opacity-70"
+            tabIndex="0"
+          >
+            {props.title}
+            {props.href.substring(0, 8) === "https://" ? (
+              <img src="/external-link.svg" className="px-1 py-2" />
+            ) : undefined}
+          </a>
+        </Link>
+      </h2>
       <span
         className={`block w-max py-2 px-2 my-4 font-body font-bold border-l-4 ${
           "border-" + (tagColours[props.tag] || "gray-experiment") + "-darker"


### PR DESCRIPTION
# Description

[Project cards missing header](https://jira-dev.bdm-dev.dts-stn.com/browse/SCL-563)

The project cards should be using an h2 for the name of the project, but it is currently just an "a" tag. This is easily solved by wrapping the "a" with the h2.

## Test Instructions

1. Run the code locally or check it out manually
2. Check to see if the project cards have a h2 header

## Checklist

- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated
- [ ] Update CHANGELOG

## Product and Sprint Backlog

[Jira](https://jira-dev.bdm-dev.dts-stn.com/secure/RapidBoard.jspa?rapidView=96&projectKey=SCL)
