### PR TITLE
Refactor signup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,11 +52,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Update home page data model to read content from cms
 - Update about page to read content from cms
 - Changed number of steps for signup and unsubscribe from 3 to 2
-- Removed srSpeak function from feedback widget and instead put `aria-live="polite"` on the form 
+- Removed srSpeak function from feedback widget and instead put `aria-live="polite"` on the form
 - Update signup-info page to read content from cms
 - Removed `experience` email from privacy page, Report a Problem and Feedback components
 - Updated to Next.js `v12.1.6`
 - Updated `/notsupported`, `/404` and `/500` to use data from AEM
+- Updated `/signup` page to use get data from AEM
 
 ## Fixed
 
@@ -69,7 +70,6 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Fixed how we handle data from Strapi
 - Fixed CallToAction redirect on `/projects` page so that it links to `/signup-info` instead of `/signup`
 - Fixed email and close button focus on the feedback widget
-
 
 ## [v1.1.3] - 2021-10-27
 

--- a/__mocks__/mockStore.js
+++ b/__mocks__/mockStore.js
@@ -485,3 +485,243 @@ export const error404Page = {
     },
   },
 };
+
+export const signupPage = {
+  data: {
+    sclabsSignupList: {
+      items: [
+        {
+          _path:
+            "/content/dam/decd-endc/content-fragments/alpha/sclabs/pages/signup",
+          form: {
+            formFields: {
+              en: {
+                label: {
+                  email: "Email",
+                  confirmEmail: "Confirm email address",
+                  yearOfBirth: "What is your year of birth",
+                  language:
+                    "What language would you like us to contact you in?",
+                  province: "What province/territory do you live in?",
+                  gender: "Which term best describes your gender identity?",
+                  indigenous:
+                    "Do you identify as Indigenous; that is First Nations, Métis, or Inuit?",
+                  disability: "Do you identify as a person with a disability?",
+                  minority:
+                    "Do you identify as a member of a visible minority in Canada?",
+                  income:
+                    "What is your approximate annual household income (before taxes)?",
+                  publicServant:
+                    "Are you currently working as a public servant?",
+                },
+                option: {
+                  yes: "yes",
+                  no: "no",
+                  notSure: "I'm not sure",
+                  notApply: "Does not apply to me",
+                  preferNotAnswer: "I prefer not to answer",
+                  english: "English",
+                  french: "French",
+                  woman: "Woman",
+                  man: "Man",
+                  another: "Another",
+                  anotherDetail: "If 'Another' please specify",
+                  firstNations: "First Nations",
+                  metis: "Métis",
+                  inuk: "Inuk (Inuit)",
+                  income1: "Less than $30,000",
+                  income2: "$30,001 to $59,999",
+                  income3: "$60,000 to $99,999",
+                  income4: "$100,000 to $149,999",
+                  income5: "$150,000 or more",
+                  assistiveTech:
+                    "If 'Yes', what assistive technology will you need in order to participate in an online research session with us?",
+                  personalInfo:
+                    "Do not include any personal, medical or financial details, such as your name, social insurance number (SIN), home or business address, phone number or any case or file numbers.",
+                  province: {
+                    AB: "Alberta",
+                    BC: "British Columbia",
+                    MB: "Manitoba",
+                    NB: "New Brunswick",
+                    NL: "Newfoundland and Labrador",
+                    NT: "Northwest Territory",
+                    NS: "Nova Scotia",
+                    NU: "Nunavut",
+                    ON: "Ontario",
+                    PE: "Prince Edward Island",
+                    QC: "Quebec",
+                    SK: "Saskatchewan",
+                    YT: "Yukon",
+                    other: "Other",
+                  },
+                  minority: {
+                    detail:
+                      "If 'yes', select the options that you identify with.",
+                    black: "Black",
+                    chinese: "Chinese",
+                    filipino: "Filipino",
+                    japanese: "Japanese",
+                    korean: "Korean",
+                    latinAmerican:
+                      "Non-White Latin American (including: indigenous persons from Central and South America, etc.)",
+                    southAsian:
+                      "South Asian/East Indian (including: Indian from India; Bangladeshi; Pakistani; East Indian from Guyana, Trinidad, East Africa; etc.)",
+                    sea: "South-East Asian (including: Burmese; Cambodian; Laotian; Thai; Vietnamese; etc.)",
+                    nonWhite:
+                      "Non-White West Asian, North African or Arab (including: Egyptian; Libyan; Lebanese; Iranian; etc.)",
+                    mixedOrigin:
+                      "Person of Mixed Origin (with one parent in one of the visible minority groups)",
+                    another: "Another visible minority",
+                    anotherDetail:
+                      "If 'Another visible minority group', please specify",
+                  },
+                },
+                errorMsg: {
+                  error: "Error",
+                  invalidEmail: "Must be a valid email",
+                  emailMustMatch: "Emails must match",
+                  age: "Must be at least 18 years old",
+                  emailRequired: "Email - This field is required",
+                  yearOfBirthRequired: "Year of birth - This field is required",
+                  language:
+                    "What language would you like us to contact you in - This field is required",
+                  agreeToConditions:
+                    "You must agree to conditions before sign up",
+                  errorRegistered:
+                    "It looks like you have previously registered with us. Check your inbox for the validation email!",
+                  errorUnknown:
+                    "An unknown error has occurred during your registration. Please contact experience@servicecanada.gc.ca to continue your registration or try again later",
+                },
+                agreeToConditions:
+                  "I have read, understood and agree to the above. I affirm that I am 18 years old, or older. I understand that I can withdraw from this participant pool, or any research study at any time without consequence.",
+                privacy: "Read the full privacy policy",
+                privacyLink: "/signup/privacy",
+                submit: "Submit",
+                clearForm: "Clear my information from this form",
+              },
+              fr: {
+                label: {
+                  email: "Adresse de courrier électronique",
+                  confirmEmail: "Confirmer l'adresse courriel",
+                  yearOfBirth: "En quelle année êtes-vous né?",
+                  language:
+                    "Dans quelle langue souhaitez-vous que nous communiquions avec vous?",
+                  province: "Dans quelle province ou territoire résidez-vous?",
+                  gender:
+                    "Lequel de ces choix décrit le mieux votre identité de genre?",
+                  indigenous:
+                    "Vous identifiez-vous comme étant une personne autochtone, c’est-à-dire membre des peuples des Premières Nations, Métis ou Inuits?",
+                  disability:
+                    "Vous identifiez-vous comme une personne en situation de handicap?",
+                  minority:
+                    "Vous identifiez-vous comme étant membre d’une minorité visible au Canada?",
+                  income:
+                    "Quel est le revenu annuel approximatif de votre ménage (avant impôts)?",
+                  publicServant:
+                    "Travaillez-vous actuellement en tant que fonctionnaire?",
+                },
+                option: {
+                  yes: "Oui",
+                  no: "Non",
+                  notSure: "Je ne suis pas certain",
+                  notApply: "Ne s’applique pas à moi",
+                  preferNotAnswer: "Je préfère ne pas répondre",
+                  english: "Anglais",
+                  french: "Français",
+                  woman: "Femme",
+                  man: "Homme",
+                  another: "Un autre genre",
+                  anotherDetail:
+                    "Si vous indiquez « Un autre genre », veuillez préciser.",
+                  firstNations: "Premières nations",
+                  metis: "Métis",
+                  inuk: "Inuit",
+                  income1: "Moins de 30 000 $",
+                  income2: "De 30 001 $ à 59 999 $",
+                  income3: "De 60 000 $ à 99 999 $",
+                  income4: "De 100 000 $ à 149 999 $",
+                  income5: "150 000 $ ou plus",
+                  assistiveTech:
+                    "Si la réponse est « oui », de quelles technologie d’assistance aurez-vous besoin pour participer à une séance de recherche en ligne avec nous?",
+                  personalInfo:
+                    "Ne pas inclure de renseignements personnels, médicaux ou financiers, comme par exemple, un numéro d’assurance sociale (NAS), une adresse de domicile ou de lieu de travail, un numéro de téléphone ou numéro de dossier.",
+                  province: {
+                    AB: "Alberta",
+                    BC: "Colombie-Britannique",
+                    MB: "Manitoba",
+                    NB: "Nouveau-Brunswick",
+                    NL: "Terre-Neuve-et-Labrador",
+                    NT: "Territoires du Nord-Ouest",
+                    NS: "Nouvelle-Écosse",
+                    NU: "Nunavut",
+                    ON: "Ontario",
+                    PE: "île du Prince-Édouard",
+                    QC: "Québec",
+                    SK: "Saskatchewan",
+                    YT: "Yukon",
+                    other: "Autres",
+                  },
+                  minority: {
+                    detail:
+                      "Si vous avez répondu « Oui », sélectionnez les options auxquelles vous vous identifiez.",
+                    black: "Noirs",
+                    chinese: "Chinois",
+                    filipino: "Philippin",
+                    japanese: "Japonais",
+                    korean: "Coréen",
+                    latinAmerican:
+                      "Latino-Américain non blanc (incluant : Amérindiens de l’Amérique centrale et de l’Amérique du Sud, etc.)",
+                    southAsian:
+                      "Asiatique du Sud/Indien de l’Est (incluant : Indien de l’Inde, Bangladais, Pakistanais, Indien de l’Est originaire de la Guyane, de la Trinité, de l’Afrique orientale, etc.)",
+                    sea: "Asiatique du Sud-Est (incluant : Birman, Cambodgien, Laotien, Thaïlandais, Vietnamien, etc.)",
+                    nonWhite:
+                      "Asiatique de l’Ouest non blanc, Nord-Africain non blanc ou Arabe (incluant : Égyptien, Libyen, Libanais, Iranien, etc.)",
+                    mixedOrigin:
+                      "Personnes d’origine mixte (dont l’un des parents provient de l’un des groupes de minorité visible)",
+                    another: "Autre groupe de minorité visiblecollapsed",
+                    anotherDetail:
+                      "Si vous avez répondu « Autre groupe des minorités visibles », veuillez préciser.",
+                  },
+                },
+                errorMsg: {
+                  error: "Erreur",
+                  invalidEmail:
+                    "Doit être une adresse de courrier électronique valide",
+                  emailMustMatch: "les courriels doivent être identiques",
+                  age: "Vous devez être âgé de 18 ans ou plus",
+                  emailRequired:
+                    "Adresse de courrier électronique - Ce champ est obligatoire",
+                  yearOfBirthRequired:
+                    "Année de naissance - Ce champ est obligatoire",
+                  language:
+                    "Langue pour communiquer avec vous - Ce champ est obligatoire",
+                  agreeToConditions:
+                    "Vous devez accepter les conditions avant de vous inscrire",
+                  errorRegistered:
+                    "Il semble que vous vous soyez déjà enregistré auprès de nous. Vérifiez votre boîte de réception pour l’email de validation !",
+                  errorUnknown:
+                    "Une erreur inconnue s’est produite lors de votre inscription. Veuillez contacter experience@servicecanada.gc.ca pour poursuivre votre inscription ou réessayer plus tard",
+                },
+                agreeToConditions:
+                  "J’ai lu, compris et accepté ce qui précède. J’affirme que j’ai 18 ans ou plus. Je comprends que je peux me retirer de ce groupe de participants ou de toute étude de recherche à tout moment, sans conséquence.",
+                privacy:
+                  "Lire la politique en matière de protection des renseignements personnels dans son intégralité",
+                privacyLink:
+                  "/fr/inscription/protection-renseignements-personnels",
+                submit: "Soumettre",
+                clearForm: "Effacer mes renseignements du formulaire",
+              },
+            },
+          },
+          title: "Sign up to get invited to research sessions (Step 1 of 2)",
+          titleFr:
+            "S’inscrire pour être invité aux séances de recherche (étape 1 sur 2)",
+          requiredInformation: "Indicates required information",
+          requiredInformationFr: "Indique que les renseignements sont requis",
+          url: "/signup",
+          urlFr: "/fr/inscription",
+        },
+      ],
+    },
+  },
+};

--- a/__tests__/pages/signup.test.js
+++ b/__tests__/pages/signup.test.js
@@ -3,10 +3,17 @@
  */
 import { render, screen } from "@testing-library/react";
 import Signup from "../../pages/signup";
+import { signupPage } from "../../__mocks__/mockStore";
+
+jest.mock("@apollo/client");
 
 describe("Signup", () => {
   it("renders without crashing", () => {
-    render(<Signup />);
-    expect(screen.getByText("signupTitle")).toBeInTheDocument();
+    render(<Signup pageData={signupPage.data.sclabsSignupList} />);
+    expect(
+      screen.getByRole("heading", {
+        name: "Sign up to get invited to research sessions (Step 1 of 2)",
+      })
+    ).toBeInTheDocument();
   });
 });

--- a/graphql/queries/signupQuery.graphql
+++ b/graphql/queries/signupQuery.graphql
@@ -1,0 +1,16 @@
+query getSignupPage {
+  sclabsSignupList {
+    items {
+      _path
+      form {
+        formFields
+      }
+      title
+      titleFr
+      requiredInformation
+      requiredInformationFr
+      url
+      urlFr
+    }
+  }
+}

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -17,6 +17,8 @@ import { CheckBox } from "../components/atoms/CheckBox";
 import { OptionalListField } from "../components/molecules/OptionalListField";
 import { maskEmail } from "../lib/utils/maskEmail";
 import Link from "next/link";
+import queryGraphQL from "../graphql/client";
+import getSignupPage from "../graphql/queries/signupQuery.graphql";
 
 // TODO
 //  - fix bug with error messages not showing custom error message [x]
@@ -27,7 +29,12 @@ import Link from "next/link";
 export default function Signup(props) {
   const { t } = useTranslation("common");
   const { push } = useRouter();
+  const [pageData] = useState(props.pageData.items);
   const fr = props.locale === "fr";
+  const formField =
+    props.locale === "en"
+      ? pageData[0].form.formFields.en
+      : pageData[0].form.formFields.fr;
 
   // get the options for the year of birth ranges
   const minYear = new Date().getFullYear() - 18;
@@ -58,10 +65,10 @@ export default function Signup(props) {
         errors.forEach((error) => {
           switch (error.code) {
             case "any.required":
-              error.message = t("emailRequired");
+              error.message = formField.errorMsg.emailRequired;
               break;
             case "string.email":
-              error.message = t("errorEmail");
+              error.message = formField.errorMsg.invalidEmail;
             default:
               break;
           }
@@ -76,12 +83,12 @@ export default function Signup(props) {
         errors.forEach((error) => {
           switch (error.code) {
             case "any.required":
-              error.message = t("emailRequired");
+              error.message = formField.errorMsg.emailRequired;
               break;
             case "string.email":
-              error.message = t("errorEmail");
+              error.message = formField.errorMsg.invalidEmail;
             case "any.only":
-              error.message = t("emailError");
+              error.message = formField.errorMsg.emailMustMatch;
             default:
               break;
           }
@@ -95,10 +102,10 @@ export default function Signup(props) {
         errors.forEach((error) => {
           switch (error.code) {
             case "any.required":
-              error.message = t("yearRequired");
+              error.message = formField.errorMsg.yearOfBirthRequired;
               break;
             case "any.invalid":
-              error.message = t("errorMustBe18");
+              error.message = formField.errorMsg.age;
               break;
             default:
               break;
@@ -113,7 +120,7 @@ export default function Signup(props) {
         errors.forEach((error) => {
           switch (error.code) {
             case "any.required":
-              error.message = t("languageRequired");
+              error.message = formField.errorMsg.language;
               break;
             default:
               break;
@@ -175,7 +182,7 @@ export default function Signup(props) {
         errors.forEach((error) => {
           switch (error.code) {
             case "any.required":
-              error.message = t("errorTerms");
+              error.message = formField.errorMsg.agreeToConditions;
               break;
             default:
               break;
@@ -335,14 +342,16 @@ export default function Signup(props) {
         if (!prevErrors[field]) {
           prevErrors[field] = {
             id: field,
-            text: `${t("error")} ${fr ? "\u00A0:" : ":"} ` + message,
+            text:
+              `${formField.errorMsg.error} ${fr ? "\u00A0:" : ":"} ` + message,
           };
         }
         // override the error message if the type of error is because the field is empty
         else if (type.includes("empty")) {
           prevErrors[field] = {
             id: field,
-            text: `${t("error")} ${fr ? "\u00A0:" : ":"} ` + message,
+            text:
+              `${formField.errorMsg.error} ${fr ? "\u00A0:" : ":"} ` + message,
           };
         }
         return prevErrors;
@@ -386,9 +395,9 @@ export default function Signup(props) {
           query: { e: maskedEmail, ref: "signup" },
         });
       } else if (response.status === 400) {
-        await setGlobalErrorText(t("errorRegistered"));
+        await setGlobalErrorText(formField.errorMsg.errorRegistered);
       } else {
-        await setGlobalErrorText(t("errorUnknown"));
+        await setGlobalErrorText(formField.errorMsg.errorUnknown);
       }
     }
     // Checks if error exists
@@ -415,7 +424,7 @@ export default function Signup(props) {
     <>
       <Layout
         locale={props.locale}
-        langUrl={t("signupPath")}
+        langUrl={fr ? pageData[0].url : pageData[0].urlFr}
         breadcrumbItems={[
           { text: t("siteTitle"), link: t("breadCrumbsHref1") },
           { text: t("signupInfoTitle"), link: t("breadCrumbsHref4") },
@@ -511,7 +520,7 @@ export default function Signup(props) {
         <section className="layout-container mb-2 mt-12">
           <div className="xl:w-2/3">
             <h1 className="mb-12" id="pageMainTitle" tabIndex="-1">
-              {t("signupTitle")}
+              {fr ? pageData[0].titleFr : pageData[0].title}
             </h1>
           </div>
         </section>
@@ -541,11 +550,13 @@ export default function Signup(props) {
                 <b className="text-error-border-red mr-2" aria-hidden="true">
                   *
                 </b>
-                {t("requiredInfo")}
+                {fr
+                  ? pageData[0].requiredInformationFr
+                  : pageData[0].requiredInformation}
               </p>
               <TextField
                 className="mb-10"
-                label={t("email")}
+                label={formField.label.email}
                 type="email"
                 name="email"
                 id="email"
@@ -559,7 +570,7 @@ export default function Signup(props) {
               />
               <TextField
                 className="mb-10"
-                label={t("confirmEmail")}
+                label={formField.label.confirmEmail}
                 type="email"
                 name="confirmEmail"
                 id="confirmEmail"
@@ -571,7 +582,7 @@ export default function Signup(props) {
                 autoComplete="email"
               />
               <SelectField
-                label={t("formYear")}
+                label={formField.label.yearOfBirth}
                 className="mb-10"
                 id="yearOfBirthRange"
                 boldLabel
@@ -594,14 +605,16 @@ export default function Signup(props) {
                   <b className="text-error-border-red" aria-hidden="true">
                     *
                   </b>{" "}
-                  {t("formLang")}
+                  {formField.label.language}
                   <span className="sr-only">required</span>
                 </legend>
                 {languageError ? (
                   <ErrorLabel message={languageError} />
                 ) : undefined}
                 <RadioField
-                  label={fr ? t("fr") : t("en")}
+                  label={
+                    fr ? formField.option.french : formField.option.english
+                  }
                   id={fr ? "languageFr" : "languageEn"}
                   name="language"
                   value={fr ? "fr" : "en"}
@@ -610,7 +623,9 @@ export default function Signup(props) {
                   onChange={(checked, name, value) => setLanguage(value)}
                 />
                 <RadioField
-                  label={fr ? t("en") : t("fr")}
+                  label={
+                    fr ? formField.option.english : formField.option.french
+                  }
                   id={fr ? "languageEn" : "languageFr"}
                   name="language"
                   value={fr ? "en" : "fr"}
@@ -621,7 +636,7 @@ export default function Signup(props) {
               </fieldset>
 
               <SelectField
-                label={t("prov")}
+                label={formField.label.province}
                 className="mb-10"
                 id="province"
                 boldLabel
@@ -631,67 +646,67 @@ export default function Signup(props) {
                 options={[
                   {
                     id: "on",
-                    name: t("ON"),
+                    name: formField.option.province.ON,
                     value: "ON",
                   },
                   {
                     id: "qc",
-                    name: t("QC"),
+                    name: formField.option.province.QC,
                     value: "QC",
                   },
                   {
                     id: "nl",
-                    name: t("NL"),
+                    name: formField.option.province.NL,
                     value: "NL",
                   },
                   {
                     id: "pe",
-                    name: t("PE"),
+                    name: formField.option.province.PE,
                     value: "PE",
                   },
                   {
                     id: "ns",
-                    name: t("NS"),
+                    name: formField.option.province.NS,
                     value: "NS",
                   },
                   {
                     id: "nb",
-                    name: t("NB"),
+                    name: formField.option.province.NB,
                     value: "NB",
                   },
                   {
                     id: "mb",
-                    name: t("MB"),
+                    name: formField.option.province.MB,
                     value: "MB",
                   },
                   {
                     id: "sk",
-                    name: t("SK"),
+                    name: formField.option.province.SK,
                     value: "SK",
                   },
                   {
                     id: "ab",
-                    name: t("AB"),
+                    name: formField.option.province.AB,
                     value: "AB",
                   },
                   {
                     id: "bc",
-                    name: t("BC"),
+                    name: formField.option.province.BC,
                     value: "BC",
                   },
                   {
                     id: "yt",
-                    name: t("YT"),
+                    name: formField.option.province.YT,
                     value: "YT",
                   },
                   {
                     id: "nt",
-                    name: t("NT"),
+                    name: formField.option.province.NT,
                     value: "NT",
                   },
                   {
                     id: "nu",
-                    name: t("NU"),
+                    name: formField.option.province.NU,
                     value: "NU",
                   },
                 ]}
@@ -701,10 +716,10 @@ export default function Signup(props) {
 
               <fieldset className="mb-6">
                 <legend className="block leading-tight text-sm lg:text-p font-body mb-5 font-bold">
-                  {t("formGender")}{" "}
+                  {formField.label.gender}{" "}
                 </legend>
                 <RadioField
-                  label={t("woman")}
+                  label={formField.option.woman}
                   id="genderWoman"
                   name="gender"
                   onChange={(checked, name, value) => setGender(value)}
@@ -712,7 +727,7 @@ export default function Signup(props) {
                   value="woman"
                 />
                 <RadioField
-                  label={t("man")}
+                  label={formField.option.man}
                   id="genderMan"
                   name="gender"
                   onChange={(checked, name, value) => setGender(value)}
@@ -720,10 +735,10 @@ export default function Signup(props) {
                   value="man"
                 />
                 <OptionalTextField
-                  controlLabel={t("another")}
+                  controlLabel={formField.option.another}
                   textFieldName="genderOtherDetails"
                   textFieldId="genderOtherDetails"
-                  textFieldLabel={t("otherDetails")}
+                  textFieldLabel={formField.option.anotherDetail}
                   controlName="gender"
                   controlId="genderOther"
                   controlValue="other"
@@ -739,7 +754,7 @@ export default function Signup(props) {
                   describedby="genderotherDescribedBy"
                 />
                 <RadioField
-                  label={t("preferNotAnswer")}
+                  label={formField.option.preferNotAnswer}
                   id="genderPreferNotToAnswer"
                   name="gender"
                   onChange={(checked, name, value) => setGender(value)}
@@ -750,10 +765,10 @@ export default function Signup(props) {
 
               <fieldset className="mb-6">
                 <legend className="block leading-tight text-sm lg:text-p font-body mb-5 font-bold">
-                  {t("formIndigenous")}{" "}
+                  {formField.label.indigenous}{" "}
                 </legend>
                 <RadioField
-                  label={t("FN")}
+                  label={formField.option.firstNations}
                   id="nativeStatusFirstNations"
                   checked={nativeStatus === "firstNations"}
                   onChange={(checked, name, value) => {
@@ -763,7 +778,7 @@ export default function Signup(props) {
                   value="firstNations"
                 />
                 <RadioField
-                  label={t("metis")}
+                  label={formField.option.metis}
                   id="nativeStatusMétis"
                   checked={nativeStatus === "métis"}
                   onChange={(checked, name, value) => {
@@ -773,7 +788,7 @@ export default function Signup(props) {
                   value="métis"
                 />
                 <RadioField
-                  label={t("inuit")}
+                  label={formField.option.inuk}
                   id="nativeStatusInuit"
                   checked={nativeStatus === "inuit"}
                   onChange={(checked, name, value) => {
@@ -783,7 +798,7 @@ export default function Signup(props) {
                   value="inuit"
                 />
                 <RadioField
-                  label={t("doesNotApply")}
+                  label={formField.option.notApply}
                   id="nativeStatusNA"
                   checked={nativeStatus === "N/A"}
                   onChange={(checked, name, value) => {
@@ -793,7 +808,7 @@ export default function Signup(props) {
                   value="N/A"
                 />
                 <RadioField
-                  label={t("preferNotAnswer")}
+                  label={formField.option.preferNotAnswer}
                   id="nativeStatusPreferNotToAnswer"
                   checked={nativeStatus === "preferNotToAnswer"}
                   onChange={(checked, name, value) => {
@@ -806,13 +821,13 @@ export default function Signup(props) {
 
               <fieldset className="mb-6">
                 <legend className="block leading-tight text-sm lg:text-p font-body mb-5 font-bold">
-                  {t("disability")}{" "}
+                  {formField.label.disability}{" "}
                 </legend>
                 <OptionalTextField
-                  controlLabel={t("yes")}
+                  controlLabel={formField.option.yes}
                   textFieldName="disabilityDetails"
                   textFieldId="disabilityDetails"
-                  textFieldLabel={t("yesDetails")}
+                  textFieldLabel={formField.option.assistiveTech}
                   textLabelBold={true}
                   textFieldRequired={true}
                   multiText={true}
@@ -833,7 +848,7 @@ export default function Signup(props) {
                   describedby="disabilityDetailsDescribedBy"
                 />
                 <RadioField
-                  label={t("no")}
+                  label={formField.option.no}
                   id="disabilityNo"
                   onChange={(checked, name, value) => setDisability(value)}
                   checked={disability === "no"}
@@ -842,7 +857,7 @@ export default function Signup(props) {
                   dataCy="btn-disability-no"
                 />
                 <RadioField
-                  label={t("notSure")}
+                  label={formField.option.notSure}
                   id="disabilityNotSure"
                   onChange={(checked, name, value) => setDisability(value)}
                   checked={disability === "notSure"}
@@ -850,7 +865,7 @@ export default function Signup(props) {
                   value="notSure"
                 />
                 <RadioField
-                  label={t("preferNotAnswer")}
+                  label={formField.option.preferNotAnswer}
                   id="disabilityPreferNotToAnswer"
                   onChange={(checked, name, value) => setDisability(value)}
                   checked={disability === "preferNotToAnswer"}
@@ -861,20 +876,20 @@ export default function Signup(props) {
 
               <fieldset className="mb-6">
                 <legend className="block leading-tight text-sm lg:text-p font-body mb-5 font-bold">
-                  {t("formMinority")}{" "}
+                  {formField.label.minority}{" "}
                 </legend>
                 <OptionalListField
                   controlName="minority"
                   controlId="minorityYes"
-                  controlLabel={t("yes")}
+                  controlLabel={formField.option.yes}
                   controlValue="yes"
                   controlType="radiofield"
                   checked={minority === "yes"}
                   onControlChange={(checked, name, value) => setMinority(value)}
-                  listLabel={t("minorityYesDetails")}
+                  listLabel={formField.option.minority.detail}
                 >
                   <CheckBox
-                    label={t("black")}
+                    label={formField.option.minority.black}
                     id="minorityGroupBlack"
                     name="minorityGroup"
                     checked={minorityGroup.includes("black")}
@@ -883,7 +898,7 @@ export default function Signup(props) {
                     className="mb-7"
                   />
                   <CheckBox
-                    label={t("chinese")}
+                    label={formField.option.minority.chinese}
                     id="minorityGroupChinese"
                     name="minorityGroup"
                     checked={minorityGroup.includes("chinese")}
@@ -892,7 +907,7 @@ export default function Signup(props) {
                     className="mb-7"
                   />
                   <CheckBox
-                    label={t("filipino")}
+                    label={formField.option.minority.filipino}
                     id="minorityGroupFilipino"
                     name="minorityGroup"
                     checked={minorityGroup.includes("filipino")}
@@ -901,7 +916,7 @@ export default function Signup(props) {
                     className="mb-7"
                   />
                   <CheckBox
-                    label={t("japanese")}
+                    label={formField.option.minority.japanese}
                     id="minorityGroupJapanese"
                     name="minorityGroup"
                     checked={minorityGroup.includes("japanese")}
@@ -910,7 +925,7 @@ export default function Signup(props) {
                     className="mb-7"
                   />
                   <CheckBox
-                    label={t("korean")}
+                    label={formField.option.minority.korean}
                     id="minorityGroupKorean"
                     name="minorityGroup"
                     checked={minorityGroup.includes("korean")}
@@ -919,7 +934,7 @@ export default function Signup(props) {
                     className="mb-7"
                   />
                   <CheckBox
-                    label={t("SA")}
+                    label={formField.option.minority.southAsian}
                     id="minorityGroupSouthAsian"
                     name="minorityGroup"
                     checked={minorityGroup.includes("southAsian")}
@@ -932,7 +947,7 @@ export default function Signup(props) {
                     }
                   />
                   <CheckBox
-                    label={t("SEA")}
+                    label={formField.option.minority.sea}
                     id="minorityGroupSoutheastAsian"
                     name="minorityGroup"
                     checked={minorityGroup.includes("southeastAsian")}
@@ -941,7 +956,7 @@ export default function Signup(props) {
                     className="mb-12 md:mb-7"
                   />
                   <CheckBox
-                    label={t("nonWhiteAAA")}
+                    label={formField.option.minority.nonWhite}
                     id="minorityGroupNonWhiteAAA"
                     name="minorityGroup"
                     checked={minorityGroup.includes("nonWhiteAAA")}
@@ -952,7 +967,7 @@ export default function Signup(props) {
                     }
                   />
                   <CheckBox
-                    label={t("LA")}
+                    label={formField.option.minority.latinAmerican}
                     id="minorityGroupLatinAmerican"
                     name="minorityGroup"
                     checked={minorityGroup.includes("latinAmerican")}
@@ -961,7 +976,7 @@ export default function Signup(props) {
                     className="mb-16 md:mb-7"
                   />
                   <CheckBox
-                    label={t("mixedOrigin")}
+                    label={formField.option.minority.mixedOrigin}
                     id="minorityGroupMixedOrigin"
                     name="minorityGroup"
                     checked={minorityGroup.includes("mixedOrigin")}
@@ -970,7 +985,7 @@ export default function Signup(props) {
                     className="mb-12 md:mb-7"
                   />
                   <OptionalTextField
-                    controlLabel={t("otherMinority")}
+                    controlLabel={formField.option.minority.another}
                     textFieldName="minorityGroupOther"
                     textFieldId="minorityGroupOtherDetails"
                     textLabelBold={true}
@@ -978,7 +993,7 @@ export default function Signup(props) {
                     onControlChange={handlerMinorityGroupOnChange}
                     onTextFieldChange={setMinorityGroupOther}
                     textFieldValue={minorityGroupOther}
-                    textFieldLabel={t("otherMinorityDetails")}
+                    textFieldLabel={formField.option.minority.anotherDetail}
                     controlValue="other"
                     controlName="minorityGroup"
                     controlId="minorityGroupOther"
@@ -986,7 +1001,7 @@ export default function Signup(props) {
                   />
                 </OptionalListField>
                 <RadioField
-                  label={t("no")}
+                  label={formField.option.no}
                   id="minorityNo"
                   name="minority"
                   value="no"
@@ -994,7 +1009,7 @@ export default function Signup(props) {
                   onChange={(checked, name, value) => setMinority(value)}
                 />
                 <RadioField
-                  label={t("preferNotAnswer")}
+                  label={formField.option.preferNotAnswer}
                   id="minorityPreferNotToAnswer"
                   onChange={(checked, name, value) => setMinority(value)}
                   checked={minority === "preferNotToAnswer"}
@@ -1005,10 +1020,10 @@ export default function Signup(props) {
 
               <fieldset className="mb-6">
                 <legend className="block leading-tight text-sm lg:text-p font-body mb-5 font-bold">
-                  {t("formIncome")}{" "}
+                  {formField.label.income}{" "}
                 </legend>
                 <RadioField
-                  label={t("income1")}
+                  label={formField.option.income1}
                   id="income30kLess"
                   name="incomeLevel"
                   checked={incomeLevel === "30kLess"}
@@ -1016,7 +1031,7 @@ export default function Signup(props) {
                   value="30kLess"
                 />
                 <RadioField
-                  label={t("income2")}
+                  label={formField.option.income2}
                   id="income60kLess"
                   name="incomeLevel"
                   checked={incomeLevel === "30kto60k"}
@@ -1024,7 +1039,7 @@ export default function Signup(props) {
                   value="30kto60k"
                 />
                 <RadioField
-                  label={t("income3")}
+                  label={formField.option.income3}
                   id="income100kLess"
                   name="incomeLevel"
                   checked={incomeLevel === "60kto100k"}
@@ -1032,7 +1047,7 @@ export default function Signup(props) {
                   value="60kto100k"
                 />
                 <RadioField
-                  label={t("income4")}
+                  label={formField.option.income4}
                   id="income150kLess"
                   name="incomeLevel"
                   checked={incomeLevel === "100kto150k"}
@@ -1040,7 +1055,7 @@ export default function Signup(props) {
                   value="100kto150k"
                 />
                 <RadioField
-                  label={t("income5")}
+                  label={formField.option.income5}
                   id="income150kMore"
                   name="incomeLevel"
                   checked={incomeLevel === "150kMore"}
@@ -1048,7 +1063,7 @@ export default function Signup(props) {
                   value="150kMore"
                 />
                 <RadioField
-                  label={t("preferNotAnswer")}
+                  label={formField.option.preferNotAnswer}
                   id="incomePreferNotToAnswer"
                   name="incomeLevel"
                   checked={incomeLevel === "preferNotToAnswer"}
@@ -1059,10 +1074,10 @@ export default function Signup(props) {
 
               <fieldset className="mb-16">
                 <legend className="block leading-tight text-sm lg:text-p font-body mb-5 font-bold">
-                  {t("formPublicServant")}{" "}
+                  {formField.label.publicServant}{" "}
                 </legend>
                 <RadioField
-                  label={t("yes")}
+                  label={formField.option.yes}
                   id="publicServantYes"
                   name="publicServant"
                   checked={publicServant === "yes"}
@@ -1070,7 +1085,7 @@ export default function Signup(props) {
                   value="yes"
                 />
                 <RadioField
-                  label={t("no")}
+                  label={formField.option.no}
                   id="publicServantNo"
                   name="publicServant"
                   checked={publicServant === "no"}
@@ -1093,7 +1108,7 @@ export default function Signup(props) {
                       setAgreeToConditions(value);
                     }
                   }}
-                  label={t("formCheckBox")}
+                  label={formField.agreeToConditions}
                   id="agreeToConditions"
                   name="agreeToConditions"
                   value="yes"
@@ -1102,9 +1117,9 @@ export default function Signup(props) {
                 />
               </div>
             </div>
-            <Link href={t("privacyRedirect")} locale={props.locale}>
+            <Link href={formField.privacyLink} locale={props.locale}>
               <a className="block font-body hover:text-canada-footer-hover-font-blue text-canada-footer-font underline mb-10 text-sm lg:text-p">
-                {t("privacy")}
+                {formField.privacy}
               </a>
             </Link>
             <ActionButton
@@ -1115,7 +1130,7 @@ export default function Signup(props) {
               dataTestId="signup-submit"
               analyticsTracking
             >
-              {t("reportAProblemSubmit")}
+              {formField.submit}
             </ActionButton>
             <ActionButton
               id="reset-bottom"
@@ -1126,7 +1141,7 @@ export default function Signup(props) {
                 setProvince("");
               }}
             >
-              {t("clear")}
+              {formField.clearForm}
             </ActionButton>
           </form>
         </section>
@@ -1141,10 +1156,27 @@ export default function Signup(props) {
 }
 
 export const getStaticProps = async ({ locale }) => {
-  return {
-    props: {
-      locale,
-      ...(await serverSideTranslations(locale, ["common"])),
-    },
-  };
+  // get page data from AEM
+  const res = await queryGraphQL(getSignupPage).then((result) => {
+    return result;
+  });
+
+  const data = res.data.sclabsSignupList;
+
+  return process.env.NEXT_PUBLIC_ISR_ENABLED
+    ? {
+        props: {
+          locale: locale,
+          ...(await serverSideTranslations(locale, ["common"])),
+          pageData: data,
+        },
+        revalidate: 60, // revalidate once an minute
+      }
+    : {
+        props: {
+          locale: locale,
+          ...(await serverSideTranslations(locale, ["common"])),
+          pageData: data,
+        },
+      };
 };

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -31,10 +31,13 @@ export default function Signup(props) {
   const { push } = useRouter();
   const [pageData] = useState(props.pageData.items);
   const fr = props.locale === "fr";
-  const formField =
+
+  const [formField] = useState(
     props.locale === "en"
       ? pageData[0].form.formFields.en
-      : pageData[0].form.formFields.fr;
+      : pageData[0].form.formFields.fr
+  );
+  console.log(props.pageData);
 
   // get the options for the year of birth ranges
   const minYear = new Date().getFullYear() - 18;

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -37,7 +37,6 @@ export default function Signup(props) {
       ? pageData[0].form.formFields.en
       : pageData[0].form.formFields.fr
   );
-  console.log(props.pageData);
 
   // get the options for the year of birth ranges
   const minYear = new Date().getFullYear() - 18;


### PR DESCRIPTION
# Description

[SCL-734 Refactor signup page to use queried data from AEM](https://jira-dev.bdm-dev.dts-stn.com/browse/SCL-734)

Update signup page to use data from AEM. 
Content that comes from AEM:

- Title and texts on the page
- URL (for language toggle)
- Form labels and options
- Error messages

## Test Instructions

Go to signup page, check if content displays properly.

## Checklist

- [x] Strings use placeholders for translation (No hard coded strings)
- [x] Unit tests have been added/updated
- [x] Update CHANGELOG

