### PR TITLE
Updated custom error page to use AEM data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Update signup-info page to read content from cms
 - Removed `experience` email from privacy page, Report a Problem and Feedback components
 - Updated to Next.js `v12.1.6`
-- Updated `/notsupported`, `/404` and `/500` to use data from AEM
+- Updated `/notsupported`, `/404`, `/500`, and `/error` to use data from AEM
 
 ## Fixed
 

--- a/graphql/queries/customErrorQuery.graphql
+++ b/graphql/queries/customErrorQuery.graphql
@@ -1,0 +1,25 @@
+query getCustomErrorPage {
+	scLabsErrorPageByPath(_path: "/content/dam/decd-endc/content-fragments/alpha/sclabs/pages/custom-error-page") {
+	    item {
+            sclGcImages {
+                ... on DocumentRef {
+                    _path
+                }
+            }
+            sclImagelist {
+                ... on DocumentRef {
+                    _path
+                }
+                ... on ImageRef {
+                    _path
+                }
+            }
+            sclContentEn {
+                json
+            }
+            sclContentFr {
+                json
+            }
+        }
+	}
+}

--- a/pages/error.js
+++ b/pages/error.js
@@ -5,21 +5,24 @@ import { ActionButton } from "../components/atoms/ActionButton";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { useTranslation } from "next-i18next";
 import { useRouter } from "next/router";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
+import queryGraphQL from "../graphql/client";
+import getCustomErrorPage from "../graphql/queries/customErrorQuery.graphql";
 
 export default function ErrorPage(props) {
   const { t } = useTranslation("common");
   const { query } = useRouter();
+  const [pageData] = useState(props.pageData.item);
 
   const statusCode = query.statusCode || "";
-  const errorTitle = query.errorTitle || "The web site has reported an error.";
+  const errorTitle =
+    query.errorTitle || pageData.sclContentEn.json[0].content[0].value;
   const errorTitleFr =
-    query.errorTitleFr || "Le site Web a signalé une erreur.";
+    query.errorTitleFr || pageData.sclContentFr.json[0].content[0].value;
   const errorMessage =
-    query.errorMessage || "If the problem persists, report the problem.";
+    query.errorMessage || pageData.sclContentEn.json[1].content[0].value;
   const errorMessageFr =
-    query.errorMessageFr ||
-    "Si le problème persiste, veuillez signaler le problème.";
+    query.errorMessageFr || pageData.sclContentFr.json[1].content[0].value;
 
   useEffect(() => {
     if (process.env.NEXT_PUBLIC_ADOBE_ANALYTICS_URL) {
@@ -40,8 +43,8 @@ export default function ErrorPage(props) {
 
           {/* Primary HTML Meta Tags */}
           <title data-gc-analytics-error={props.statusCode}>
-            The web site has reported an error | Le site Web a signalé une
-            erreur
+            {pageData.sclContentEn.json[0].content[0].value} |{" "}
+            {pageData.sclContentFr.json[0].content[0].value}
           </title>
           <link rel="schema.dcterms" href="http://purl.org/dc/terms/" />
           <meta content="width=device-width, initial-scale=1" name="viewport" />
@@ -167,7 +170,7 @@ export default function ErrorPage(props) {
           <section className="layout-container pb-44">
             <img
               className="h-auto w-60 pt-6 xl:w-96 xxl:w-1/2"
-              src={"/sig-blk-en.svg"}
+              src={`https://www.canada.ca${pageData.sclGcImages[0]._path}`}
               alt={"Symbol of the Government of Canada"}
             />
             <div className="flex flex-col lg:flex-row justify-between items-center lg:items-start mt-8">
@@ -185,7 +188,8 @@ export default function ErrorPage(props) {
                       className="font-bold font-body mb-8"
                       data-testid="statuscode-en"
                     >
-                      Error {statusCode}
+                      {pageData.sclContentEn.json[2].content[0].value}{" "}
+                      {statusCode}
                     </p>
                   ) : (
                     ""
@@ -200,57 +204,62 @@ export default function ErrorPage(props) {
                     <>
                       {/* Wrong URL English Section */}
                       <p className="font-body text-sm leading-30px mb-5">
-                        It may be due to an invalid ID or missing ID. What’s
-                        next?
+                        {pageData.sclContentEn.json[3].content[0].value}
                       </p>
                       <ul>
                         <li className="flex">
                           <span className="error404-link" />
                           <p className="font-body text-sm leading-30px">
-                            Try clicking the link again from your email;
+                            {pageData.sclContentEn.json[4].content[0].value}
                           </p>
                         </li>
                         <li className="flex">
                           <span className="error404-link" />
                           <p className="font-body text-sm leading-30px">
-                            Contact us at{" "}
+                            {pageData.sclContentEn.json[5].content[0].value}
                             <a
                               href={`mailto:${process.env.NEXT_PUBLIC_NOTIFY_REPORT_A_PROBLEM_EMAIL}`}
                               className="text-custom-blue-link underline"
                             >
-                              experience@service.gc.ca
+                              {
+                                process.env
+                                  .NEXT_PUBLIC_NOTIFY_REPORT_A_PROBLEM_EMAIL
+                              }
                             </a>{" "}
-                            and we’ll help you out.
+                            {pageData.sclContentEn.json[6].content[0].value}
                           </p>
                         </li>
                       </ul>
                       <p className="font-body text-sm leading-30px mt-5">
-                        Thank you for your patience.
+                        {pageData.sclContentEn.json[7].content[0].value}
                       </p>
                     </>
                   ) : errorMessage === "Expired URL" ? (
                     <>
                       {/* Expired URL English Section */}
                       <p className="font-body text-sm leading-30px mb-5">
-                        It may be due to an expired URL if it has been more than
-                        24 hours since you received the email to verify your
-                        email address. What’s next?
+                        {pageData.sclContentEn.json[8].content[0].value}
                       </p>
                       <ul>
                         <li className="flex">
                           <span className="error404-link" />
                           <p className="font-body text-sm leading-30px">
-                            <Link href="/signup">
+                            <Link
+                              href={
+                                pageData.sclContentEn.json[9].content[0].data
+                                  .href
+                              }
+                            >
                               <a className="underline hover:text-canada-footer-hover-font-blue text-canada-footer-font">
-                                Sign up
+                                {pageData.sclContentEn.json[9].content[0].value}
                               </a>
                             </Link>{" "}
-                            again
+                            {pageData.sclContentEn.json[9].content[1].value}
                           </p>
                         </li>
                       </ul>
                       <p className="font-body text-sm leading-30px mt-5">
-                        Thank you for your patience.
+                        {pageData.sclContentEn.json[7].content[0].value}
                       </p>
                     </>
                   ) : (
@@ -258,10 +267,14 @@ export default function ErrorPage(props) {
                     <div className="flex">
                       <span className="error404-link" />
                       <p className="font-body text-sm leading-30px">
-                        Return to the &nbsp;
-                        <Link href="/">
+                        {pageData.sclContentEn.json[10].content[0].value}
+                        <Link
+                          href={
+                            pageData.sclContentEn.json[10].content[1].data.href
+                          }
+                        >
                           <a className="underline hover:text-canada-footer-hover-font-blue text-canada-footer-font">
-                            Service Canada Labs home page
+                            {pageData.sclContentEn.json[10].content[1].value}
                           </a>
                         </Link>
                       </p>
@@ -273,7 +286,7 @@ export default function ErrorPage(props) {
               <div className="flex items-center justify-center circle-background my-8 lg:mt-0">
                 <img
                   className="w-68px xl:w-24"
-                  src="/crackedbulb.svg"
+                  src={`https://www.canada.ca${pageData.sclImagelist[0]._path}`}
                   alt="Cracked lightbulb"
                 />
               </div>
@@ -294,7 +307,8 @@ export default function ErrorPage(props) {
                       className="font-bold font-body mb-8"
                       data-testid="statuscode-fr"
                     >
-                      Erreur {statusCode}
+                      {pageData.sclContentFr.json[2].content[0].value}{" "}
+                      {statusCode}
                     </p>
                   ) : (
                     ""
@@ -309,59 +323,62 @@ export default function ErrorPage(props) {
                     <>
                       {/* Wrong URL French Section */}
                       <p className="font-body text-sm leading-30px mb-5">
-                        Cela peut être dû à un identificateur invalide ou à un
-                        identificateur manquant. Que faire?
+                        {pageData.sclContentFr.json[3].content[0].value}
                       </p>
                       <ul>
                         <li className="flex">
                           <span className="error404-link" />
                           <p className="font-body text-sm leading-30px">
-                            Essayez de cliquer à nouveau sur le lien depuis
-                            votre courriel;
+                            {pageData.sclContentFr.json[4].content[0].value}
                           </p>
                         </li>
                         <li className="flex">
                           <span className="error404-link" />
                           <p className="font-body text-sm leading-30px">
-                            Contactez nous à{" "}
+                            {pageData.sclContentFr.json[5].content[0].value}
                             <a
                               href={`mailto:${process.env.NEXT_PUBLIC_NOTIFY_REPORT_A_PROBLEM_EMAIL}`}
                               className="text-custom-blue-link underline"
                             >
-                              experience@service.gc.ca
-                            </a>{" "}
-                            et nous vous aiderons.
+                              {
+                                process.env
+                                  .NEXT_PUBLIC_NOTIFY_REPORT_A_PROBLEM_EMAIL
+                              }
+                            </a>
+                            {pageData.sclContentFr.json[6].content[0].value}
                           </p>
                         </li>
                       </ul>
                       <p className="font-body text-sm leading-30px mt-5">
-                        Merci de votre patience.
+                        {pageData.sclContentFr.json[7].content[0].value}
                       </p>
                     </>
                   ) : errorMessageFr === "URL expirée" ? (
                     <>
                       {/* Expired URL French Section */}
                       <p className="font-body text-sm leading-30px mb-5">
-                        Le problème peut être dû à une URL expirée si cela fait
-                        plus de 24 heures que vous avez reçu le courriel
-                        vérifier votre adresse de courrier électronique. Que
-                        faire?
+                        {pageData.sclContentFr.json[8].content[0].value}
                       </p>
                       <ul>
                         <li className="flex">
                           <span className="error404-link" />
                           <p className="font-body text-sm leading-30px">
-                            <Link href="/signup">
+                            <Link
+                              href={
+                                pageData.sclContentFr.json[9].content[0].data
+                                  .href
+                              }
+                            >
                               <a className="underline hover:text-canada-footer-hover-font-blue text-canada-footer-font">
-                                Inscrivez-vous
+                                {pageData.sclContentFr.json[9].content[0].value}
                               </a>
                             </Link>{" "}
-                            de nouveau
+                            {pageData.sclContentFr.json[9].content[1].value}
                           </p>
                         </li>
                       </ul>
                       <p className="font-body text-sm leading-30px mt-5">
-                        Merci de votre patience.
+                        {pageData.sclContentFr.json[7].content[0].value}
                       </p>
                     </>
                   ) : (
@@ -369,10 +386,14 @@ export default function ErrorPage(props) {
                     <div className="flex">
                       <span className="error404-link" />
                       <p className="font-body text-sm leading-30px">
-                        Retournez à la &nbsp;
-                        <Link href="/fr">
+                        {pageData.sclContentFr.json[10].content[0].value}
+                        <Link
+                          href={
+                            pageData.sclContentFr.json[10].content[1].data.href
+                          }
+                        >
                           <a className="underline hover:text-canada-footer-hover-font-blue text-canada-footer-font">
-                            page d'accueil des laboratoires de Service Canada
+                            {pageData.sclContentFr.json[10].content[1].value}
                           </a>
                         </Link>
                       </p>
@@ -396,7 +417,7 @@ export default function ErrorPage(props) {
             />
             <img
               className="h-6 w-auto lg:h-auto lg:w-40"
-              src="/wmms-blk.svg"
+              src={`https://www.canada.ca${pageData.sclGcImages[1]._path}`}
               alt="Symbol of the Government of Canada"
             />
           </div>
@@ -412,11 +433,29 @@ export default function ErrorPage(props) {
 }
 
 export const getStaticProps = async ({ locale }) => {
-  return {
-    props: {
-      locale: locale,
-      ...(await serverSideTranslations("en", ["common"])),
-      ...(await serverSideTranslations("fr", ["common"])),
-    },
-  };
+  // get page data from AEM
+  const res = await queryGraphQL(getCustomErrorPage).then((result) => {
+    return result;
+  });
+
+  const data = res.data.scLabsErrorPageByPath;
+
+  return process.env.NEXT_PUBLIC_ISR_ENABLED
+    ? {
+        props: {
+          locale: locale,
+          ...(await serverSideTranslations("en", ["common"])),
+          ...(await serverSideTranslations("fr", ["common"])),
+          pageData: data,
+        },
+        revalidate: 60, // revalidate once an minute
+      }
+    : {
+        props: {
+          locale: locale,
+          ...(await serverSideTranslations("en", ["common"])),
+          ...(await serverSideTranslations("fr", ["common"])),
+          pageData: data,
+        },
+      };
 };


### PR DESCRIPTION
# Description

[SCL-736 - Refactor custom /error page to use queried data](https://jira-dev.bdm-dev.dts-stn.com/browse/SCL-736)

The purpose of this PR is to update the custom `/error.js` page to use content from AEM.

## Test Instructions

1. Pull in branch
2. Type `yarn dev`
3. Navigate to `/error?errorMessage=Wrong%20URL&errorMessageFr=URL%20erronée` and ensure everything shows up properly
4. Navigate to `/error?errorMessage=Expired%20URL&errorMessageFr=URL%20expirée` and ensure everything shows up properly

## Checklist

- [x] Strings use placeholders for translation (No hard coded strings)
- [x] Unit tests have been added/updated
- [x] Update CHANGELOG

## Product and Sprint Backlog

[Jira](https://jira-dev.bdm-dev.dts-stn.com/secure/RapidBoard.jspa?rapidView=96&projectKey=SCL)
