### PR TITLE
Refactor notsupported page to use data from AEM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Update signup-info page to read content from cms
 - Removed `experience` email from privacy page, Report a Problem and Feedback components
 - Updated to Next.js `v12.1.6`
+- Updated `/notsupported` to use data from AEM
 
 ## Fixed
 

--- a/__mocks__/mockStore.js
+++ b/__mocks__/mockStore.js
@@ -1,0 +1,223 @@
+/* This file will be used to store mock AEM data for testing purposes*/
+
+export const notSupportedData = {
+  data: {
+    scLabsErrorPageByPath: {
+      item: {
+        sclGcImages: [
+          {
+            _path: "/content/dam/decd-endc/images/sclabs/sig-blk-en.svg",
+          },
+          {
+            _path: "/content/dam/decd-endc/images/sclabs/wmms-blk.svg",
+          },
+        ],
+        sclImagelist: [
+          {
+            _path: "/content/dam/decd-endc/images/sclabs/crackedbulb.svg",
+          },
+          {
+            _path: "/content/dam/decd-endc/images/sclabs/chrome.png",
+          },
+          {
+            _path: "/content/dam/decd-endc/images/sclabs/safari.png",
+          },
+          {
+            _path: "/content/dam/decd-endc/images/sclabs/edge.png",
+          },
+          {
+            _path: "/content/dam/decd-endc/images/sclabs/firefox.svg",
+          },
+        ],
+        sclContentEn: {
+          json: [
+            {
+              nodeType: "header",
+              style: "h1",
+              content: [
+                {
+                  nodeType: "text",
+                  value:
+                    "Sorry, this site will not work with Internet Explorer",
+                },
+              ],
+            },
+            {
+              nodeType: "paragraph",
+              content: [
+                {
+                  nodeType: "text",
+                  value:
+                    "Please use one of the following Web browsers to visit Service Canada Labs:",
+                },
+              ],
+            },
+          ],
+        },
+        sclCopyToClipboardLabelEn:
+          "Copy the link below and paste in that browser.",
+        sclBrowserDownloadLinksEn: {
+          json: [
+            {
+              nodeType: "paragraph",
+              content: [
+                {
+                  nodeType: "text",
+                  value:
+                    "If you do not have any of these browsers installed, you can download the one of your choice using the links below:",
+                },
+              ],
+            },
+            {
+              nodeType: "unordered-list",
+              content: [
+                {
+                  nodeType: "list-item",
+                  content: [
+                    {
+                      nodeType: "link",
+                      data: {
+                        href: "https://www.google.com/intl/en_ca/chrome/",
+                      },
+                      value: "Download Chrome",
+                    },
+                  ],
+                },
+                {
+                  nodeType: "list-item",
+                  content: [
+                    {
+                      nodeType: "link",
+                      data: {
+                        href: "https://support.apple.com/en_CA/downloads",
+                      },
+                      value: "Download Safari",
+                    },
+                  ],
+                },
+                {
+                  nodeType: "list-item",
+                  content: [
+                    {
+                      nodeType: "link",
+                      data: {
+                        href: "https://www.microsoft.com/en-us/edge",
+                      },
+                      value: "Download Edge",
+                    },
+                  ],
+                },
+                {
+                  nodeType: "list-item",
+                  content: [
+                    {
+                      nodeType: "link",
+                      data: {
+                        href: "https://www.mozilla.org/en-CA/firefox/new/",
+                      },
+                      value: "Download Firefox",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        sclContentFr: {
+          json: [
+            {
+              nodeType: "header",
+              style: "h1",
+              content: [
+                {
+                  nodeType: "text",
+                  value:
+                    "Désolé, ce site ne fonctionne pas avec Internet Explorer",
+                },
+              ],
+            },
+            {
+              nodeType: "paragraph",
+              content: [
+                {
+                  nodeType: "text",
+                  value:
+                    "Veuillez utiliser l'un des navigateurs Web suivants pour accéder aux laboratoires de Service Canada:",
+                },
+              ],
+            },
+          ],
+        },
+        sclCopyToClipboardLabelFr:
+          "Vous n'avez qu'à copier le lien ci-dessous et le coller dans ce navigateur.",
+        sclBrowserDownloadLinksFr: {
+          json: [
+            {
+              nodeType: "paragraph",
+              content: [
+                {
+                  nodeType: "text",
+                  value:
+                    "Si aucun de ces navigateurs n'est installé, vous pouvez télécharger celui de votre choix à l'aide des liens ci-dessous:",
+                },
+              ],
+            },
+            {
+              nodeType: "unordered-list",
+              content: [
+                {
+                  nodeType: "list-item",
+                  content: [
+                    {
+                      nodeType: "link",
+                      data: {
+                        href: "https://www.google.com/intl/fr_ca/chrome/",
+                      },
+                      value: "Télécharger Chrome",
+                    },
+                  ],
+                },
+                {
+                  nodeType: "list-item",
+                  content: [
+                    {
+                      nodeType: "link",
+                      data: {
+                        href: "https://support.apple.com/fr_CA/downloads",
+                      },
+                      value: "Télécharger Safari",
+                    },
+                  ],
+                },
+                {
+                  nodeType: "list-item",
+                  content: [
+                    {
+                      nodeType: "link",
+                      data: {
+                        href: "https://www.microsoft.com/fr-fr/edge",
+                      },
+                      value: "Télécharger Edge",
+                    },
+                  ],
+                },
+                {
+                  nodeType: "list-item",
+                  content: [
+                    {
+                      nodeType: "link",
+                      data: {
+                        href: "https://www.mozilla.org/fr-CA/firefox/new/",
+                      },
+                      value: "Télécharger Firefox",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    },
+  },
+};

--- a/__tests__/pages/notsupported.test.js
+++ b/__tests__/pages/notsupported.test.js
@@ -3,10 +3,15 @@
  */
 import { render, screen } from "@testing-library/react";
 import NotSupported from "../../pages/notsupported";
+import { notSupportedData, test } from "../../__mocks__/mockStore";
+
+jest.mock("@apollo/client");
 
 describe("Browser not supported page", () => {
   it("renders without crashing", () => {
-    render(<NotSupported />);
+    render(
+      <NotSupported pageData={notSupportedData.data.scLabsErrorPageByPath} />
+    );
     expect(
       screen.getByText("Sorry, this site will not work with Internet Explorer")
     ).toBeInTheDocument();

--- a/graphql/queries/notsupportedQuery.graphql
+++ b/graphql/queries/notsupportedQuery.graphql
@@ -1,0 +1,33 @@
+query getNotSupported {
+	scLabsErrorPageByPath(_path: "/content/dam/decd-endc/content-fragments/alpha/sclabs/pages/browser-not-supported-page") {
+	    item {
+            sclGcImages {
+                ... on DocumentRef {
+                    _path
+                }
+            }
+            sclImagelist {
+                ... on DocumentRef {
+                    _path
+                }
+                ... on ImageRef {
+                    _path
+                }
+            }
+            sclContentEn {
+                json
+            }
+            sclCopyToClipboardLabelEn
+            sclBrowserDownloadLinksEn {
+                json
+            }
+            sclContentFr {
+                json
+            }
+            sclCopyToClipboardLabelFr
+            sclBrowserDownloadLinksFr {
+                json
+            }
+        }
+	}
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -11,7 +11,7 @@ module.exports = {
     "^.+\\.(js|jsx|ts|tsx)$": "<rootDir>/node_modules/babel-jest",
   },
   moduleNameMapper: {
-    "\\.(jpg|ico|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$":
+    "\\.(jpg|ico|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga|graphql)$":
       "<rootDir>/__mocks__/fileMock.js",
     "\\.(css|less)$": "<rootDir>/__mocks__/styleMock.js",
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.3",
   "private": true,
   "dependencies": {
-    "@apollo/client": "^3.6.2",
+    "@apollo/client": "^3.6.6",
     "@lottiefiles/react-lottie-player": "^3.4.7",
     "@storybook/addons": "^6.4.22",
     "@storybook/client-api": "^6.4.22",

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -16,7 +16,7 @@ function getCsp() {
   } https://ajax.googleapis.com https://assets.adobedtm.com;`; // NextJS requires 'unsafe-eval' in dev (faster source maps)
   csp += `connect-src 'self' *.demdex.net *.omtrdc.net cm.everesttech.net;`;
   csp += `style-src 'self' 'unsafe-inline' https://fonts.googleapis.com data:;`; // NextJS requires 'unsafe-inline'
-  csp += `img-src 'self' *.omtrdc.net *.demdex.net cm.everesttech.net assets.adobedtm.com;`;
+  csp += `img-src 'self' *.omtrdc.net *.demdex.net cm.everesttech.net assets.adobedtm.com https://www.canada.ca;`;
   csp += `font-src 'self' https://fonts.googleapis.com https://fonts.gstatic.com;`;
   csp += `frame-src 'self' *.demdex.net`;
   // csp += `frame-src *;` // TODO

--- a/pages/notsupported.js
+++ b/pages/notsupported.js
@@ -426,6 +426,8 @@ export const getStaticProps = async ({ locale }) => {
 
   const data = res.data.scLabsErrorPageByPath;
 
+  console.log(res);
+
   return process.env.NEXT_PUBLIC_ISR_ENABLED
     ? {
         props: {

--- a/pages/notsupported.js
+++ b/pages/notsupported.js
@@ -13,7 +13,6 @@ export default function error404(props) {
   const [enCopied, setEnCopied] = useState(false);
   const [frCopied, setFrCopied] = useState(false);
   const [pageData] = useState(props.pageData.item);
-  console.log(`https://www.canada.ca${pageData.sclGcImages[0]._path}`);
 
   useEffect(() => {
     if (process.env.NEXT_PUBLIC_ADOBE_ANALYTICS_URL) {
@@ -43,8 +42,8 @@ export default function error404(props) {
 
           {/* Primary HTML Meta Tags */}
           <title data-gc-analytics-error="notSupported">
-            Sorry, this site will not work with Internet Explorer | Désolé, ce
-            site ne fonctionne pas avec Internet Explorer
+            {pageData.sclContentEn.json[0].content[0].value} |{" "}
+            {pageData.sclContentFr.json[0].content[0].value}
           </title>
           <meta
             name="description"
@@ -153,25 +152,24 @@ export default function error404(props) {
         <section className="xs:px-0 lg:mx-auto lg:px-6 container">
           <img
             className="canadaLogo pt-6"
-            src="https://www.canada.ca/content/dam/decd-endc/images/sclabs/sig-blk-en.svg"
+            src={`https://www.canada.ca${pageData.sclGcImages[0]._path}`}
             alt={"Symbol of the Government of Canada"}
           />
           <div className="flex flex-col lg:flex-row justify-between items-center lg:items-start mt-8">
             <div>
               <div className="relative h-auto xl:w-96 xxl:w-400px lg:w-72 xl:h-400px lg:h-500px mb-8 lg:mb-0">
                 <h1 className="font-bold font-display mb-4">
-                  Sorry, this site will not work with Internet Explorer
+                  {pageData.sclContentEn.json[0].content[0].value}
                 </h1>
                 <p className="font-body text-sm mb-4 leading-normal">
-                  Please use one of the following Web browsers to visit Service
-                  Canada Labs:
+                  {pageData.sclContentEn.json[1].content[0].value}
                 </p>
               </div>
             </div>
             <div className="flex items-center justify-center circle-background my-8 lg:mt-0">
               <img
                 className="w-68px xl:w-24"
-                src="/crackedbulb.svg"
+                src={`https://www.canada.ca${pageData.sclImagelist[0]._path}`}
                 alt="Cracked lightbulb"
               />
             </div>
@@ -181,11 +179,10 @@ export default function error404(props) {
                 lang="fr"
               >
                 <h1 className="font-bold font-display mb-4">
-                  Désolé, ce site ne fonctionne pas avec Internet Explorer
+                  {pageData.sclContentFr.json[0].content[0].value}
                 </h1>
                 <p className="font-body text-sm mb-4 leading-normal">
-                  Veuillez utiliser l'un des navigateurs Web suivants pour
-                  accéder aux laboratoires de Service Canada:
+                  {pageData.sclContentFr.json[1].content[0].value}
                 </p>
               </div>
             </div>
@@ -194,25 +191,45 @@ export default function error404(props) {
         <section className="-mt-0 lg:-mt-36 sm:-mt-4 pb-5">
           <div className="flex items-center justify-center">
             <figure className="mx-4">
-              <img src="/chrome.png" alt="safari" width="98" height="98" />
+              <img
+                src={`https://www.canada.ca${pageData.sclImagelist[1]._path}`}
+                alt="chrome"
+                width="98"
+                height="98"
+              />
               <figcaption className="flex items-center justify-center">
                 Chrome
               </figcaption>
             </figure>
             <figure className="mx-4">
-              <img src="/safari.png" alt="safari" width="98" height="98" />
+              <img
+                src={`https://www.canada.ca${pageData.sclImagelist[2]._path}`}
+                alt="safari"
+                width="98"
+                height="98"
+              />
               <figcaption className="flex items-center justify-center">
                 Safari
               </figcaption>
             </figure>
             <figure className="mx-4">
-              <img src="/edge.png" alt="safari" width="94" height="94" />
+              <img
+                src={`https://www.canada.ca${pageData.sclImagelist[3]._path}`}
+                alt="edge"
+                width="94"
+                height="94"
+              />
               <figcaption className="pt-1.5 flex items-center justify-center">
                 Edge
               </figcaption>
             </figure>
             <figure className="mx-4">
-              <img src="/firefox.svg" alt="safari" width="98" height="98" />
+              <img
+                src={`https://www.canada.ca${pageData.sclImagelist[4]._path}`}
+                alt="firefox"
+                width="98"
+                height="98"
+              />
               <figcaption className="flex items-center justify-center">
                 Firefox
               </figcaption>
@@ -222,9 +239,8 @@ export default function error404(props) {
         <section className="xs:px-0 lg:mx-auto lg:px-6 container pb-44">
           <div className="flex flex-col lg:flex-row justify-between items-center lg:items-start mt-8">
             <div className="relative h-auto xl:w-96 xxl:w-400px lg:w-72 mb-8 lg:mb-0">
-              <p className="font-body text-sm mb-4 leading-normal">
-                Copy the link below and paste in that <br />
-                browser.
+              <p className="font-body text-sm mb-4 pb-5 leading-normal">
+                {pageData.sclCopyToClipboardLabelEn}
               </p>
               <CopyToClipboard
                 buttonId="enClipboardButton"
@@ -238,21 +254,60 @@ export default function error404(props) {
                 aria_label="Copy the link below and paste in that browser."
               />
               <p className="font-body text-sm pt-6 leading-normal">
-                If you do not have any of these browsers installed, you can
-                download the one of your choice using the links below:
+                {pageData.sclBrowserDownloadLinksEn.json[0].content[0].value}
               </p>
               <ul className="underline pt-4 font-body text-sm ieLinksList">
                 <li className="browser-item">
-                  <a href={t("chromeLink")}>Download Chrome</a>
+                  <a
+                    href={
+                      pageData.sclBrowserDownloadLinksEn.json[1].content[0]
+                        .content[0].data.href
+                    }
+                  >
+                    {
+                      pageData.sclBrowserDownloadLinksEn.json[1].content[0]
+                        .content[0].value
+                    }
+                  </a>
                 </li>
                 <li className="browser-item">
-                  <a href={t("safariLink")}>Download Safari</a>
+                  <a
+                    href={
+                      pageData.sclBrowserDownloadLinksEn.json[1].content[1]
+                        .content[0].data.href
+                    }
+                  >
+                    {
+                      pageData.sclBrowserDownloadLinksEn.json[1].content[1]
+                        .content[0].value
+                    }
+                  </a>
                 </li>
                 <li className="browser-item">
-                  <a href={t("edgeLink")}>Download Edge</a>
+                  <a
+                    href={
+                      pageData.sclBrowserDownloadLinksEn.json[1].content[2]
+                        .content[0].data.href
+                    }
+                  >
+                    {
+                      pageData.sclBrowserDownloadLinksEn.json[1].content[2]
+                        .content[0].value
+                    }
+                  </a>
                 </li>
                 <li className="browser-item">
-                  <a href={t("firefoxLink")}>Download Firefox</a>
+                  <a
+                    href={
+                      pageData.sclBrowserDownloadLinksEn.json[1].content[3]
+                        .content[0].data.href
+                    }
+                  >
+                    {
+                      pageData.sclBrowserDownloadLinksEn.json[1].content[3]
+                        .content[0].value
+                    }
+                  </a>
                 </li>
               </ul>
             </div>
@@ -262,8 +317,7 @@ export default function error404(props) {
                 lang="fr"
               >
                 <p className="font-body text-sm mb-4 leading-normal">
-                  Vous n'avez qu'à copier le lien ci-dessous et le coller dans
-                  ce navigateur.
+                  {pageData.sclCopyToClipboardLabelFr}
                 </p>
                 <CopyToClipboard
                   buttonText={frCopied ? "Copié!" : "Copier lien"}
@@ -277,22 +331,60 @@ export default function error404(props) {
                   aria_label="Vous n'avez qu'à copier le lien ci-dessous et le coller dans ce navigateur."
                 />
                 <p className="font-body text-sm pt-6 leading-normal">
-                  Si aucun de ces navigateurs n'est installé, vous pouvez
-                  télécharger celui de votre choix à l'aide des liens
-                  ci-dessous:
+                  {pageData.sclBrowserDownloadLinksFr.json[0].content[0].value}
                 </p>
                 <ul className="underline pt-4 font-body text-sm ieLinksList">
                   <li className="browser-item">
-                    <a href={t("chromeLinkFR")}>Télécharger Chrome</a>
+                    <a
+                      href={
+                        pageData.sclBrowserDownloadLinksFr.json[1].content[0]
+                          .content[0].data.href
+                      }
+                    >
+                      {
+                        pageData.sclBrowserDownloadLinksFr.json[1].content[0]
+                          .content[0].value
+                      }
+                    </a>
                   </li>
                   <li className="browser-item">
-                    <a href={t("safariLinkFR")}>Télécharger Safari</a>
+                    <a
+                      href={
+                        pageData.sclBrowserDownloadLinksFr.json[1].content[1]
+                          .content[0].data.href
+                      }
+                    >
+                      {
+                        pageData.sclBrowserDownloadLinksFr.json[1].content[1]
+                          .content[0].value
+                      }
+                    </a>
                   </li>
                   <li className="browser-item">
-                    <a href={t("edgeLinkFR")}>Télécharger Edge</a>
+                    <a
+                      href={
+                        pageData.sclBrowserDownloadLinksFr.json[1].content[2]
+                          .content[0].data.href
+                      }
+                    >
+                      {
+                        pageData.sclBrowserDownloadLinksFr.json[1].content[2]
+                          .content[0].value
+                      }
+                    </a>
                   </li>
                   <li className="browser-item">
-                    <a href={t("firefoxLinkFR")}>Télécharger Firefox</a>
+                    <a
+                      href={
+                        pageData.sclBrowserDownloadLinksFr.json[1].content[3]
+                          .content[0].data.href
+                      }
+                    >
+                      {
+                        pageData.sclBrowserDownloadLinksFr.json[1].content[3]
+                          .content[0].value
+                      }
+                    </a>
                   </li>
                 </ul>
               </div>
@@ -311,7 +403,7 @@ export default function error404(props) {
             />
             <img
               className="h-6 w-auto lg:h-auto lg:w-40"
-              src="/wmms-blk.svg"
+              src={`https://www.canada.ca${pageData.sclGcImages[1]._path}`}
               alt="Symbol of the Government of Canada"
             />
           </div>
@@ -327,14 +419,12 @@ export default function error404(props) {
 }
 
 export const getStaticProps = async ({ locale }) => {
-  // get projects data from AEM
+  // get page data from AEM
   const res = await queryGraphQL(getNotSupported).then((result) => {
     return result;
   });
 
   const data = res.data.scLabsErrorPageByPath;
-
-  console.log(data.item.sclContentEn.json[1]);
 
   return process.env.NEXT_PUBLIC_ISR_ENABLED
     ? {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,10 +9,10 @@
   dependencies:
     "@jridgewell/trace-mapping" "^0.3.0"
 
-"@apollo/client@^3.6.2":
-  version "3.6.2"
-  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.6.2.tgz#0418bfa6358dd117894c8af396706cfa2b186032"
-  integrity sha512-DNWyl+NNU2VsfHtXwOr4rV9hnQFPkl2/dNXeouhk9q7bXCWdEh3K8YTt/frULGVKbQjtnlPmz8C+LFI/JZ2N3w==
+"@apollo/client@^3.6.6":
+  version "3.6.6"
+  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.6.6.tgz#3fb1f5b11da9a64b51b5a86b62450bee034e7f41"
+  integrity sha512-AzNLN043wy0bDTTR9wzKYSu+I1IT2Ox3+vWckxgIt88Jfw5jHBvumf3lXE1JlgvbFCTiKS/Sa66AadQXWMVBRQ==
   dependencies:
     "@graphql-typed-document-node/core" "^3.1.1"
     "@wry/context" "^0.6.0"
@@ -23,10 +23,9 @@
     optimism "^0.16.1"
     prop-types "^15.7.2"
     symbol-observable "^4.0.0"
-    ts-invariant "^0.10.0"
+    ts-invariant "^0.10.3"
     tslib "^2.3.0"
-    use-sync-external-store "^1.0.0"
-    zen-observable-ts "^1.2.0"
+    zen-observable-ts "^1.2.5"
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.16.7", "@babel/code-frame@^7.5.5", "@babel/code-frame@^7.8.3":
   version "7.16.7"
@@ -13281,10 +13280,10 @@ ts-dedent@^2.0.0:
   resolved "https://registry.yarnpkg.com/ts-dedent/-/ts-dedent-2.2.0.tgz#39e4bd297cd036292ae2394eb3412be63f563bb5"
   integrity sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==
 
-ts-invariant@^0.10.0:
-  version "0.10.2"
-  resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.10.2.tgz#ae0413fa60cc3603edf8709d9a11db9d9ddb335a"
-  integrity sha512-5BybOL23OXYmmnA0C8NYPkUo5Kb/I4IVQk31K1VcdBZpQIn4fWKMIORGBJqGkwvDLyu9cxUb4Zv4G6xA4/07IQ==
+ts-invariant@^0.10.3:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.10.3.tgz#3e048ff96e91459ffca01304dbc7f61c1f642f6c"
+  integrity sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==
   dependencies:
     tslib "^2.1.0"
 
@@ -13681,11 +13680,6 @@ use-latest@^1.0.0:
   integrity sha512-d2TEuG6nSLKQLAfW3By8mKr8HurOlTkul0sOpxbClIv4SQ4iOd7BYr7VIzdbktUCnv7dua/60xzd8igMU6jmyw==
   dependencies:
     use-isomorphic-layout-effect "^1.0.0"
-
-use-sync-external-store@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.1.0.tgz#3343c3fe7f7e404db70f8c687adf5c1652d34e82"
-  integrity sha512-SEnieB2FPKEVne66NpXPd1Np4R1lTNKfjuy3XdIoPQKYBAFdzbzSZlSn1KJZUiihQLQC5Znot4SBz1EOTBwQAQ==
 
 use@^3.1.0:
   version "3.1.1"
@@ -14325,10 +14319,10 @@ yocto-queue@^0.1.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-zen-observable-ts@^1.2.0:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-1.2.3.tgz#c2f5ccebe812faf0cfcde547e6004f65b1a6d769"
-  integrity sha512-hc/TGiPkAWpByykMwDcem3SdUgA4We+0Qb36bItSuJC9xD0XVBZoFHYoadAomDSNf64CG8Ydj0Qb8Od8BUWz5g==
+zen-observable-ts@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-1.2.5.tgz#6c6d9ea3d3a842812c6e9519209365a122ba8b58"
+  integrity sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==
   dependencies:
     zen-observable "0.8.15"
 


### PR DESCRIPTION
# Description

[SCL-731 - Refactor /notsupported page to use queried data](https://jira-dev.bdm-dev.dts-stn.com/browse/SCL-731)

The purpose of this PR is to refactor the notsupported page so it uses the content and assets from AEM rather than being hardcoded. I added a mock data store for testing purposes which will grow in size as we continue to update our site to use data from AEM, though we should really look into mapping our data/creating a service class eventually. I've also updated apollo client to 3.6.6 as per #513. 

I didn't touch any of the metadata since since a meeting regarding that still needs to happen with Isabelle, so eventually our `getStaticProps` will be rid of the `serverSideTranslations` lines as they won't be necessary anymore.

It appears as if our content security policy was implemented in both our custom document file and in our next config. This is honestly pretty messy and we should look to move all of our security headers into our next config instead.

## Test Instructions

1. Pull in branch
2. Type `yarn install --frozen-lockfile`
3. Type `yarn dev`
4. Navigate to `/notsupported`
5. Ensure the page is rendered properly with the correct content

## Checklist

- [x] Strings use placeholders for translation (No hard coded strings)
- [x] Unit tests have been added/updated
- [x] Update CHANGELOG

## Product and Sprint Backlog

[Jira](https://jira-dev.bdm-dev.dts-stn.com/secure/RapidBoard.jspa?rapidView=96&projectKey=SCL)
