### PR TITLE
Changed feedback widget color scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Added an `Confirm email` field to sign-up form
 - Added a wrapper class that uses singleton pattern to manage Strapi data
 - Added `autoComplete` prop type to TextField component
+- Added remaining character counter to feedback widget
 
 # Changed
 
@@ -35,7 +36,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Updated metadata on every page according to the master content inventory
 - Updated project to use Tailwind V3
 - Updated the language question on the signup page by putting `aria-required` on the legend and removing `required` from each radio button so screen readers only announce required once for the grouping
-- Removed red `required` from signup page fields to match Figma design 
+- Removed red `required` from signup page fields to match Figma design
+- Updated feedback widget's color scheme to improve a11y
 
 ## Fixed
 

--- a/components/molecules/FeedbackWidget.js
+++ b/components/molecules/FeedbackWidget.js
@@ -286,6 +286,7 @@ export const FeedbackWidget = ({
                     onInput={(e) =>
                       setCount(maxLength - e.currentTarget.value.length)
                     }
+                    aria-required="true"
                   />
                   <ActionButton
                     id="feedback-submit"

--- a/components/molecules/FeedbackWidget.js
+++ b/components/molecules/FeedbackWidget.js
@@ -22,6 +22,8 @@ export const FeedbackWidget = ({
   const { t } = useTranslation("common");
   const [response, setResponse] = useState(t("thankYouFeedback"));
   const email = process.env.NEXT_PUBLIC_NOTIFY_REPORT_A_PROBLEM_EMAIL;
+  const [count, setCount] = useState(2000);
+  var maxLength = 2000;
 
   lockScroll(showFeedback);
 
@@ -99,6 +101,7 @@ export const FeedbackWidget = ({
       if (response.status === 201 || response.status === 200) {
         await setResponse(t("thankYouFeedback"));
         setFeedback("");
+        setCount(2000);
       } else {
         await setResponse(t("sorryFeedback"));
       }
@@ -138,7 +141,7 @@ export const FeedbackWidget = ({
             style={{ background: "rgba(71, 71, 71, 0.8)" }}
           >
             <div
-              className="w-auto mx-12 md:mx-24 bg-custom-blue-blue shadow-lg border-black border-4"
+              className="w-auto mx-12 md:mx-24 bg-white shadow-lg border-black border-4"
               data-testid="feedbackDropdown"
             >
               {submitted ? (
@@ -169,12 +172,16 @@ export const FeedbackWidget = ({
                         <button
                           id="feedbackClose"
                           onClick={() => setFeedbackClose(true)}
-                          className="font-body text-white flex mt-2.5 lg:mt-0 outline-none focus:outline-white-solid justify-end items-center w-1/4"
+                          className="font-body text-gray-dark-100 flex mt-2.5 lg:mt-0 outline-none focus:outline-white-solid justify-end items-center w-1/4"
                           data-testid="closeButton"
                           aria-label="Close the expanded feedback section"
                         >
-                          <img src="/close-x.svg" alt="Close button" />
-                          <span className="text-xs leading-4 lg:text-sm underline ml-1 lg:ml-2 lg:leading-10">
+                          <img
+                            className="svg"
+                            src="/close-x.svg"
+                            alt="Close button"
+                          />
+                          <span className="text-xs text-white leading-4 lg:text-sm underline ml-1 lg:ml-2 lg:leading-10">
                             {t("close")}
                           </span>
                         </button>
@@ -187,11 +194,14 @@ export const FeedbackWidget = ({
               ) : (
                 ""
               )}
-              <div className="layout-container text-white pb-4">
+              <div className="layout-container text-gray-dark-100 pb-4">
                 <button
                   id="feedbackClose"
-                  onClick={toggleForm}
-                  className="flex float-right pt-4 font-body text-white flex mt-2.5 lg:mt-0 outline-none focus:outline-white-solid items-center"
+                  onClick={() => {
+                    toggleForm();
+                    setCount(2000);
+                  }}
+                  className="flex float-right pt-4 font-body text-gray-dark-100 flex mt-2.5 lg:mt-0 outline-none focus:outline-white-solid items-center"
                   data-testid="closeButton"
                   aria-label="Close the expanded feedback section"
                 >
@@ -237,16 +247,22 @@ export const FeedbackWidget = ({
                 >
                   <label
                     htmlFor="feedbackTextArea"
-                    className="text-xs lg:text-sm font-body font-bold"
+                    className="text-xs lg:text-sm font-body"
                   >
-                    {t("doBetter")}
-                    <span className="text-gray-md"> {t("required")}</span>
+                    <b
+                      className="text-error-border-red mr-1"
+                      aria-hidden="true"
+                    >
+                      *
+                    </b>
+                    <b>{t("doBetter")}</b>
                   </label>
                   <div id="feedbackInfo">
                     <p className="text-xs lg:text-sm my-2">
                       {t("doNotInclude")}
                     </p>
-                    <p className="text-xs lg:text-sm my-2">
+                    <p className="text-xs lg:text-sm mb-1 mt-4">
+                      {count}
                       {t("maximum2000")}
                     </p>
                   </div>
@@ -263,14 +279,17 @@ export const FeedbackWidget = ({
                     maxLength="2000"
                     rows="5"
                     className={
-                      "text-input font-body w-full min-h-40px shadow-sm text-form-input-gray border-2 my-2 py-6px px-12px rounded"
+                      "text-input font-body w-full min-h-40px shadow-sm text-form-input-gray border-2 border-gray-dark-100 my-2 py-6px px-12px rounded"
                     }
                     value={feedback}
                     onChange={(e) => setFeedback(e.currentTarget.value)}
+                    onInput={(e) =>
+                      setCount(maxLength - e.currentTarget.value.length)
+                    }
                   />
                   <ActionButton
                     id="feedback-submit"
-                    custom="outline-none focus:outline-black-solid rounded block w-full lg:w-auto lg:px-12 text-xs lg:text-sm py-2 mt-2 font-bold text-custom-blue-projects-link bg-details-button-gray hover:bg-gray-300 flex justify-center"
+                    custom="outline-none focus:outline-black-solid rounded block w-full lg:w-auto lg:px-12 text-xs lg:text-sm py-2 mt-2 font-bold bg-custom-blue-blue text-white border border-custom-blue-blue active:bg-custom-blue-dark hover:bg-custom-blue-light flex justify-center"
                     type="submit"
                     dataCy="feedback-submit"
                     dataTestId="feedback-submit"

--- a/components/molecules/FeedbackWidget.test.js
+++ b/components/molecules/FeedbackWidget.test.js
@@ -12,7 +12,7 @@ describe("FeedbackWidget tests", () => {
   it("renders FeedbackWidget in its primary state", () => {
     render(<Primary {...Primary.args} />);
     expect(screen.getByTestId("feedbackDropdown")).toHaveClass(
-      "w-auto mx-12 md:mx-24 bg-custom-blue-blue shadow-lg border-black border-4"
+      "w-auto mx-12 md:mx-24 bg-white shadow-lg border-black border-4"
     );
   });
 

--- a/public/close-x.svg
+++ b/public/close-x.svg
@@ -1,3 +1,3 @@
-<svg width="12" height="12" viewBox="0 0 12 12" fill="white" xmlns="http://www.w3.org/2000/svg">
-<path d="M12 1.05L10.95 0L6 4.95L1.05 0L0 1.05L4.95 6L0 10.95L1.05 12L6 7.05L10.95 12L12 10.95L7.05 6L12 1.05Z" fill="white"/>
+<svg width="12" height="12" viewBox="0 0 12 12" fill="#333" xmlns="http://www.w3.org/2000/svg">
+<path d="M12 1.05L10.95 0L6 4.95L1.05 0L0 1.05L4.95 6L0 10.95L1.05 12L6 7.05L10.95 12L12 10.95L7.05 6L12 1.05Z" fill="#333"/>
 </svg>

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -271,7 +271,7 @@
   "close": "Close",
   "improveService": "Help us improve this service",
   "doBetter": "How can we do better?",
-  "maximum2000": "Maximum of 2000 characters",
+  "maximum2000": "/2000 characters remaining",
   "confidential": "Your feedback is confidential and anonymous.",
   "feedbackRequired": "Feedback - This field is required",
   "bottomFeedbackDescription": "We are always trying to better meet the needs of our users. We welcome any feedback or opinions you may have on our site to improve our current service.",

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -269,7 +269,7 @@
   "close": "Fermer",
   "improveService": "Aidez-nous à améliorer ce service",
   "doBetter": "Comment pouvons-nous faire mieux?",
-  "maximum2000": "Maximum de 2000 caractères",
+  "maximum2000": "/2000 caractères restants",
   "confidential": "Vos commentaires sont confidentiels et anonymes.",
   "feedbackRequired": "Ce champ est obligatoire",
   "bottomFeedbackDescription": "Dites-nous comment s'est passée votre exploration du projet. Vos commentaires nous aideront à l'améliorer afin qu'il réponde davantage à vos besoins.",

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -270,3 +270,7 @@ html {
 .footerBackground {
   background: #26374a url(../public/landscape.png) no-repeat right bottom;
 }
+
+.svg {
+  filter: brightness(0) invert(1);
+}


### PR DESCRIPTION
# Description

[Text elements must have sufficient color contrast against the background](https://jira-dev.bdm-dev.dts-stn.com/browse/SCL-605)

Our a11y audit came back with a suggestion to increase the contrast ratio of the `(required)` label on our feedback widget so it complies with AAA (7:1 contrast ratio, or 4.5:1 if the text is considered "Large text", which is 18px and bold). Rather than changing just the required label, we're using this task as an opportunity to improve the overall readability of the feedback widget by changing the color scheme to a more common design pattern (black text on white background).

In addition to the above, this PR also adds a remaining character counter which changes whenever the `textarea` element receives any input. I've also removed the `(required)` label and added a red star in it's place to stay consistent with the signup page's design.  

I've added a CSS class to change the color of the close ( X ) SVG when successfully submitting feedback, but since the plan is to eventually do away with the success banner and change the content within the window, this is only temporary.


## Test Instructions

1. Pull in branch
2. Type `npm run dev`
3. Navigate to `/projects/digital-centre`
4. Open feedback widget
5. Start typing, remove text, paste text into box to ensure character counter works as expected

## Checklist

- [x] Strings use placeholders for translation (No hard coded strings)
- [x] Unit tests have been added/updated
- [x] Update CHANGELOG

## Product and Sprint Backlog

[Jira](https://jira-dev.bdm-dev.dts-stn.com/secure/RapidBoard.jspa?rapidView=96&projectKey=SCL)
