### PR TITLE
Small Docker fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ ENV NEXT_PUBLIC_THANK_YOU_EMAIL=$NEXT_PUBLIC_THANK_YOU_EMAIL
 ENV NODE_ENV=production
 WORKDIR /build
 COPY --from=base /base ./
+RUN true
 COPY . .
 RUN yarn install --frozen-lockfile
 RUN yarn build


### PR DESCRIPTION
# Description

Small fix related to #482 that addresses an issue where our multistage build fails when a specific sequence of COPY commands are given. Simply adding `RUN true` between the trouble COPY commands ***should*** fix it.


## Test Instructions

Follow steps in #482 for running the project locally, however the problem is when it is being built in Azure

## Checklist

- [x] Strings use placeholders for translation (No hard coded strings)
- [x] Unit tests have been added/updated
- [x] Update CHANGELOG

## Product and Sprint Backlog

[Jira](https://jira-dev.bdm-dev.dts-stn.com/secure/RapidBoard.jspa?rapidView=96&projectKey=SCL)
