### PR TITLE
Fixed issue with fonts not loading

### DIFF
--- a/.storybook/fonts.css
+++ b/.storybook/fonts.css
@@ -1,0 +1,1 @@
+@import url("https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&family=Noto+Sans:wght@400;700&display=swap");

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,9 +1,9 @@
 import * as nextImage from "next/image";
 import "../icomoon/style.css";
 import "../styles/globals.css";
-import "../styles/fonts.css";
 import "../styles/forms.css";
 import "../styles/menu.css";
+import "./fonts.css"
 
 import i18n from "./i18n.js";
 import { I18nProviderWrapper } from "./i18nextProviderWrapper";

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -2,7 +2,6 @@ import { appWithTranslation } from "next-i18next";
 import "../icomoon/style.css";
 import "../styles/globals.css";
 import "../styles/forms.css";
-import "../styles/fonts.css";
 import "../styles/menu.css";
 import Head from "next/head";
 

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -37,6 +37,11 @@ class MyDocument extends Document {
       <Html>
         <Head>
           <meta httpEquiv="Content-Security-Policy" content={getCsp()} />
+          {/* Import fonts */}
+          <link
+            href="https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&family=Noto+Sans:wght@400;700&display=swap"
+            rel="stylesheet"
+          />
         </Head>
         <body>
           <Main />

--- a/styles/fonts.css
+++ b/styles/fonts.css
@@ -1,1 +1,0 @@
-@import url("https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&family=Noto+Sans:wght@400;700&display=swap")


### PR DESCRIPTION
# Description

[Figure out why fonts are broken](https://jira-dev.bdm-dev.dts-stn.com/browse/SCL-579)

Fonts across the site were not loading properly, and was displaying system defaut fonts.

The issue appears to have been related to the way fonts were previously being imported into the application which was through a `styles/fonts.css` file that included an  `@import url` statement that gave Google Fonts as a remote source. This was working for some time but was broken at some point.

To fix this, I found alternative Nextjs documentation on how to import fonts from Google Fonts while leveraging Nextjs font optimization through creating a `<link>` in our _document.js `<Head>` element that links out the fonts we need. This fixed the issue.

## Acceptance Criteria

Fonts (Lato and Noto Sans) should be loading and display properly.

## Test Instructions

1. Build and run the app in prod
2. see that fonts are displayed correctly

## Product and Sprint Backlog

[Jira](https://jira-dev.bdm-dev.dts-stn.com/secure/RapidBoard.jspa?rapidView=96&projectKey=SCL)
