### PR TITLE
fix styling issue

### DIFF
--- a/components/atoms/Breadcrumb.js
+++ b/components/atoms/Breadcrumb.js
@@ -7,7 +7,7 @@ import Link from "next/link";
 export function Breadcrumb(props) {
   return (
     <nav aria-label="breadcrumbs">
-      <ul className="block text-custom-blue-dark text-base font-body -ml-4 -my-4">
+      <ul className="block text-custom-blue-dark text-base font-body -ml-4 -my-4 ">
         <li className="inline-block min-w-0 max-w-full truncate px-1 -my-4">
           <Link href="https://www.canada.ca/">
             <a className="text-sm hover:text-custom-blue-link visited:text-purple-700 underline">

--- a/components/atoms/Breadcrumb.js
+++ b/components/atoms/Breadcrumb.js
@@ -21,7 +21,7 @@ export function Breadcrumb(props) {
               return (
                 <li
                   key={key}
-                  className="inline-block min-w-0 max-w-full truncate -my-4"
+                  className="inline-block min-w-0 max-w-full truncate -my-4 px-1"
                 >
                   <span className="inline-block align-middle text-gray-breadcrumb icon-cheveron-right mr-4" />
                   <Link href={item.link}>

--- a/components/atoms/Breadcrumb.js
+++ b/components/atoms/Breadcrumb.js
@@ -7,8 +7,8 @@ import Link from "next/link";
 export function Breadcrumb(props) {
   return (
     <nav aria-label="breadcrumbs">
-      <ul className="block text-custom-blue-dark text-base font-body -my-4 -ml-4">
-        <li className="inline-block min-w-0 max-w-full truncate px-1">
+      <ul className="block text-custom-blue-dark text-base font-body -ml-4 -my-4">
+        <li className="inline-block min-w-0 max-w-full truncate px-1 -my-4">
           <Link href="https://www.canada.ca/">
             <a className="text-sm hover:text-custom-blue-link visited:text-purple-700 underline">
               Canada.ca
@@ -21,7 +21,7 @@ export function Breadcrumb(props) {
               return (
                 <li
                   key={key}
-                  className="inline-block min-w-0 max-w-full truncate"
+                  className="inline-block min-w-0 max-w-full truncate -my-4"
                 >
                   <span className="inline-block align-middle text-gray-breadcrumb icon-cheveron-right mr-4" />
                   <Link href={item.link}>

--- a/components/molecules/Menu.js
+++ b/components/molecules/Menu.js
@@ -67,7 +67,7 @@ export function Menu(props) {
           return (
             <li
               key={key}
-              className={`py-3 lg:py-0 cursor-pointer text-custom-blue-projects-link `}
+              className={`py-3 lg:py-0 cursor-pointer text-custom-blue-projects-link list-none -my-4 -ml-4`}
               role="menuitem"
               aria-current={exactURL ? "page" : null}
             >

--- a/components/molecules/Menu.js
+++ b/components/molecules/Menu.js
@@ -56,7 +56,7 @@ export function Menu(props) {
 
       <ul
         id="menuDropdown"
-        className={`menuDropdown ${showMenu ? "active" : ""}`}
+        className={`menuDropdown mt-2 ${showMenu ? "active" : ""}`}
         role="menu"
         aria-expanded={showMenu}
       >

--- a/components/molecules/Menu.js
+++ b/components/molecules/Menu.js
@@ -67,7 +67,7 @@ export function Menu(props) {
           return (
             <li
               key={key}
-              className={`py-3 lg:py-0 cursor-pointer text-custom-blue-projects-link list-none -my-4 -ml-4`}
+              className={`py-3 lg:py-0 cursor-pointer text-custom-blue-projects-link list-none -my-2 -ml-2`}
               role="menuitem"
               aria-current={exactURL ? "page" : null}
             >

--- a/components/organisms/Layout.js
+++ b/components/organisms/Layout.js
@@ -131,7 +131,7 @@ export const Layout = ({
               },
             ]}
           />
-          <div className="layout-container mt-2 mb-8">
+          <div className="layout-container mt-2 mb-12">
             <Breadcrumb items={breadcrumbItems} />
           </div>
         </div>

--- a/pages/signup-info.js
+++ b/pages/signup-info.js
@@ -24,7 +24,7 @@ export default function SignupInfo(props) {
   return (
     <>
       {pageContent &&
-        pageContent.map((content) => (
+        pageContent.map((content, index) => (
           <Layout
             locale={props.locale}
             langUrl={content.attributes.url}
@@ -34,6 +34,7 @@ export default function SignupInfo(props) {
                 link: content.attributes.navigation.home,
               },
             ]}
+            key={index}
           >
             <Head>
               {process.env.NEXT_PUBLIC_ADOBE_ANALYTICS_URL ? (

--- a/styles/menu.css
+++ b/styles/menu.css
@@ -1,44 +1,44 @@
 @tailwind screens;
 
 .menuDropdown {
-    display: none;
-    background-color: white;
+  display: none;
+  background-color: white;
 }
 
 .menuLink:hover {
-    color: #0A75C6;
+  color: #0a75c6;
 }
 
 .activePage {
-    border-bottom: 4px solid #1d5b90;
+  border-bottom: 4px solid #1d5b90;
 }
 
-.activePage:hover{
-    color: #0A75C6;
-    border-bottom: 4px solid #0A75C6;
+.activePage:hover {
+  color: #0a75c6;
+  border-bottom: 4px solid #0a75c6;
 }
 
 .active {
-    display: block;
+  display: block;
 }
 
 @screen lg {
-    #menuButton, #closeMenu {
-        display: none;
-    }
+  #menuButton,
+  #closeMenu {
+    display: none;
+  }
 
-    .menuDropdown {
-        background: white;
-        display: inline-block;
-        position: static;
-        min-width: fit-content;
-        min-height: fit-content;
-        padding-bottom: 1rem;
-    }
+  .menuDropdown {
+    background: white;
+    display: inline-block;
+    position: static;
+    min-width: fit-content;
+    min-height: fit-content;
+    padding-bottom: 1rem;
+  }
 
-    .menuDropdown > li{
-        display: inline-block;
-        padding-left: 2rem;
-    }
+  .menuDropdown > li {
+    display: inline-block;
+    padding-left: 2rem;
+  }
 }
-  


### PR DESCRIPTION
# Description

Open this pr to fix styling issue on the `breadcrumb` nav and `menu` link. 
The styling was off because of the `li` element style that applied globally (spacing and bullet list) in my previous pr. The styling issue is fixed in this pr.

<img width="254" alt="Screen Shot 2022-03-25 at 1 19 43 PM" src="https://user-images.githubusercontent.com/64853947/160170258-7db2762a-99e2-48b8-a3ca-ef3ec0d49f08.png">
<img width="977" alt="Screen Shot 2022-03-25 at 1 20 17 PM" src="https://user-images.githubusercontent.com/64853947/160170282-d3a55a41-83ac-43bd-bb64-1804d0f0bc56.png">



## Acceptance Criteria

- Fixed the extra spacing issue for `Menu` and `Breadcrumb` navigation
- Remove the bullet style in the `Menu` when viewing in mobile 

## Test Instructions

1. checkout the `Menu` link, it should not have extra space on top
2. in mobile view `Menu` link should not show bullet list and no extra space between each list item
3. checkout the `Breadcrumb` nav, no huge gaps between each list item. 

## Checklist

- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated
- [ ] Update CHANGELOG
