### PR TITLE
Refactor 404 and 500 error pages to use AEM data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Update signup-info page to read content from cms
 - Removed `experience` email from privacy page, Report a Problem and Feedback components
 - Updated to Next.js `v12.1.6`
-- Updated `/notsupported` to use data from AEM
+- Updated `/notsupported`, `/404` and `/500` to use data from AEM
 
 ## Fixed
 

--- a/__mocks__/mockStore.js
+++ b/__mocks__/mockStore.js
@@ -221,3 +221,267 @@ export const notSupportedData = {
     },
   },
 };
+
+export const error500Page = {
+  data: {
+    scLabsErrorPageByPath: {
+      item: {
+        sclGcImages: [
+          {
+            _path: "/content/dam/decd-endc/images/sclabs/sig-blk-en.svg",
+          },
+          {
+            _path: "/content/dam/decd-endc/images/sclabs/wmms-blk.svg",
+          },
+        ],
+        sclImagelist: [
+          {
+            _path: "/content/dam/decd-endc/images/sclabs/crackedbulb.svg",
+          },
+        ],
+        sclContentEn: {
+          json: [
+            {
+              nodeType: "header",
+              style: "h1",
+              content: [
+                {
+                  nodeType: "text",
+                  value:
+                    "The web site has reported an error. Please try again later.",
+                },
+              ],
+            },
+            {
+              nodeType: "paragraph",
+              content: [
+                {
+                  nodeType: "text",
+                  value: "Error 500",
+                },
+              ],
+            },
+            {
+              nodeType: "paragraph",
+              content: [
+                {
+                  nodeType: "text",
+                  value:
+                    "It may be due to server trouble or an incorrect or expired URL. If the problem persists, report the problem.",
+                },
+              ],
+            },
+            {
+              nodeType: "unordered-list",
+              content: [
+                {
+                  nodeType: "list-item",
+                  content: [
+                    {
+                      nodeType: "text",
+                      value: "Return to the ",
+                    },
+                    {
+                      nodeType: "link",
+                      data: {
+                        href: "/",
+                      },
+                      value: "Service Canada Labs home page",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        sclContentFr: {
+          json: [
+            {
+              nodeType: "header",
+              style: "h1",
+              content: [
+                {
+                  nodeType: "text",
+                  value:
+                    "Le site Web a signalé une erreur. Veuiller réessayer plus tard.",
+                },
+              ],
+            },
+            {
+              nodeType: "paragraph",
+              content: [
+                {
+                  nodeType: "text",
+                  value: "Erreur 500",
+                },
+              ],
+            },
+            {
+              nodeType: "paragraph",
+              content: [
+                {
+                  nodeType: "text",
+                  value:
+                    "Cela peut être dû à un problème de serveur ou à une URL incorrecte ou expirée. Si le problème persiste, signalez-le.",
+                },
+              ],
+            },
+            {
+              nodeType: "unordered-list",
+              content: [
+                {
+                  nodeType: "list-item",
+                  content: [
+                    {
+                      nodeType: "text",
+                      value: "Retournez à la ",
+                    },
+                    {
+                      nodeType: "link",
+                      data: {
+                        href: "/fr/",
+                      },
+                      value:
+                        "page d'accueil des laboratoires de Service Canada",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    },
+  },
+};
+
+export const error404Page = {
+  data: {
+    scLabsErrorPageByPath: {
+      item: {
+        sclGcImages: [
+          {
+            _path: "/content/dam/decd-endc/images/sclabs/sig-blk-en.svg",
+          },
+          {
+            _path: "/content/dam/decd-endc/images/sclabs/wmms-blk.svg",
+          },
+        ],
+        sclImagelist: [
+          {
+            _path: "/content/dam/decd-endc/images/sclabs/crackedbulb.svg",
+          },
+        ],
+        sclContentEn: {
+          json: [
+            {
+              nodeType: "header",
+              style: "h1",
+              content: [
+                {
+                  nodeType: "text",
+                  value: "We couldn't find that page",
+                },
+              ],
+            },
+            {
+              nodeType: "paragraph",
+              content: [
+                {
+                  nodeType: "text",
+                  value: "Error 404",
+                },
+              ],
+            },
+            {
+              nodeType: "paragraph",
+              content: [
+                {
+                  nodeType: "text",
+                  value:
+                    "We're sorry you ended up here. Sometimes a page gets moved or deleted, but hopefully we can help you find what you're looking for.",
+                },
+              ],
+            },
+            {
+              nodeType: "unordered-list",
+              content: [
+                {
+                  nodeType: "list-item",
+                  content: [
+                    {
+                      nodeType: "text",
+                      value: "Return to the ",
+                    },
+                    {
+                      nodeType: "link",
+                      data: {
+                        href: "/",
+                      },
+                      value: "Service Canada Labs home page",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        sclContentFr: {
+          json: [
+            {
+              nodeType: "header",
+              style: "h1",
+              content: [
+                {
+                  nodeType: "text",
+                  value: "Nous ne trouvons pas cette page",
+                },
+              ],
+            },
+            {
+              nodeType: "paragraph",
+              content: [
+                {
+                  nodeType: "text",
+                  value: "Erreur 404",
+                },
+              ],
+            },
+            {
+              nodeType: "paragraph",
+              content: [
+                {
+                  nodeType: "text",
+                  value:
+                    "Nous sommes désolés que vous ayez abouti ici. Il arrive parfois qu'une page ait été déplacée ou supprimée. Heureusement, nous pouvons vous aider à trouver ce que vous cherchez.",
+                },
+              ],
+            },
+            {
+              nodeType: "unordered-list",
+              content: [
+                {
+                  nodeType: "list-item",
+                  content: [
+                    {
+                      nodeType: "text",
+                      value: "Retournez à la ",
+                    },
+                    {
+                      nodeType: "link",
+                      data: {
+                        href: "/fr/",
+                      },
+                      value:
+                        "page d'accueil des laboratoires de Service Canada",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    },
+  },
+};

--- a/__tests__/pages/404.test.js
+++ b/__tests__/pages/404.test.js
@@ -3,10 +3,13 @@
  */
 import { render, screen } from "@testing-library/react";
 import Error404 from "../../pages/404";
+import { error404Page } from "../../__mocks__/mockStore";
+
+jest.mock("@apollo/client");
 
 describe("404", () => {
   it("renders without crashing", () => {
-    render(<Error404 />);
+    render(<Error404 pageData={error404Page.data.scLabsErrorPageByPath} />);
     expect(
       screen.getByRole("heading", { name: "We couldn't find that page" })
     ).toBeInTheDocument();

--- a/__tests__/pages/500.test.js
+++ b/__tests__/pages/500.test.js
@@ -3,10 +3,13 @@
  */
 import { render, screen } from "@testing-library/react";
 import Error500 from "../../pages/500";
+import { error500Page } from "../../__mocks__/mockStore";
+
+jest.mock("@apollo/client");
 
 describe("500", () => {
   it("renders without crashing", () => {
-    render(<Error500 />);
+    render(<Error500 pageData={error500Page.data.scLabsErrorPageByPath} />);
     expect(
       screen.getByRole("heading", {
         name: "The web site has reported an error. Please try again later.",

--- a/__tests__/pages/notsupported.test.js
+++ b/__tests__/pages/notsupported.test.js
@@ -3,7 +3,7 @@
  */
 import { render, screen } from "@testing-library/react";
 import NotSupported from "../../pages/notsupported";
-import { notSupportedData, test } from "../../__mocks__/mockStore";
+import { notSupportedData } from "../../__mocks__/mockStore";
 
 jest.mock("@apollo/client");
 

--- a/graphql/queries/error404Query.graphql
+++ b/graphql/queries/error404Query.graphql
@@ -1,0 +1,25 @@
+query get404Page {
+	scLabsErrorPageByPath(_path: "/content/dam/decd-endc/content-fragments/alpha/sclabs/pages/404-error-page") {
+	    item {
+            sclGcImages {
+                ... on DocumentRef {
+                    _path
+                }
+            }
+            sclImagelist {
+                ... on DocumentRef {
+                    _path
+                }
+                ... on ImageRef {
+                    _path
+                }
+            }
+            sclContentEn {
+                json
+            }
+            sclContentFr {
+                json
+            }
+        }
+	}
+}

--- a/graphql/queries/error500Query.graphql
+++ b/graphql/queries/error500Query.graphql
@@ -1,0 +1,25 @@
+query get500Page {
+	scLabsErrorPageByPath(_path: "/content/dam/decd-endc/content-fragments/alpha/sclabs/pages/500-error-page") {
+	    item {
+            sclGcImages {
+                ... on DocumentRef {
+                    _path
+                }
+            }
+            sclImagelist {
+                ... on DocumentRef {
+                    _path
+                }
+                ... on ImageRef {
+                    _path
+                }
+            }
+            sclContentEn {
+                json
+            }
+            sclContentFr {
+                json
+            }
+        }
+	}
+}

--- a/pages/404.js
+++ b/pages/404.js
@@ -6,11 +6,14 @@ import { ReportAProblem } from "../components/organisms/ReportAProblem";
 import { ActionButton } from "../components/atoms/ActionButton";
 import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
+import queryGraphQL from "../graphql/client";
+import get404Page from "../graphql/queries/error404Query.graphql";
 
 export default function error404(props) {
   const { t } = useTranslation("common");
   const [loaded, setLoaded] = useState(false);
   const router = useRouter();
+  const [pageData] = useState(props.pageData.item);
 
   useEffect(() => {
     if (process.env.NEXT_PUBLIC_ADOBE_ANALYTICS_URL) {
@@ -43,7 +46,8 @@ export default function error404(props) {
 
           {/* Primary HTML Meta Tags */}
           <title data-gc-analytics-error="404">
-            {`404 — ${t("siteTitle")}`}
+            {pageData.sclContentEn.json[0].content[0].value} (404) |{" "}
+            {pageData.sclContentFr.json[0].content[0].value} (404)
           </title>
           <meta
             name="description"
@@ -116,28 +120,36 @@ export default function error404(props) {
         <section className="layout-container pb-44">
           <img
             className="h-auto w-60 pt-6 xl:w-96 xxl:w-1/2"
-            src={"/sig-blk-en.svg"}
+            src={`https://www.canada.ca${pageData.sclGcImages[0]._path}`}
             alt={"Symbol of the Government of Canada"}
           />
           <div className="flex flex-col lg:flex-row justify-between items-center lg:items-start mt-8">
             <div>
               <div className="relative h-auto xl:w-96 xxl:w-400px lg:w-72 xl:h-400px lg:h-500px mb-8 lg:mb-0">
                 <h1 className="font-bold font-display mb-4">
-                  We couldn't find that page
+                  {pageData.sclContentEn.json[0].content[0].value}
                 </h1>
-                <p className="font-bold font-body mb-8">Error 404</p>
+                <p className="font-bold font-body mb-8">
+                  {pageData.sclContentEn.json[1].content[0].value}
+                </p>
                 <p className="font-body text-sm mb-4 leading-30px">
-                  We're sorry you ended up here. Sometimes a page gets moved or
-                  deleted, but hopefully we can help you find what you're
-                  looking for.
+                  {pageData.sclContentEn.json[2].content[0].value}
                 </p>
                 <div className="flex">
                   <span className="error404-link" />
                   <p className="font-body text-sm leading-30px">
-                    Return to the &nbsp;
-                    <Link href="/">
+                    {pageData.sclContentEn.json[3].content[0].content[0].value}
+                    <Link
+                      href={
+                        pageData.sclContentEn.json[3].content[0].content[1].data
+                          .href
+                      }
+                    >
                       <a className="underline hover:text-canada-footer-hover-font-blue text-canada-footer-font">
-                        Service Canada Labs home page
+                        {
+                          pageData.sclContentEn.json[3].content[0].content[1]
+                            .value
+                        }
                       </a>
                     </Link>
                   </p>
@@ -148,7 +160,7 @@ export default function error404(props) {
             <div className="flex items-center justify-center circle-background my-8 lg:mt-0">
               <img
                 className="w-68px xl:w-24"
-                src="/crackedbulb.svg"
+                src={`https://www.canada.ca${pageData.sclImagelist[0]._path}`}
                 alt="Cracked lightbulb"
               />
             </div>
@@ -158,22 +170,29 @@ export default function error404(props) {
                 lang="fr"
               >
                 <h1 className="font-bold font-display mb-4">
-                  Nous ne trouvons pas cette page
+                  {pageData.sclContentFr.json[0].content[0].value}
                 </h1>
-                <p className="font-bold font-body mb-8">Erreur 404</p>
+                <p className="font-bold font-body mb-8">
+                  {pageData.sclContentFr.json[1].content[0].value}
+                </p>
                 <p className="font-body text-sm mb-4 leading-30px">
-                  Nous sommes désolés que vous ayez abouti ici. Il arrive
-                  parfois qu'une page ait été déplacée ou supprimée.
-                  Heureusement, nous pouvons vous aider à trouver ce que vous
-                  cherchez.
+                  {pageData.sclContentFr.json[2].content[0].value}
                 </p>
                 <div className="flex">
                   <span className="error404-link" />
                   <p className="font-body text-sm leading-30px">
-                    Retournez à la &nbsp;
-                    <Link href="/fr">
+                    {pageData.sclContentFr.json[3].content[0].content[0].value}
+                    <Link
+                      href={
+                        pageData.sclContentFr.json[3].content[0].content[1].data
+                          .href
+                      }
+                    >
                       <a className="underline hover:text-canada-footer-hover-font-blue text-canada-footer-font">
-                        page d'accueil des laboratoires de Service Canada
+                        {
+                          pageData.sclContentFr.json[3].content[0].content[1]
+                            .value
+                        }
                       </a>
                     </Link>
                   </p>
@@ -195,7 +214,7 @@ export default function error404(props) {
             />
             <img
               className="h-6 w-auto lg:h-auto lg:w-40"
-              src="/wmms-blk.svg"
+              src={`https://www.canada.ca${pageData.sclGcImages[1]._path}`}
               alt="Symbol of the Government of Canada"
             />
           </div>
@@ -210,10 +229,30 @@ export default function error404(props) {
   );
 }
 
-export const getStaticProps = async ({ locale }) => ({
-  props: {
-    locale: locale,
-    ...(await serverSideTranslations("en", ["common"])),
-    ...(await serverSideTranslations("fr", ["common"])),
-  },
-});
+export const getStaticProps = async ({ locale }) => {
+  // get page data from AEM
+  const res = await queryGraphQL(get404Page).then((result) => {
+    return result;
+  });
+
+  const data = res.data.scLabsErrorPageByPath;
+
+  return process.env.NEXT_PUBLIC_ISR_ENABLED
+    ? {
+        props: {
+          locale: locale,
+          ...(await serverSideTranslations("en", ["common"])),
+          ...(await serverSideTranslations("fr", ["common"])),
+          pageData: data,
+        },
+        revalidate: 60, // revalidate once an minute
+      }
+    : {
+        props: {
+          locale: locale,
+          ...(await serverSideTranslations("en", ["common"])),
+          ...(await serverSideTranslations("fr", ["common"])),
+          pageData: data,
+        },
+      };
+};

--- a/pages/notsupported.js
+++ b/pages/notsupported.js
@@ -8,7 +8,7 @@ import { useState } from "react";
 import queryGraphQL from "../graphql/client";
 import getNotSupported from "../graphql/queries/notsupportedQuery.graphql";
 
-export default function error404(props) {
+export default function notSupported(props) {
   const { t } = useTranslation("common");
   const [enCopied, setEnCopied] = useState(false);
   const [frCopied, setFrCopied] = useState(false);
@@ -425,8 +425,6 @@ export const getStaticProps = async ({ locale }) => {
   });
 
   const data = res.data.scLabsErrorPageByPath;
-
-  console.log(res);
 
   return process.env.NEXT_PUBLIC_ISR_ENABLED
     ? {


### PR DESCRIPTION
# Description

[SCL-729 - Refactor 404 page to use queried data](https://jira-dev.bdm-dev.dts-stn.com/browse/SCL-729)
[SCL-729 - Refactor 500 page to use queried data](https://jira-dev.bdm-dev.dts-stn.com/browse/SCL-730)

The purpose of this PR is to refactor the 404 and 500 error pages to use content and assets from AEM.

## Test Instructions

1. Pull in branch
2. Type `yarn dev`
3. Navigate to both `/404` and `/500` to ensure both pages show up as expected

## Checklist

- [x] Strings use placeholders for translation (No hard coded strings)
- [x] Unit tests have been added/updated
- [x] Update CHANGELOG

## Product and Sprint Backlog

[Jira](https://jira-dev.bdm-dev.dts-stn.com/secure/RapidBoard.jspa?rapidView=96&projectKey=SCL)
