### PR TITLE
Confirm email address

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -3,7 +3,7 @@ import "../icomoon/style.css";
 import "../styles/globals.css";
 import "../styles/forms.css";
 import "../styles/menu.css";
-import "./fonts.css"
+import "./fonts.css";
 
 import i18n from "./i18n.js";
 import { I18nProviderWrapper } from "./i18nextProviderWrapper";

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Added a signup info page prior to the signup page
 - Added metadata for `/500`, `/error`, `/404`, `/notsupported`, `/projects/virtual-assistant`, `/projects/digital-centre`, `/signup-info`, and the splash page
 - Added an optional `Are you a public servant` question to sign-up form
+- Added an `Confirm email` field to sign-up form
 
 # Changed
 

--- a/components/atoms/TextField.js
+++ b/components/atoms/TextField.js
@@ -37,12 +37,17 @@ export function TextField(props) {
           </p>
         )}
       </label>
-      <p
-        id={props.describedby}
-        className="text-xs lg:text-sm mb-5 leading-30px"
-      >
-        {t("doNotInclude")}
-      </p>
+      {props.describedby ? (
+        <p
+          id={props.describedby}
+          className="text-xs lg:text-sm mb-5 leading-30px"
+        >
+          {t("doNotInclude")}
+        </p>
+      ) : (
+        ""
+      )}
+
       {props.error ? <ErrorLabel message={props.error} /> : undefined}
       <input
         className={`text-input font-body w-full lg:w-3/4 min-h-40px shadow-sm text-form-input-gray border-2 py-6px px-12px ${

--- a/cypress/integration/signup.spec.js
+++ b/cypress/integration/signup.spec.js
@@ -30,11 +30,12 @@ describe("signup page", () => {
     cy.get('[data-cy="signup-submit"]').click();
     cy.url().should("contains", "/signup");
     cy.get('[data-cy="error-box"').should("exist");
-    cy.get('[data-cy="error-box-items"').children().should("have.length", 4);
+    cy.get('[data-cy="error-box-items"').children().should("have.length", 5);
   });
 
   it("Validates that an email is entered in the email field", () => {
     cy.get('[id="email"]').type("not an email");
+    cy.get('[id="confirmEmail"]').type("not an email");
     cy.get('[id="yearOfBirthRange-choice"]').select("before1936");
     cy.get('[id="languageEn"]').click();
     cy.get('[id="agreeToConditions"]').click();
@@ -46,6 +47,7 @@ describe("signup page", () => {
 
   it("Validates age of user is greater or equal to 18", () => {
     cy.get('[id="email"]').type("some@email.com");
+    cy.get('[id="confirmEmail"]').type("some@email.com");
     cy.get('[id="yearOfBirthRange-choice"]').select("after2003");
     cy.get('[id="languageEn"]').click();
     cy.get('[id="agreeToConditions"]').click();
@@ -57,6 +59,7 @@ describe("signup page", () => {
 
   it("Validates disability field is required if yes is selected", () => {
     cy.get('[id="email"]').type("some@email.com");
+    cy.get('[id="confirmEmail"]').type("some@email.com");
     cy.get('[id="yearOfBirthRange-choice"]').select("before1936");
     cy.get('[id="languageEn"]').click();
     cy.get('[id="agreeToConditions"]').click();
@@ -70,6 +73,7 @@ describe("signup page", () => {
 
   it("Validates disability field is not required after yes has been unselected (selected no)", () => {
     cy.get('[id="email"]').type("some@email.com");
+    cy.get('[id="confirmEmail"]').type("some@email.com");
     cy.get('[id="yearOfBirthRange-choice"]').select("before1936");
     cy.get('[data-cy="btn-disability-yes"').click();
     cy.get('[data-cy="btn-disability-no"').click();
@@ -97,6 +101,7 @@ describe("signup page", () => {
     }).as("response");
 
     cy.get('[id="email"]').type("some@email.com");
+    cy.get('[id="confirmEmail"]').type("some@email.com");
     cy.get('[id="yearOfBirthRange-choice"]').select("before1936");
     cy.get('[id="languageEn"]').click();
     cy.get('[id="agreeToConditions"]').click();
@@ -121,6 +126,7 @@ describe("signup page", () => {
     cy.intercept("/api/**", { statusCode: 400 }).as("response");
 
     cy.get('[id="email"]').type("some@email.com");
+    cy.get('[id="confirmEmail"]').type("some@email.com");
     cy.get('[id="yearOfBirthRange-choice"]').select("before1936");
     cy.get('[id="languageEn"]').click();
     cy.get('[id="agreeToConditions"]').click();
@@ -142,6 +148,7 @@ describe("signup page", () => {
     cy.intercept("/api/**", { statusCode: 500 }).as("response");
 
     cy.get('[id="email"]').type("some@email.com");
+    cy.get('[id="confirmEmail"]').type("some@email.com");
     cy.get('[id="yearOfBirthRange-choice"]').select("before1936");
     cy.get('[id="languageEn"]').click();
     cy.get('[id="agreeToConditions"]').click();

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -72,7 +72,7 @@ export default function Signup(props) {
     confirmEmail: Joi.string()
       .email({ tlds: { allow: false } })
       .required()
-      .valid(Joi.ref("email"))
+      .equal(Joi.ref("email"))
       .error((errors) => {
         errors.forEach((error) => {
           switch (error.code) {
@@ -81,7 +81,7 @@ export default function Signup(props) {
               break;
             case "string.email":
               error.message = t("errorEmail");
-            case "string.valid":
+            case "any.only":
               error.message = t("emailError");
             default:
               break;
@@ -282,6 +282,7 @@ export default function Signup(props) {
     // compile data into one object
     const formData = {
       email,
+      confirmEmail,
       yearOfBirthRange,
       language,
       province,
@@ -392,6 +393,8 @@ export default function Signup(props) {
 
       // if the response is good, redirect to the thankyou page
       if (response.status === 201 || response.status === 200) {
+        // Remove confirm email since it's no longer needed
+        delete formData["confirmEmail"];
         let maskedEmail = maskEmail(formData.email);
         await push({
           pathname: "/thankyou",

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -69,6 +69,26 @@ export default function Signup(props) {
         });
         return errors;
       }),
+    confirmEmail: Joi.string()
+      .email({ tlds: { allow: false } })
+      .required()
+      .valid(Joi.ref("email"))
+      .error((errors) => {
+        errors.forEach((error) => {
+          switch (error.code) {
+            case "any.required":
+              error.message = t("emailRequired");
+              break;
+            case "string.email":
+              error.message = t("errorEmail");
+            case "string.valid":
+              error.message = t("emailError");
+            default:
+              break;
+          }
+        });
+        return errors;
+      }),
     yearOfBirthRange: Joi.string()
       .invalid(yearOptions[0].id)
       .required()
@@ -169,6 +189,9 @@ export default function Signup(props) {
   const [email, setEmail] = useState("");
   const [emailError, setEmailError] = useState("");
 
+  const [confirmEmail, setConfirmEmail] = useState("");
+  const [confirmEmailError, setConfirmEmailError] = useState("");
+
   const [yearOfBirthRange, setYearOfBirthRange] = useState("");
   const [yearOfBirthRangeError, setYearOfBirthRangeError] = useState("");
 
@@ -220,6 +243,7 @@ export default function Signup(props) {
   const handlerClearData = (e) => {
     e.preventDefault();
     setEmailError("");
+    setConfirmEmailError("");
     setLanguageError("");
     setYearOfBirthRangeError("");
     setProvinceError("");
@@ -227,6 +251,7 @@ export default function Signup(props) {
     setAgreeToConditionsError("");
 
     setEmail("");
+    setConfirmEmail("");
     setYearOfBirthRange("");
     setLanguage("");
     setGender("");
@@ -245,6 +270,7 @@ export default function Signup(props) {
     e.preventDefault();
     // clear out error values
     await setEmailError("");
+    await setConfirmEmailError("");
     await setLanguageError("");
     await setYearOfBirthRangeError("");
     await setProvinceError("");
@@ -292,6 +318,7 @@ export default function Signup(props) {
       // map error message setters to field names so that they can be called dynamically
       const errorSetFunctions = {
         email: setEmailError,
+        confirmEmail: setConfirmEmailError,
         language: setLanguageError,
         yearOfBirthRange: setYearOfBirthRangeError,
         province: setProvinceError,
@@ -538,6 +565,18 @@ export default function Signup(props) {
                 onChange={setEmail}
                 boldLabel={true}
                 describedby="emailDoNoInclude"
+                required
+              />
+              <TextField
+                className="mb-10"
+                label={t("confirmEmail")}
+                type="email"
+                name="confirmEmail"
+                id="confirmEmail"
+                error={confirmEmailError}
+                value={confirmEmail}
+                onChange={setConfirmEmail}
+                boldLabel={true}
                 required
               />
               <SelectField

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -339,5 +339,7 @@
   "signupInfoKeywords": "digital services, user experience research",
   "homeKeywords": "digital services",
   "privacyKeywords": "privacy",
-  "privacyMetaSubject": "SO Society and Culture;Privacy"
+  "privacyMetaSubject": "SO Society and Culture;Privacy",
+  "confirmEmail": "Confirm Email address",
+  "emailError": "Email must match"
 }

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -330,5 +330,7 @@
   "signupInfoKeywords": "services numériques, recherche sur l’expérience utilisateur",
   "homeKeywords": "services numériques",
   "privacyKeywords": "Renseignements personnels",
-  "privacyMetaSubject": "SO Société et culture;Vie privée"
+  "privacyMetaSubject": "SO Société et culture;Vie privée",
+  "confirmEmail": "Confirmer l'adresse courriel",
+  "emailError": "les courriels doivent être identiques"
 }


### PR DESCRIPTION
# Description

[Add a new field on the signup page for confirming email address](https://jira-dev.bdm-dev.dts-stn.com/browse/SCL-582)

Added a confirm email field with an error message
![image](https://user-images.githubusercontent.com/72703030/147691801-504411bc-54e6-4536-aaba-c8b839b748ef.png)
![image](https://user-images.githubusercontent.com/72703030/147691848-efd56e7f-9312-4ef2-9c9c-e91e6ded8a43.png)

## Acceptance Criteria

If the emails do not match, an error message should show up.

## Test Instructions

1. Fill the signup form with a different email in the confirmation email field
2. Check to see if an error shows up
3. Compare it with the Figma design

## Checklist

- [x] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated
- [x] Update CHANGELOG

## Product and Sprint Backlog

[Jira](https://jira-dev.bdm-dev.dts-stn.com/secure/RapidBoard.jspa?rapidView=96&projectKey=SCL)
