### PR TITLE
submit feedback bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Fixed
 
+- Fixed feedback submit bug when submitting feedback for the second attempt
 - Fixed infinite redirect issue when switch language and refresh the page
 - Fixed tailwind configuration so font and some css are showing properly again
 - Fixed feedback widget so it sends the proper payload to the feedback API

--- a/components/molecules/FeedbackWidget.js
+++ b/components/molecules/FeedbackWidget.js
@@ -28,6 +28,7 @@ export const FeedbackWidget = ({
   useEffect(() => {
     if (!showFeedback) {
       setFeedbackError("");
+      setFeedback("");
     }
   }, [showFeedback]);
 
@@ -97,6 +98,7 @@ export const FeedbackWidget = ({
       // if the response is good, show thank you message
       if (response.status === 201 || response.status === 200) {
         await setResponse(t("thankYouFeedback"));
+        setFeedback("");
       } else {
         await setResponse(t("sorryFeedback"));
       }
@@ -104,7 +106,6 @@ export const FeedbackWidget = ({
       setSubmitted(true);
       setFeedbackClose(false);
       setFocusAfterSubmit();
-      setFeedback("");
     } else {
       setFeedbackError(error.message);
       srSpeak(error.message);
@@ -264,6 +265,7 @@ export const FeedbackWidget = ({
                     className={
                       "text-input font-body w-full min-h-40px shadow-sm text-form-input-gray border-2 my-2 py-6px px-12px rounded"
                     }
+                    value={feedback}
                     onChange={(e) => setFeedback(e.currentTarget.value)}
                   />
                   <ActionButton


### PR DESCRIPTION
# Description

[Feedback submit bug](https://jira-dev.bdm-dev.dts-stn.com/browse/SCL-581)

After a successful or failed submit, if the user try to submit the feedback again, the "This field is required" error will show up even if the input still exists. The purpose of this pr is to fix this bug.

- If the feedback successfully submited, the input field should be cleared.
- If the feedback submit is failed, the input should remain, but the required error should not show up when submit again.
- When the feedback popup is closed, the input should be cleared as well. 

## Checklist

- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated
- [x] Update CHANGELOG
