### PR TITLE
Added autocomplete prop to TextField

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Added metadata for `/500`, `/error`, `/404`, `/notsupported`, `/projects/virtual-assistant`, `/projects/digital-centre`, `/signup-info`, and the splash page
 - Added an optional `Are you a public servant` question to sign-up form
 - Added an `Confirm email` field to sign-up form
+- Added `autoComplete` prop type to TextField component
 
 # Changed
 

--- a/components/atoms/TextField.js
+++ b/components/atoms/TextField.js
@@ -66,6 +66,7 @@ export function TextField(props) {
         {...ifControlledProps}
         data-testid={props.dataTestId}
         data-cy={props.dataCy}
+        autoComplete={props.autoComplete}
       />
     </div>
   );
@@ -74,6 +75,7 @@ export function TextField(props) {
 TextField.defaultProps = {
   value: "",
   type: "text",
+  autoComplete: "off",
 };
 
 TextField.propTypes = {
@@ -171,4 +173,9 @@ TextField.propTypes = {
    * aria-describedby label id
    */
   describedby: PropTypes.string,
+
+  /**
+   * Option to enable autocomplete on field
+   */
+  autocomplete: PropTypes.string,
 };

--- a/components/atoms/TextField.js
+++ b/components/atoms/TextField.js
@@ -75,7 +75,6 @@ export function TextField(props) {
 TextField.defaultProps = {
   value: "",
   type: "text",
-  autoComplete: "off",
 };
 
 TextField.propTypes = {

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -574,6 +574,7 @@ export default function Signup(props) {
                 boldLabel={true}
                 describedby="emailDoNoInclude"
                 required
+                autoComplete="email"
               />
               <TextField
                 className="mb-10"
@@ -586,6 +587,7 @@ export default function Signup(props) {
                 onChange={setConfirmEmail}
                 boldLabel={true}
                 required
+                autoComplete="email"
               />
               <SelectField
                 label={t("formYear")}


### PR DESCRIPTION
# Description

[Add autocomplete to appropriate inputs](https://jira-dev.bdm-dev.dts-stn.com/browse/SCL-571)

Small PR that adds the `autoComplete` prop to the TextField component. By default it is set to "off" (which may not do a whole lot depending on which browser you use since Chromium browsers tend to ignore this). At this point in time this really doesn't do a whole lot since we really only have the email fields on the signup form that can take advantage of this but this will let us tailor autocomplete to our needs if we add new fields in the future.


## Test Instructions

1. Pull in branch
2. Type `npm run dev`
3. If your browser does not already have saved information, fill out the form once with information and press submit (else you should see your saved e-mail pop up when clicking on the email field)
4. Click on the email field(s) and ensure your information pops up
5. Try changing the value for `autoComplete` from `email` to `country` and click on the field to see the autocomplete suggestion change

## Checklist

- [x] Strings use placeholders for translation (No hard coded strings)
- [x] Unit tests have been added/updated
- [x] Update CHANGELOG

## Product and Sprint Backlog

[Jira](https://jira-dev.bdm-dev.dts-stn.com/secure/RapidBoard.jspa?rapidView=96&projectKey=SCL)
