### PR TITLE
Convert img

### DIFF
--- a/__mocks__/fileMock.js
+++ b/__mocks__/fileMock.js
@@ -1,1 +1,1 @@
-module.exports = 'sig-blk-en.svg';
+module.exports = "/sig-blk-en.svg";

--- a/components/molecules/Card.js
+++ b/components/molecules/Card.js
@@ -50,16 +50,19 @@ export const Card = (props) => {
         {props.isExperiment ? (
           <Link href={props.href}>
             <a
-              className="flex block text-p text-custom-blue-projects-link underline hover:opacity-70 px-4"
+              className="flex block text-p text-custom-blue-projects-link underline hover:opacity-70 px-4 items-center"
               tabIndex="0"
             >
               {props.title}
               {props.href.substring(0, 8) === "https://" ? (
-                <img
-                  src="/external-link.svg"
-                  className="px-1 py-2"
-                  alt={t("externalLink")}
-                />
+                <div className="h-4 w-4 ml-1 mt-1 relative">
+                  <Image
+                    src={props.icon}
+                    alt={props.iconAlt}
+                    layout="fill"
+                    objectFit="cover"
+                  />
+                </div>
               ) : undefined}
             </a>
           </Link>

--- a/components/molecules/Card.js
+++ b/components/molecules/Card.js
@@ -23,12 +23,11 @@ export const Card = (props) => {
         props.isExperiment ? "shadow-experiment-shadow -ml-8" : ""
       } xl:min-h-250px ${
         "border-" + (tagColours[props.tag] || "gray-experiment")
-      }`}
+      } min-w-full`}
       data-testid={props.dataTestId}
       data-cy={props.dataCy}
       style={{
-        width: "560px",
-        minWidth: "min-content",
+        maxWidth: "560px",
       }}
     >
       <div

--- a/components/organisms/Footer.js
+++ b/components/organisms/Footer.js
@@ -1,4 +1,5 @@
 import PropTypes from "prop-types";
+import Image from "next/image";
 
 /**
  * footer element for all pages
@@ -66,13 +67,12 @@ export function Footer(props) {
               })}
             </ul>
           </div>
-          <div>
-            <img
-              className="mb-2.5 mt-8 xl:mt-0 h-6 md:h-10 w-auto float-right"
-              src={props.footerLogoImage}
-              alt={props.footerLogoAltText}
-            />
-          </div>
+          <Image
+            src={props.footerLogoImage}
+            alt={props.footerLogoAltText}
+            width="174"
+            height="51"
+          />
         </div>
       </div>
     </div>

--- a/components/organisms/Layout.js
+++ b/components/organisms/Layout.js
@@ -1,6 +1,5 @@
 import PropTypes from "prop-types";
 import { Banner } from "../atoms/Banner";
-import { Menu } from "../molecules/Menu";
 import { Footer } from "./Footer";
 import { PhaseBanner } from "./PhaseBanner";
 import { ReportAProblem } from "./ReportAProblem";

--- a/components/organisms/Layout.js
+++ b/components/organisms/Layout.js
@@ -8,6 +8,7 @@ import { useTranslation } from "next-i18next";
 import { DateModified } from "../atoms/DateModified";
 import { Breadcrumb } from "../atoms/Breadcrumb";
 import Cookies from "js-cookie";
+import Image from "next/image";
 
 const setLanguage = (language) => {
   language === "fr"
@@ -70,10 +71,11 @@ export const Layout = ({
               {t("officialSiteNavigation")}
             </h3>
             <a href="https://www.canada.ca">
-              <img
-                className="h-5 w-auto xs:h-6 sm:h-8 md:h-8 lg:h-7 xl:h-8"
+              <Image
                 src={language === "en" ? "/sig-blk-fr.svg" : "/sig-blk-en.svg"}
                 alt={t("symbol")}
+                width="375"
+                height="35"
               />
             </a>
             <h3 className="sr-only">{t("languageSelection")}</h3>

--- a/pages/404.js
+++ b/pages/404.js
@@ -167,12 +167,21 @@ export default function error404(props) {
               </div>
               <ReportAProblem language={"en"} />
             </div>
-            <div className="flex items-center justify-center circle-background my-8 lg:mt-0">
-              <img
-                className="w-68px xl:w-24"
-                src={`https://www.canada.ca${pageData.sclImagelist[0]._path}`}
-                alt="Cracked lightbulb"
-              />
+            <div
+              className="flex items-center justify-center circle-background my-8 lg:mt-0"
+              style={{ width: "218px", height: "218px" }}
+            >
+              <span
+                className="relative"
+                style={{ width: "96.25px", height: "140px" }}
+              >
+                <Image
+                  src={`https://www.canada.ca${pageData.sclImagelist[0]._path}`}
+                  alt="Cracked lightbulb"
+                  layout="fill"
+                  objectFit="cover"
+                />
+              </span>
             </div>
             <div>
               <div
@@ -222,11 +231,17 @@ export default function error404(props) {
               icon="icon-up-caret"
               iconEnd
             />
-            <img
-              className="h-6 w-auto lg:h-auto lg:w-40"
-              src={`https://www.canada.ca${pageData.sclGcImages[1]._path}`}
-              alt="Symbol of the Government of Canada"
-            />
+            <span
+              className="relative"
+              style={{ width: "104px", height: "25px" }}
+            >
+              <Image
+                src={`https://www.canada.ca${pageData.sclGcImages[1]._path}`}
+                alt="Symbol of the Government of Canada"
+                layout="fill"
+                objectFit="cover"
+              />
+            </span>
           </div>
         </footer>
       </div>

--- a/pages/404.js
+++ b/pages/404.js
@@ -8,6 +8,7 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import queryGraphQL from "../graphql/client";
 import get404Page from "../graphql/queries/error404Query.graphql";
+import Image from "next/image";
 
 export default function error404(props) {
   const { t } = useTranslation("common");
@@ -118,11 +119,20 @@ export default function error404(props) {
           <meta property="twitter:image:alt" content={`${t("siteTitle")}`} />
         </Head>
         <section className="layout-container pb-44">
-          <img
-            className="h-auto w-60 pt-6 xl:w-96 xxl:w-1/2"
-            src={`https://www.canada.ca${pageData.sclGcImages[0]._path}`}
-            alt={"Symbol of the Government of Canada"}
-          />
+          <div
+            className="relative mt-6"
+            style={{
+              width: "375px",
+              height: "35px",
+            }}
+          >
+            <Image
+              src={`https://www.canada.ca${pageData.sclGcImages[0]._path}`}
+              alt={"Symbol of the Government of Canada"}
+              layout="fill"
+              objectFit="cover"
+            />
+          </div>
           <div className="flex flex-col lg:flex-row justify-between items-center lg:items-start mt-8">
             <div>
               <div className="relative h-auto xl:w-96 xxl:w-400px lg:w-72 xl:h-400px lg:h-500px mb-8 lg:mb-0">

--- a/pages/500.js
+++ b/pages/500.js
@@ -8,6 +8,7 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import queryGraphQL from "../graphql/client";
 import get500Page from "../graphql/queries/error500Query.graphql";
+import Image from "next/image";
 
 export default function error500(props) {
   const { t } = useTranslation("common");
@@ -151,11 +152,20 @@ export default function error500(props) {
           <meta property="twitter:image:alt" content={`${t("siteTitle")}`} />
         </Head>
         <section className="layout-container pb-44">
-          <img
-            className="h-auto w-60 pt-6 xl:w-96 xxl:w-1/2"
-            src={`https://www.canada.ca${pageData.sclGcImages[0]._path}`}
-            alt={"Symbol of the Government of Canada"}
-          />
+          <div
+            className="relative mt-6"
+            style={{
+              width: "375px",
+              height: "35px",
+            }}
+          >
+            <Image
+              src={`https://www.canada.ca${pageData.sclGcImages[0]._path}`}
+              alt={"Symbol of the Government of Canada"}
+              layout="fill"
+              objectFit="cover"
+            />
+          </div>
           <div className="flex flex-col lg:flex-row justify-between items-center lg:items-start mt-8">
             <div>
               <div className="relative h-auto xl:w-96 xxl:w-400px lg:w-72 xl:h-400px lg:h-500px mb-8 lg:mb-0">
@@ -190,12 +200,21 @@ export default function error500(props) {
               </div>
               <ReportAProblem language={"en"} />
             </div>
-            <div className="flex items-center justify-center circle-background my-8 lg:mt-0">
-              <img
-                className="w-68px xl:w-24"
-                src={`https://www.canada.ca${pageData.sclImagelist[0]._path}`}
-                alt="Cracked lightbulb"
-              />
+            <div
+              className="flex items-center justify-center circle-background my-8 lg:mt-0"
+              style={{ width: "218px", height: "218px" }}
+            >
+              <span
+                className="relative"
+                style={{ width: "96.25px", height: "140px" }}
+              >
+                <Image
+                  src={`https://www.canada.ca${pageData.sclImagelist[0]._path}`}
+                  alt="Cracked lightbulb"
+                  layout="fill"
+                  objectFit="cover"
+                />
+              </span>
             </div>
             <div>
               <div
@@ -245,11 +264,17 @@ export default function error500(props) {
               icon="icon-up-caret"
               iconEnd
             />
-            <img
-              className="h-6 w-auto lg:h-auto lg:w-40"
-              src={`https://www.canada.ca${pageData.sclGcImages[1]._path}`}
-              alt="Symbol of the Government of Canada"
-            />
+            <span
+              className="relative"
+              style={{ width: "104px", height: "25px" }}
+            >
+              <Image
+                src={`https://www.canada.ca${pageData.sclGcImages[1]._path}`}
+                alt="Symbol of the Government of Canada"
+                layout="fill"
+                objectFit="cover"
+              />
+            </span>
           </div>
         </footer>
       </div>

--- a/pages/confirmation.js
+++ b/pages/confirmation.js
@@ -5,6 +5,7 @@ import { Layout } from "../components/organisms/Layout";
 import Head from "next/head";
 import { TextButtonField } from "../components/molecules/TextButtonField";
 import { useEffect } from "react";
+import Image from "next/image";
 
 export default function Confirmation(props) {
   const { t } = useTranslation("common");
@@ -160,10 +161,11 @@ export default function Confirmation(props) {
           </h1>
           <div className="lg:flex lg:flex-row-reverse">
             <span className="w-full flex justify-center lg:w-1/3">
-              <img
-                className="w-80px mb-10 lg:mb-0 lg:ml-24 lg:w-160px"
+              <Image
                 src="/circle-check.svg"
-                alt=""
+                alt="checkmark"
+                width="160"
+                height="160"
               />
             </span>
             {referrer === "unsubscribe" ? (

--- a/pages/error.js
+++ b/pages/error.js
@@ -8,6 +8,7 @@ import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import queryGraphQL from "../graphql/client";
 import getCustomErrorPage from "../graphql/queries/customErrorQuery.graphql";
+import Image from "next/image";
 
 export default function ErrorPage(props) {
   const { t } = useTranslation("common");
@@ -168,11 +169,20 @@ export default function ErrorPage(props) {
         </Head>
         <main>
           <section className="layout-container pb-44">
-            <img
-              className="h-auto w-60 pt-6 xl:w-96 xxl:w-1/2"
-              src={`https://www.canada.ca${pageData.sclGcImages[0]._path}`}
-              alt={"Symbol of the Government of Canada"}
-            />
+            <div
+              className="relative mt-6"
+              style={{
+                width: "375px",
+                height: "35px",
+              }}
+            >
+              <Image
+                src={`https://www.canada.ca${pageData.sclGcImages[0]._path}`}
+                alt={"Symbol of the Government of Canada"}
+                layout="fill"
+                objectFit="cover"
+              />
+            </div>
             <div className="flex flex-col lg:flex-row justify-between items-center lg:items-start mt-8">
               {/* Left Side (English section) */}
               <div>
@@ -283,12 +293,21 @@ export default function ErrorPage(props) {
                 </div>
                 <ReportAProblem language="en" />
               </div>
-              <div className="flex items-center justify-center circle-background my-8 lg:mt-0">
-                <img
-                  className="w-68px xl:w-24"
-                  src={`https://www.canada.ca${pageData.sclImagelist[0]._path}`}
-                  alt="Cracked lightbulb"
-                />
+              <div
+                className="flex items-center justify-center circle-background my-8 lg:mt-0"
+                style={{ width: "218px", height: "218px" }}
+              >
+                <span
+                  className="relative"
+                  style={{ width: "96.25px", height: "140px" }}
+                >
+                  <Image
+                    src={`https://www.canada.ca${pageData.sclImagelist[0]._path}`}
+                    alt="Cracked lightbulb"
+                    layout="fill"
+                    objectFit="cover"
+                  />
+                </span>
               </div>
               {/* Right Side (French section) */}
               <div>
@@ -415,11 +434,17 @@ export default function ErrorPage(props) {
               icon="icon-up-caret"
               iconEnd
             />
-            <img
-              className="h-6 w-auto lg:h-auto lg:w-40"
-              src={`https://www.canada.ca${pageData.sclGcImages[1]._path}`}
-              alt="Symbol of the Government of Canada"
-            />
+            <span
+              className="relative"
+              style={{ width: "104px", height: "25px" }}
+            >
+              <Image
+                src={`https://www.canada.ca${pageData.sclGcImages[1]._path}`}
+                alt="Symbol of the Government of Canada"
+                layout="fill"
+                objectFit="cover"
+              />
+            </span>
           </div>
         </footer>
       </div>

--- a/pages/index.js
+++ b/pages/index.js
@@ -5,6 +5,7 @@ import { ActionButton } from "../components/atoms/ActionButton";
 import Link from "next/link";
 import { useEffect } from "react";
 import Cookies from "js-cookie";
+import Image from "next/image";
 
 export default function Index(props) {
   const { t } = useTranslation("common");
@@ -128,11 +129,14 @@ export default function Index(props) {
         <div className="flex flex-col justify-center items-center m-auto v-xxs:h-screen">
           <div className="z-10 bg-white h-auto min-w-300px w-300px xl:w-500px">
             <h1 className="sr-only">alpha.service.canada.ca</h1>
-            <img
-              className="h-auto w-64 container mx-auto pt-6 xl:w-2/3 xl:mx-0 xl:px-6"
-              src={"/sig-blk-en.svg"}
-              alt={"Government of Canada / Gouvernement du Canada"}
-            />
+            <div className="p-4">
+              <Image
+                src={"/sig-blk-en.svg"}
+                alt={"Government of Canada / Gouvernement du Canada"}
+                width="300"
+                height="35"
+              />
+            </div>
             <div className="flex w-max container mx-auto py-6 font-display">
               <h2
                 className="text-p text-right xl:text-h4 mr-6 w-32 xl:w-40"
@@ -179,10 +183,11 @@ export default function Index(props) {
                 </a>
               </Link>
             </div>
-            <img
-              className="h-auto w-24 xl:w-28"
+            <Image
               src="/wmms-blk.svg"
               alt="Symbol of the Government of Canada / Symbole du gouvernement du Canada"
+              width="150"
+              height="25"
             />
           </div>
         </div>

--- a/pages/notsupported.js
+++ b/pages/notsupported.js
@@ -7,6 +7,7 @@ import { CopyToClipboard } from "../components/molecules/CopyToClipboard";
 import { useState } from "react";
 import queryGraphQL from "../graphql/client";
 import getNotSupported from "../graphql/queries/notsupportedQuery.graphql";
+import Image from "next/image";
 
 export default function notSupported(props) {
   const { t } = useTranslation("common");
@@ -150,11 +151,20 @@ export default function notSupported(props) {
           <meta property="twitter:image:alt" content={`${t("siteTitle")}`} />
         </Head>
         <section className="xs:px-0 lg:mx-auto lg:px-6 container">
-          <img
-            className="canadaLogo pt-6"
-            src={`https://www.canada.ca${pageData.sclGcImages[0]._path}`}
-            alt={"Symbol of the Government of Canada"}
-          />
+          <div
+            className="relative mt-6"
+            style={{
+              width: "375px",
+              height: "35px",
+            }}
+          >
+            <Image
+              src={`https://www.canada.ca${pageData.sclGcImages[0]._path}`}
+              alt={"Symbol of the Government of Canada"}
+              layout="fill"
+              objectFit="cover"
+            />
+          </div>
           <div className="flex flex-col lg:flex-row justify-between items-center lg:items-start mt-8">
             <div>
               <div className="relative h-auto xl:w-96 xxl:w-400px lg:w-72 xl:h-400px lg:h-500px mb-8 lg:mb-0">
@@ -166,12 +176,21 @@ export default function notSupported(props) {
                 </p>
               </div>
             </div>
-            <div className="flex items-center justify-center circle-background my-8 lg:mt-0">
-              <img
-                className="w-68px xl:w-24"
-                src={`https://www.canada.ca${pageData.sclImagelist[0]._path}`}
-                alt="Cracked lightbulb"
-              />
+            <div
+              className="flex items-center justify-center circle-background my-8 lg:mt-0"
+              style={{ width: "218px", height: "218px" }}
+            >
+              <span
+                className="relative"
+                style={{ width: "96.25px", height: "140px" }}
+              >
+                <Image
+                  src={`https://www.canada.ca${pageData.sclImagelist[0]._path}`}
+                  alt="Cracked lightbulb"
+                  layout="fill"
+                  objectFit="cover"
+                />
+              </span>
             </div>
             <div>
               <div
@@ -191,7 +210,7 @@ export default function notSupported(props) {
         <section className="-mt-0 lg:-mt-36 sm:-mt-4 pb-5">
           <div className="flex items-center justify-center">
             <figure className="mx-4">
-              <img
+              <Image
                 src={`https://www.canada.ca${pageData.sclImagelist[1]._path}`}
                 alt="chrome"
                 width="98"
@@ -202,7 +221,7 @@ export default function notSupported(props) {
               </figcaption>
             </figure>
             <figure className="mx-4">
-              <img
+              <Image
                 src={`https://www.canada.ca${pageData.sclImagelist[2]._path}`}
                 alt="safari"
                 width="98"
@@ -213,7 +232,7 @@ export default function notSupported(props) {
               </figcaption>
             </figure>
             <figure className="mx-4">
-              <img
+              <Image
                 src={`https://www.canada.ca${pageData.sclImagelist[3]._path}`}
                 alt="edge"
                 width="94"
@@ -224,7 +243,7 @@ export default function notSupported(props) {
               </figcaption>
             </figure>
             <figure className="mx-4">
-              <img
+              <Image
                 src={`https://www.canada.ca${pageData.sclImagelist[4]._path}`}
                 alt="firefox"
                 width="98"
@@ -401,11 +420,17 @@ export default function notSupported(props) {
               icon="icon-up-caret"
               iconEnd
             />
-            <img
-              className="h-6 w-auto lg:h-auto lg:w-40"
-              src={`https://www.canada.ca${pageData.sclGcImages[1]._path}`}
-              alt="Symbol of the Government of Canada"
-            />
+            <span
+              className="relative"
+              style={{ width: "104px", height: "25px" }}
+            >
+              <Image
+                src={`https://www.canada.ca${pageData.sclGcImages[1]._path}`}
+                alt="Symbol of the Government of Canada"
+                layout="fill"
+                objectFit="cover"
+              />
+            </span>
           </div>
         </footer>
       </div>

--- a/pages/projects.js
+++ b/pages/projects.js
@@ -221,6 +221,12 @@ export default function Projects(props) {
                   isExperiment
                   imgSrc="/placeholder.png"
                   imgAlt="placeholder"
+                  icon={`https://www.canada.ca${pageData.scFragments[3].scImageEn._path}`}
+                  iconAlt={
+                    props.locale === "en"
+                      ? pageData.scFragments[3].scImageAltTextEn
+                      : pageData.scFragments[3].scImageAltTextFr
+                  }
                   priority
                 />
               </li>

--- a/pages/projects.js
+++ b/pages/projects.js
@@ -172,8 +172,8 @@ export default function Projects(props) {
               </p>
             </span>
             <span
-              className="relative flex w-full mt-4 lg:ml-8"
-              style={{ height: "274px", width: "453px", minWidth: "453px" }}
+              className="relative flex mt-4 lg:ml-8 lg:w-3/4"
+              style={{ height: "274px", maxWidth: "453px" }}
             >
               <Image
                 src={`https://www.canada.ca${pageData.scFragments[2].scImageEn._path}`}

--- a/pages/thankyou.js
+++ b/pages/thankyou.js
@@ -7,6 +7,7 @@ import { useRouter } from "next/router";
 import { ActionButton } from "../components/atoms/ActionButton";
 import { Player, Controls } from "@lottiefiles/react-lottie-player";
 import animatedCheckmark from "../public/animatedCheckmark.json";
+import Image from "next/image";
 
 export default function Confirmation(props) {
   const { t } = useTranslation("common");
@@ -170,10 +171,11 @@ export default function Confirmation(props) {
           </h1>
           <div className="lg:flex lg:flex-row-reverse">
             <span className="w-full flex justify-center lg:w-1/3">
-              <img
-                className="w-80px mb-10 lg:mb-0 lg:ml-24 lg:w-160px"
+              <Image
                 src="/circle-info.svg"
-                alt=""
+                alt="info"
+                width="160"
+                height="160"
               />
             </span>
             <div className="lg:w-2/3">

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -82,8 +82,8 @@ html {
 
   .circle-background {
     border-radius: 50%;
-    width: 148px;
-    height: 148px;
+    width: 218px;
+    height: 218px;
     background-color: #eeeeee;
   }
 


### PR DESCRIPTION
# Description

[Convert all images to Next/image](https://jira-dev.bdm-dev.dts-stn.com/browse/SCL-746)

The purpose of this pr is to convert images that's using html `img` tag to `next/image` component. 

Converted:

- Canada flag image on header, footer, and landing page
- Link icon on the title of the projects cards
- Error pages (404, 500, notsupported, error)
- Info image on thankyou page
- Green checkmark image on confirmation page

Not converted:
- Phasebanner image
- Call to action
- Menu

Image on the phase banner and call to action banner are used for the feedback widget. I did not convert it since we are not working on the feedback widget anymore. There is a menu icon on the Menu on mobile, didn't touch this because the re-design is getting rid of the menu. 

## Test Instructions

Check the converted images, makes sure the images displays correctly. 

## Checklist

- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated
- [ ] Update CHANGELOG

## Product and Sprint Backlog

[Jira](https://jira-dev.bdm-dev.dts-stn.com/secure/RapidBoard.jspa?rapidView=96&projectKey=SCL)
