### PR TITLE
Added aria-required to language question

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Removed all the initial text on signup page
 - Updated metadata on every page according to the master content inventory
 - Updated project to use Tailwind V3
+- Updated the language question on the signup page by putting `aria-required` on the legend and removing `required` from each radio button so screen readers only announce required once for the grouping
 
 ## Fixed
 

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -607,7 +607,10 @@ export default function Signup(props) {
                 onChange={setYearOfBirthRange}
               />
               <fieldset className="mb-6">
-                <legend className="block leading-tight text-sm font-body mb-5 lg:text-p font-bold">
+                <legend
+                  className="block leading-tight text-sm font-body mb-5 lg:text-p font-bold"
+                  aria-required="true"
+                >
                   <b className="text-error-border-red">*</b> {t("formLang")}{" "}
                   <b className="text-error-border-red">{t("required")}</b>
                 </legend>
@@ -622,7 +625,6 @@ export default function Signup(props) {
                   error={languageError !== ""}
                   checked={fr ? language === "fr" : language === "en"}
                   onChange={(checked, name, value) => setLanguage(value)}
-                  required
                 />
                 <RadioField
                   label={fr ? t("en") : t("fr")}
@@ -632,7 +634,6 @@ export default function Signup(props) {
                   error={languageError !== ""}
                   checked={fr ? language === "en" : language === "fr"}
                   onChange={(checked, name, value) => setLanguage(value)}
-                  required
                 />
               </fieldset>
 


### PR DESCRIPTION
# Description

[Use aria-required on the legend instead of the radio buttons for the language preference question](https://jira-dev.bdm-dev.dts-stn.com/browse/SCL-575)

The purpose of this PR is to fix an issue where screen readers announce "required" on both radio button options when only one is required to be selected, which could lead to confusion. By removing `required` from both radio buttons and adding `aria-required="true"` to the legend, the screen reader will announce that the grouping is required rather than each individual radio button.

## Acceptance Criteria

Screen reader only announces required once on the grouping

## Test Instructions

1. Pull in branch
2. Type `npm run dev`
3. Navigate to `/signup`
4. Boot up NVDA
5. Tab to first language radio button
6. Confirm that NVDA announces `required grouping` and doesn't announce required when alternating between radio options

## Checklist

- [x] Strings use placeholders for translation (No hard coded strings)
- [x] Unit tests have been added/updated
- [x] Update CHANGELOG

## Product and Sprint Backlog

[Jira](https://jira-dev.bdm-dev.dts-stn.com/secure/RapidBoard.jspa?rapidView=96&projectKey=SCL)
