### PR TITLE
Added overwrite functionality to date modified component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Updated `/notsupported`, `/404`, `/500`, and `/error` to use data from AEM
 - Updated Experiment component to a generic card component
 - Updated home page to match new Figma designs
+- Updated DateModified component to accept a manual date (for use with AEM)
 
 ## Fixed
 

--- a/components/atoms/DateModified.js
+++ b/components/atoms/DateModified.js
@@ -4,9 +4,13 @@ import { useTranslation } from "next-i18next";
 export function DateModified(props) {
   const { t } = useTranslation("common");
   // TeamCity build dates are received in the format yyyyMMdd
-  const dateFormatted = props.date
-    ? props.date.replace(/^(.{4})(.{2})/gm, "$1-$2-")
-    : "NA";
+  let dateFormatted = "NA";
+  if (props.date) {
+    if (!props.date.match(/(?=\S*['-])([a-zA-Z'-]+)/gim)) {
+      dateFormatted = props.date.replace(/^(.{4})(.{2})/gm, "$1-$2-");
+    } else dateFormatted = props.date;
+  }
+
   return (
     <dl className="mt-8 py-2 font-body font-normal text-sm">
       <dt className="inline">{t("dateModified")}</dt>
@@ -20,6 +24,10 @@ export function DateModified(props) {
     </dl>
   );
 }
+
+DateModified.defaultProps = {
+  date: process.env.NEXT_PUBLIC_BUILD_DATE,
+};
 
 DateModified.propTypes = {
   // Date string in format yyyyMMdd

--- a/components/atoms/DateModified.js
+++ b/components/atoms/DateModified.js
@@ -6,7 +6,7 @@ export function DateModified(props) {
   // TeamCity build dates are received in the format yyyyMMdd
   let dateFormatted = "NA";
   if (props.date) {
-    if (!props.date.match(/(?=\S*['-])([a-zA-Z'-]+)/gim)) {
+    if (!props.date.match(/(?=\S*['-])([a-zA-Z'-]+)/gm)) {
       dateFormatted = props.date.replace(/^(.{4})(.{2})/gm, "$1-$2-");
     } else dateFormatted = props.date;
   }

--- a/components/organisms/Layout.js
+++ b/components/organisms/Layout.js
@@ -29,6 +29,7 @@ export const Layout = ({
   feedbackActive,
   projectName,
   path,
+  dateModifiedOverride,
 }) => {
   const { t } = useTranslation("common");
   const language = locale === "en" ? "fr" : "en";
@@ -131,7 +132,7 @@ export const Layout = ({
           <ReportAProblem />
         </div>
         <div className="layout-container mb-2">
-          <DateModified date={process.env.NEXT_PUBLIC_BUILD_DATE} />
+          <DateModified date={dateModifiedOverride} />
         </div>
         <Footer
           footerLogoAltText={t("symbol2")}
@@ -260,4 +261,8 @@ Layout.propTypes = {
    * Path that the feedback is coming from
    */
   path: PropTypes.string,
+  /**
+   * Manual override for date modified component
+   */
+  dateModifiedOverride: PropTypes.string,
 };

--- a/pages/home.js
+++ b/pages/home.js
@@ -22,7 +22,11 @@ export default function Home(props) {
 
   return (
     <>
-      <Layout locale={props.locale} langUrl={t("homePath")}>
+      <Layout
+        locale={props.locale}
+        langUrl={t("homePath")}
+        dateModifiedOverride={pageData.scDateModifiedOverwrite}
+      >
         <Head>
           {process.env.NEXT_PUBLIC_ADOBE_ANALYTICS_URL ? (
             <script src={process.env.NEXT_PUBLIC_ADOBE_ANALYTICS_URL} />


### PR DESCRIPTION
# Description

[SCL-747 - Investigate "date modified" component](https://jira-dev.bdm-dev.dts-stn.com/browse/SCL-747)

The purpose of this PR is to update the `DateModified` component to accept a manual date override, rather than solely rely on the build date from Azure. I've added a default prop that takes the Azure build time and added a new prop to the `Layout` component that accepts a date string in the format `yyyy-mm-dd`. Since the format for a date string from AEM follows the `yyyy-mm-dd` format and azure follows the `yyyyMMdd` format, I've introduced a regex pattern that is matched against the date prop which checks to see if the string contains dashes. If not, then dashes are added so it follows the `yyyy-mm-dd` format.

Since not all pages have been updated yet, I've only updated the home page to use the date override as an example.

## Test Instructions

1. Pull in branch
2. Type `yarn dev`
3. Navigate to the home page
4. On line 28 of `home.js`, change the value for `dateModifiedOverride` to "2022-06-25" and refresh the page. Ensure this shows up properly
5. Now update the value to "20220626", the regex pattern should see that there are no hyphens in the string and add them so it appears as `2022-06-26` on the screen


## Checklist

- [x] Strings use placeholders for translation (No hard coded strings)
- [x] Unit tests have been added/updated
- [x] Update CHANGELOG

## Product and Sprint Backlog

[Jira](https://jira-dev.bdm-dev.dts-stn.com/secure/RapidBoard.jspa?rapidView=96&projectKey=SCL)
