### PR TITLE
Fix CallToAction redirect on projects page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Fixed issue where the continue button and submit button on the `signup-info` and `signup` pages would go offscreen at <280px
 - Fixed re-send to get correct unsubscribe email
 - Fixed how we handle data from Strapi
+- Fixed CallToAction redirect on `/projects` page so that it links to `/signup-info` instead of `/signup`
 
 ## Changed
 

--- a/pages/projects.js
+++ b/pages/projects.js
@@ -209,7 +209,7 @@ export default function Projects(props) {
           title={t("signupTitleCallToAction")}
           html={t("becomeAParticipantDescription")}
           lang={props.locale}
-          href={t("signupRedirect")}
+          href={t("signupInfoRedirect")}
           hrefText={t("signupBtn")}
         />
       </Layout>


### PR DESCRIPTION
# Description

[SCL-612 - Signup link on Projects page is wrong](https://jira-dev.bdm-dev.dts-stn.com/browse/SCL-612)

Small PR that addresses an issue where the CallToAction link on the projects page links directly to the signup form instead of signup info. Checked all other instances as well to confirm this was the only one with the wrong link.

## Test Instructions

1. Pull in branch
2. Type `npm run dev`
3. Go to `/projects` and confirm the link in the CallToAction redirects to `signup-info`

## Checklist

- [x] Strings use placeholders for translation (No hard coded strings)
- [x] Unit tests have been added/updated
- [x] Update CHANGELOG

## Product and Sprint Backlog

[Jira](https://jira-dev.bdm-dev.dts-stn.com/secure/RapidBoard.jspa?rapidView=96&projectKey=SCL)
