### PR TITLE
Add OWASP Zap testing to github action

### DIFF
--- a/.github/workflows/zap-test.yml
+++ b/.github/workflows/zap-test.yml
@@ -1,0 +1,22 @@
+name: ZAP
+
+on:
+  pull_request:
+    branches: 
+      - main
+
+jobs:
+  zap_scan:
+    runs-on: ubuntu-latest
+    name: Scan the webapplication
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: ZAP Scan
+        uses: zaproxy/action-full-scan@v0.3.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # docker_name: 'owasp/zap2docker-stable'
+          target: 'https://alphasite.dts-stn.com/'
+          # rules_file_name: '.zap/rules.tsv'
+          # cmd_options: '-a' 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Added
 
+- Added OWASP ZAP testing to github action
 - Added copied state for IE error
 - Added `/notsupported` which IE users are redirected to by making use of the next.js redirects function
 - Added the `CopyToClickboard` component as part of the `/notsupported` page


### PR DESCRIPTION
# Description

[SCL-576](https://jira-dev.bdm-dev.dts-stn.com/browse/SCL-576)

Added zap testing to github action. Since the digital centre project already has this, I just took what they have and change the target url to Alpha. 

## Test Instructions

Tested by creating this pr.

## Checklist

- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated
- [x] Update CHANGELOG
