### PR TITLE
added public servant question

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Added language detection to redirect user to the page in prefered language
 - Added a signup info page prior to the signup page
 - Added metadata for `/500`, `/error`, `/404`, `/notsupported`, `/projects/virtual-assistant`, `/projects/digital-centre`, `/signup-info`, and the splash page
+- Added an optional `Are you a public servant` question to sign-up form
 
 # Changed
 

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -192,6 +192,7 @@ export default function Signup(props) {
   const [minorityGroupOther, setMinorityGroupOther] = useState("");
 
   const [incomeLevel, setIncomeLevel] = useState("");
+  const [publicServant, setPublicServant] = useState("");
 
   const [agreeToConditions, setAgreeToConditions] = useState("");
   const [agreeToConditionsError, setAgreeToConditionsError] = useState("");
@@ -238,6 +239,7 @@ export default function Signup(props) {
     setMinorityGroup([]);
     setMinorityGroupOther("");
     setIncomeLevel("");
+    setPublicServant("");
     setAgreeToConditions("");
   };
 
@@ -268,6 +270,7 @@ export default function Signup(props) {
       minorityGroup,
       minorityGroupOther,
       incomeLevel,
+      publicServant,
       agreeToConditions,
     };
 
@@ -1038,6 +1041,31 @@ export default function Signup(props) {
                   checked={incomeLevel === "preferNotToAnswer"}
                   onChange={(checked, name, value) => setIncomeLevel(value)}
                   value="preferNotToAnswer"
+                />
+              </fieldset>
+
+              <fieldset className="mb-16">
+                <legend className="block leading-tight text-sm lg:text-p font-body mb-5 font-bold">
+                  {t("formPublicServant")}{" "}
+                  <span className="inline text-form-input-gray text-sm lg:text-p not-italic">
+                    {t("optional")}
+                  </span>
+                </legend>
+                <RadioField
+                  label={t("yes")}
+                  id="publicServantYes"
+                  name="publicServant"
+                  checked={publicServant === "yes"}
+                  onChange={(checked, name, value) => setPublicServant(value)}
+                  value="yes"
+                />
+                <RadioField
+                  label={t("no")}
+                  id="publicServantNo"
+                  name="publicServant"
+                  checked={publicServant === "no"}
+                  onChange={(checked, name, value) => setPublicServant(value)}
+                  value="no"
                 />
               </fieldset>
 

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -184,6 +184,7 @@
   "otherMinority": "Another visible minority group",
   "otherMinorityDetails": "If “Another visible minority group”, please specify",
   "formIncome": "What is your approximate annual household income (before taxes)?",
+  "formPublicServant": "Are you currently working as a public servant?",
   "income1": "Less than $30,000",
   "income2": "$30,001 to $59,999",
   "income3": "$60,000 to $99,999",

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -184,6 +184,7 @@
   "otherMinority": "Autre groupe de minorité visible",
   "otherMinorityDetails": "Si vous avez répondu « Autre groupe des minorités visibles », veuillez préciser.",
   "formIncome": "Quel est le revenu annuel approximatif de votre ménage (avant impôts)?",
+  "formPublicServant": "Travaillez-vous actuellement en tant que fonctionnaire?",
   "income1": "Moins de 30 000 $",
   "income2": "De 30 001 $ à 59 999 $",
   "income3": "De 60 000 $ à 99 999 $",


### PR DESCRIPTION
# Description

[Add the Public Service employee question to the signup form](https://jira-dev.bdm-dev.dts-stn.com/browse/SCL-584)

The purpose of this PR is to add an optional question to the signup form to distinguish whether or not the user signing up is a public servant.


## Test Instructions

1. Pull in branch
2. Type `npm run dev`
3. Navigate to `/signup`
4. Scroll all the way to the bottom to confirm new question is visible

## Checklist

- [x] Strings use placeholders for translation (No hard coded strings)
- [x] Unit tests have been added/updated
- [x] Update CHANGELOG

## Product and Sprint Backlog

[Jira](https://jira-dev.bdm-dev.dts-stn.com/secure/RapidBoard.jspa?rapidView=96&projectKey=SCL)
