### PR TITLE
expand and collap state on checkbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 # Changed
 
+- Add collape and expand state on the checkbox on the Report A Problem form
 - Add border to feedback popup, and give background a darker color
 - Lock scroll when feedback popup is active
 - Deactivate auto focus when feedback popup is active

--- a/components/atoms/CheckBox.js
+++ b/components/atoms/CheckBox.js
@@ -24,7 +24,6 @@ export function CheckBox(props) {
         name={props.name}
         value={props.value}
         type="checkbox"
-        aria-label={props.ariaLabel}
         onChange={(e) =>
           props.onChange(
             props.uncontrolled ? !e.currentTarget.checked : props.checked,
@@ -46,7 +45,7 @@ export function CheckBox(props) {
         {props.showRequiredLabel ? (
           <b className="text-error-border-red">*</b>
         ) : undefined}{" "}
-        {props.label}{" "}
+        {props.label} <p className="sr-only">{props.expandState}</p>
         {props.showRequiredLabel ? (
           <b className="text-error-border-red">{t("required")}</b>
         ) : undefined}

--- a/components/atoms/CheckBox.js
+++ b/components/atoms/CheckBox.js
@@ -24,6 +24,7 @@ export function CheckBox(props) {
         name={props.name}
         value={props.value}
         type="checkbox"
+        aria-label={props.ariaLabel}
         onChange={(e) =>
           props.onChange(
             props.uncontrolled ? !e.currentTarget.checked : props.checked,

--- a/components/atoms/CheckBox.js
+++ b/components/atoms/CheckBox.js
@@ -45,7 +45,7 @@ export function CheckBox(props) {
         {props.showRequiredLabel ? (
           <b className="text-error-border-red">*</b>
         ) : undefined}{" "}
-        {props.label} <p className="sr-only">{props.expandState}</p>
+        {props.label} {<p className="sr-only">{props.expandState}</p>}
         {props.showRequiredLabel ? (
           <b className="text-error-border-red">{t("required")}</b>
         ) : undefined}

--- a/components/molecules/OptionalTextField.js
+++ b/components/molecules/OptionalTextField.js
@@ -3,6 +3,7 @@ import { CheckBox } from "../atoms/CheckBox";
 import { TextField } from "../atoms/TextField";
 import { MultiTextField } from "../atoms/MultiTextField";
 import { RadioField } from "../atoms/RadioField";
+import { useTranslation } from "next-i18next";
 import PropTypes from "prop-types";
 
 /**
@@ -11,13 +12,14 @@ import PropTypes from "prop-types";
 export function OptionalTextField(props) {
   let [showTextField, setShowTextField] = useState(props.checked || false);
   const [expandState, setExpandState] = useState("collapsed");
+  const { t } = useTranslation("common");
   let handleCheckChange = (wasChecked, name, value) => {
     if (wasChecked) {
       setShowTextField(false);
-      setExpandState("collapsed");
+      setExpandState(t("collapsed"));
     } else {
       setShowTextField(true);
-      setExpandState("expanded");
+      setExpandState(t("expanded"));
     }
 
     if (props.onControlChange) {

--- a/components/molecules/OptionalTextField.js
+++ b/components/molecules/OptionalTextField.js
@@ -10,11 +10,14 @@ import PropTypes from "prop-types";
  */
 export function OptionalTextField(props) {
   let [showTextField, setShowTextField] = useState(props.checked || false);
+  const [expanded, setExpanded] = useState("collapsed");
   let handleCheckChange = (wasChecked, name, value) => {
     if (wasChecked) {
       setShowTextField(false);
+      setExpanded("collapsed");
     } else {
       setShowTextField(true);
+      setExpanded("expanded");
     }
 
     if (props.onControlChange) {
@@ -36,6 +39,7 @@ export function OptionalTextField(props) {
           dataTestId={props.controlDataTestId}
           required={props.controlRequired}
           dataCy={props.controlDataCy}
+          ariaLabel={expanded}
         />
       )}
       {props.controlType === "radiofield" && (

--- a/components/molecules/OptionalTextField.js
+++ b/components/molecules/OptionalTextField.js
@@ -10,14 +10,14 @@ import PropTypes from "prop-types";
  */
 export function OptionalTextField(props) {
   let [showTextField, setShowTextField] = useState(props.checked || false);
-  const [expanded, setExpanded] = useState("collapsed");
+  const [expandState, setExpandState] = useState("collapsed");
   let handleCheckChange = (wasChecked, name, value) => {
     if (wasChecked) {
       setShowTextField(false);
-      setExpanded("collapsed");
+      setExpandState("collapsed");
     } else {
       setShowTextField(true);
-      setExpanded("expanded");
+      setExpandState("expanded");
     }
 
     if (props.onControlChange) {
@@ -39,7 +39,7 @@ export function OptionalTextField(props) {
           dataTestId={props.controlDataTestId}
           required={props.controlRequired}
           dataCy={props.controlDataCy}
-          ariaLabel={expanded}
+          expandState={expandState}
         />
       )}
       {props.controlType === "radiofield" && (

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -72,6 +72,8 @@
   "reportAProblemPrivacyStatementLink": "https://alphasite.dts-stn.com/signup/privacy",
   "reportAProblemFeedbackConfidential": "Your feedback will be confidential.",
   "reportAProblemSubmit": "Submit",
+  "expanded": "expanded",
+  "collapsed": "collapsed",
   "menuTitle": "MENU",
   "menuLink1": "Explore our projects",
   "menuLink2": "About these labs",

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -32,6 +32,8 @@
   "reportAProblemPrivacyStatementLink": "https://www.canada.ca/fr/transparence/confidentialite.html",
   "reportAProblemFeedbackConfidential": "Vos commentaires sont confidentiels.",
   "reportAProblemSubmit": "Soumettre",
+  "expanded": "affiché",
+  "collapsed": "masqué",
   "projectsAndExplorationTitle": "Participez à l’élaboration des services de demain",
   "experimentsAndExploration-1/4": "Bienvenue dans les laboratoires virtuels de Service Canada. Nous vous invitons à explorer les travaux en cours et analyser des idées expérimentales avec notre équipe travaillant au sein du gouvernement du Canada. Nous avons besoin de votre participation, dans toutes les communautés, afin de créer des services inclusifs répondant aux besoins de tous les Canadiens.",
   "experimentsAndExploration-2/4": "\n\nComment vous pouvez nous aider dans ce qui suit :",


### PR DESCRIPTION
# Description

Added `aria-label` attribute on the checkbox on the Report A Problem form. The value of aria-label will either be `collapsed` or `expanded` depend on the state of the checkbox. By default, it's `collapsed`. When checkbox is checked, the value will be `expanded`

I tried to use `aria-expanded` at the beginning, but this attribute does not work on checkbox. I've tested it on different browser, but `aria-expanded` seems only work on buttons. The screen reader won't anounce it on checkbox.

## Test Instructions

Open the Report A Problem form on any pages. Test with screen reader

## Checklist

- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated
- [x] Update CHANGELOG

## Product and Sprint Backlog

[Report A Problem Accessibility Update](https://jira-dev.bdm-dev.dts-stn.com/secure/RapidBoard.jspa?rapidView=96&projectKey=SCL&view=detail&selectedIssue=SCL-573)
