### PR TITLE
Remove srSpeak function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Added the `stripFeedback` helper function which strips PII from both the feedback and report a problem forms
 - Added error label in report a problem widget
 
-# Changed
+## Changed
 
 - Add collape and expand state on the checkbox on the Report A Problem form
 - Add border to feedback popup, and give background a darker color
@@ -50,6 +50,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Update project page to read content from cms
 - Update home page data model to read content from cms
 - Update about page to read content from cms
+- Changed number of steps for signup and unsubscribe from 3 to 2
+- Removed srSpeak function from feedback widget and instead put `aria-live="polite"` on the form 
 
 ## Fixed
 
@@ -63,9 +65,6 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Fixed CallToAction redirect on `/projects` page so that it links to `/signup-info` instead of `/signup`
 - Fixed email and close button focus on the feedback widget
 
-## Changed
-
-- Changed number of steps for signup and unsubscribe from 3 to 2
 
 ## [v1.1.3] - 2021-10-27
 

--- a/components/molecules/FeedbackWidget.js
+++ b/components/molecules/FeedbackWidget.js
@@ -115,26 +115,8 @@ export const FeedbackWidget = ({
       setFocusAfterSubmit();
     } else {
       setFeedbackError(error.message);
-      srSpeak(error.message);
     }
   };
-
-  function srSpeak(text, priority) {
-    var el = document.createElement("div");
-    var id = "speak-" + Date.now();
-    el.setAttribute("id", id);
-    el.setAttribute("aria-live", priority || "polite");
-    el.classList.add("sr-only");
-    document.body.appendChild(el);
-
-    window.setTimeout(function () {
-      document.getElementById(id).innerHTML = text;
-    }, 100);
-
-    window.setTimeout(function () {
-      document.body.removeChild(document.getElementById(id));
-    }, 1000);
-  }
 
   return (
     <>
@@ -253,6 +235,7 @@ export const FeedbackWidget = ({
                   className="w-full"
                   action="#"
                   onSubmit={onSubmitHandler}
+                  aria-live="polite"
                 >
                   <label
                     htmlFor="feedbackTextArea"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "dependencies": {
     "@lottiefiles/react-lottie-player": "^3.4.1",
-    "@tailwindcss/typography": "^0.5.2",
     "cors": "^2.8.5",
     "cuid": "^2.1.8",
     "focus-trap-react": "^8.9.1",
@@ -50,7 +49,7 @@
     "@storybook/addon-postcss": "^2.0.0",
     "@storybook/react": "^6.4.19",
     "@tailwindcss/postcss7-compat": "^2.2.17",
-    "@tailwindcss/typography": "^0.5.1",
+    "@tailwindcss/typography": "^0.5.2",
     "@testing-library/dom": "^8.1.0",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^12.0.0",


### PR DESCRIPTION
# Description

[SCL-640 - Clean up security alerts from CodeQL](https://jira-dev.bdm-dev.dts-stn.com/browse/SCL-640)

This PR addresses the CodeQL alert https://github.com/DTS-STN/Alpha-Site/security/code-scanning/1

We previously had a function that would make the screen reader announce the error label when a user hits the submit button in our feedback widget without entering feedback. This was accomplished by accessing the element in the DOM which isn't ideal. This PR does away with the function and instead just adds `aria-live = "polite"` on the entire form instead, which effectively does the same thing but with a lot less code.

The other alerts that were present were dismissed for the reasons below:

https://github.com/DTS-STN/Alpha-Site/security/code-scanning/3 - This alert was dismissed as a false positive since it thinks we're hard coding an API key when in reality we're supplying a default dummy value (as required by GCNotify). There is no security concern here.

https://github.com/DTS-STN/Alpha-Site/security/code-scanning/2 - Dismissed because this alert is not relevant. This is an icomoon demo file.


## Test Instructions

1. Pull in branch
2. Type `yarn dev`
3. Navigate to `/projects/digital-centre`
4. Open NVDA (or whatever screen reader you're using)
5. Open feedback window
6. Click Submit; The screen reader should announce the submit button's text and then the error

## Checklist

- [x] Strings use placeholders for translation (No hard coded strings)
- [x] Unit tests have been added/updated
- [x] Update CHANGELOG

## Product and Sprint Backlog

[Jira](https://jira-dev.bdm-dev.dts-stn.com/secure/RapidBoard.jspa?rapidView=96&projectKey=SCL)
