### PR TITLE
Add image in project card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Added the `stripFeedback` helper function which strips PII from both the feedback and report a problem forms
 - Added error label in report a problem widget
 - Added environment variable for our project version to our Next.js config for metadata purposes
+- Added image in Experiment card
 
 ## Changed
 

--- a/components/molecules/Experiment.js
+++ b/components/molecules/Experiment.js
@@ -22,6 +22,9 @@ export const Experiment = (props) => {
       data-testid={props.dataTestId}
       data-cy={props.dataCy}
     >
+      <div className="bg-gray-300 -mx-6 -mt-6 mb-2" style={{ height: "290px" }}>
+        <img src={props.prototypeImgSrc} alt="" />
+      </div>
       <h2>
         <Link href={props.href}>
           <a


### PR DESCRIPTION
# Description

[Updated Experiment card](https://jira-dev.bdm-dev.dts-stn.com/browse/SCL-744)

The new design has an image in each prototype. This pr update the Experiment card component with an image added to each prototype. The image `src` and `alt` are undefined for now because we don't have the images yet. 
<img width="901" alt="Screen Shot 2022-06-21 at 11 30 48 AM" src="https://user-images.githubusercontent.com/64853947/174840806-a7f7e011-dc30-41c6-a80b-305c0bc1863f.png">



## Test Instructions

1. launch the development server `yarn dev`
2. Navigate to `projects` page.
3. Project cards should have images. They are gray background for now since the image source are undefined. 
4. Check in mobile view as well, make sure everthing looks good. 

## Checklist

- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated
- [ ] Update CHANGELOG

## Product and Sprint Backlog

[Jira](https://jira-dev.bdm-dev.dts-stn.com/secure/RapidBoard.jspa?rapidView=96&projectKey=SCL)
