### PR TITLE
Moved onClick to child of next/link

### DIFF
--- a/components/organisms/Layout.js
+++ b/components/organisms/Layout.js
@@ -96,7 +96,6 @@ export const Layout = ({
               key={language}
               href={langUrl}
               locale={language}
-              onClick={() => setLanguage(language)}
               data-testid="languageLink2"
             >
               <a

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -280,7 +280,7 @@
   "globalHeader": "Global header",
   "testSiteNotice": "Test site notice",
   "siteFooter": "Site footer",
-  "officialSiteNavigation": "Cananda.ca official site",
+  "officialSiteNavigation": "Canada.ca official site",
   "languageSelection": "Language selection",
   "aboutGovernment": "About government",
   "aboutThisSite": "About this site",


### PR DESCRIPTION
# Description

[SCL-726- Fix next/link console warnings](https://jira-dev.bdm-dev.dts-stn.com/browse/SCL-726)

Following our update to NextJS, we started receiving some console warnings similar to:
```md 
"onClick" was passed to <Link> with `href` of `/projets` but "legacyBehavior" was set. The legacy behavior requires onClick be set on the child of next/link
```
every time we would either navigate to a new page or switch the language on the page. This is because the `onClick` function that would set the language within our `Layout` component was set on `<Link>` instead of it's child, which is not a valid prop as per https://nextjs.org/docs/api-reference/next/link. Setting the `onClick` on the `<a>` element instead fixes this issue.

I've also fixed a slight error with one of the English strings.

## Test Instructions

1. Pull in branch
2. Type `yarn dev`
3. Navigate through the site, switch languages and ensure there are no console warnings like above

## Checklist

- [x] Strings use placeholders for translation (No hard coded strings)

## Product and Sprint Backlog

[Jira](https://jira-dev.bdm-dev.dts-stn.com/secure/RapidBoard.jspa?rapidView=96&projectKey=SCL)
