### PR TITLE
Update past projects label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Updated `/projects` page to use data from AEM
 - Updated home page to match new Figma designs
 - Updated DateModified component to accept a manual date (for use with AEM)
+- Updated past project label to be gray instead of red, and also updated projects page to use new AEM data
 
 ## Fixed
 

--- a/components/molecules/Card.js
+++ b/components/molecules/Card.js
@@ -13,7 +13,7 @@ export const Card = (props) => {
   const { t } = useTranslation("common");
   const tagColours = {
     current_projects: "custom-green",
-    past_projects: "custom-red",
+    past_projects: "custom-gray",
     upcoming_projects: "custom-blue",
   };
 
@@ -32,7 +32,7 @@ export const Card = (props) => {
       }}
     >
       <div
-        className="bg-gray-300 mb-4"
+        className="mb-4"
         style={{
           height: `${props.isExperiment ? "290px" : "326px"}`,
           position: "relative",
@@ -92,7 +92,7 @@ export const Card = (props) => {
             text={props.btnText}
             id={props.btnId}
             dataCy={props.btnId}
-            className="rounded xxs:w-full xs:w-fit my-4 py-2 bg-custom-gray-lighter text-custom-blue-text focus:ring-inset focus:ring-2 focus:ring-black hover:bg-details-button-hover-gray text-center border border-details-button-gray"
+            className="rounded xxs:w-full xs:w-fit my-4 py-2 bg-[#EAEBED] text-custom-blue-text focus:ring-inset focus:ring-2 focus:ring-black hover:bg-details-button-hover-gray text-center border border-details-button-gray"
           />
         </span>
       ) : undefined}

--- a/cypress/integration/project.spec.js
+++ b/cypress/integration/project.spec.js
@@ -35,16 +35,16 @@ describe("project page", () => {
   });
 
   it("Filter projects: Upcoming projects", () => {
-    cy.get('[data-cy="upcoming_projects"]').click();
+    cy.get('[data-cy="gc:custom/decd-endc/project-status/upcoming"]').click();
     cy.get('[data-cy="projects-list"]>li>div>span').each(($el) => {
       expect($el.text()).to.eq("Upcoming projects");
     });
   });
 
-  it("Filter projects: Current projects", () => {
-    cy.get('[data-cy="current_projects"]').click();
+  it("Filter projects: Past projects", () => {
+    cy.get('[data-cy="gc:custom/decd-endc/project-status/past"]').click();
     cy.get('[data-cy="projects-list"]>li>div>span').each(($el) => {
-      expect($el.text()).to.eq("Current projects");
+      expect($el.text()).to.eq("Past projects");
     });
   });
 });

--- a/graphql/queries/projectQuery.graphql
+++ b/graphql/queries/projectQuery.graphql
@@ -1,11 +1,19 @@
 query getAllProjects {
-  scLabsExperimentList {
+  sCLabsProjectList {
     items {
       _path
-      title
-      description
-      href
-      tag
+      scId
+      scTitleEn
+      scTitleFr
+      scDestinationURLEn
+      scDestinationURLFr
+      scContentEn {
+          json
+      }
+      scContentFr {
+          json
+      }
+      scLabProjectStatus
     }
   }
 }

--- a/pages/projects.js
+++ b/pages/projects.js
@@ -19,8 +19,6 @@ export default function Projects(props) {
     props.experimentData.items
   );
 
-  console.log();
-
   // get the filters from the data
   const filters = props.filters.map((value) => {
     return {
@@ -37,7 +35,9 @@ export default function Projects(props) {
     } else {
       setFilter(value);
       setFilteredExperiments(
-        experimentData.filter((experiment) => experiment.tag === value)
+        experimentData.filter(
+          (experiment) => experiment.scLabProjectStatus[0] === value
+        )
       );
     }
   };
@@ -209,15 +209,43 @@ export default function Projects(props) {
           >
             {filteredExperiments.map((experiment) => (
               // Key should be experiment.id but that doesn't exist in the model yet, will need to be changed but this gets rid of console warning for now
-              <li key={experiment.title} className="flex items-stretch">
+              <li key={experiment.scTitleEn} className="flex items-stretch">
                 <Card
-                  title={experiment.title}
-                  tag={experiment.tag}
-                  tagLabel={t(experiment.tag)}
-                  description={experiment.description}
-                  href={experiment.href}
-                  dataTestId={`${experiment.id}`}
-                  dataCy={`${experiment.id}`}
+                  title={
+                    props.locale === "en"
+                      ? experiment.scTitleEn
+                      : experiment.scTitleFr
+                  }
+                  tag={
+                    experiment.scLabProjectStatus[0] ===
+                    "gc:custom/decd-endc/project-status/current"
+                      ? "current_projects"
+                      : experiment.scLabProjectStatus[0] ===
+                        "gc:custom/decd-endc/project-status/upcoming"
+                      ? "upcoming_projects"
+                      : "past_projects"
+                  }
+                  tagLabel={t(
+                    experiment.scLabProjectStatus[0] ===
+                      "gc:custom/decd-endc/project-status/current"
+                      ? "current_projects"
+                      : experiment.scLabProjectStatus[0] ===
+                        "gc:custom/decd-endc/project-status/upcoming"
+                      ? "upcoming_projects"
+                      : "past_projects"
+                  )}
+                  description={
+                    props.locale === "en"
+                      ? experiment.scContentEn.json[0].content[0].value
+                      : experiment.scContentFr.json[0].content[0].value
+                  }
+                  href={
+                    props.locale === "en"
+                      ? experiment.scDestinationURLEn
+                      : experiment.scDestinationURLFr
+                  }
+                  dataTestId={`${experiment.scId}`}
+                  dataCy={`${experiment.scId}`}
                   isExperiment
                   imgSrc="/placeholder.png"
                   imgAlt="placeholder"
@@ -246,16 +274,24 @@ export const getStaticProps = async ({ locale }) => {
     return result;
   });
 
-  const experimentsData = res1.data.scLabsExperimentList;
+  const experimentsData = res1.data.sCLabsProjectList;
+
   const pageData = res2.data.sCLabsPageByPath;
 
   const filters = Object.values(
     experimentsData.items.reduce(
-      (filters, { tag }) => {
-        if (!filters[tag]) {
-          filters[tag] = {
-            id: tag,
-            label: tag,
+      (filters, { scLabProjectStatus }) => {
+        if (!filters[scLabProjectStatus]) {
+          filters[scLabProjectStatus] = {
+            id: scLabProjectStatus[0],
+            label:
+              scLabProjectStatus[0] ===
+              "gc:custom/decd-endc/project-status/current"
+                ? "current_projects"
+                : scLabProjectStatus[0] ===
+                  "gc:custom/decd-endc/project-status/upcoming"
+                ? "upcoming_projects"
+                : "past_projects",
             checked: false,
           };
         }

--- a/pages/projects.js
+++ b/pages/projects.js
@@ -208,8 +208,7 @@ export default function Projects(props) {
             data-cy="projects-list"
           >
             {filteredExperiments.map((experiment) => (
-              // Key should be experiment.id but that doesn't exist in the model yet, will need to be changed but this gets rid of console warning for now
-              <li key={experiment.scTitleEn} className="flex items-stretch">
+              <li key={experiment.scId} className="flex items-stretch">
                 <Card
                   title={
                     props.locale === "en"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -20,12 +20,16 @@ module.exports = {
     "bg-custom-red-darker",
     "bg-custom-green-lighter",
     "bg-custom-green-darker",
+    "bg-custom-gray-lighter",
+    "bg-custom-gray-darker",
     "border-custom-blue-lighter",
     "border-custom-blue-darker",
     "border-custom-red-lighter",
     "border-custom-red-darker",
     "border-custom-green-lighter",
     "border-custom-green-darker",
+    "border-custom-gray-lighter",
+    "border-custom-gray-darker",
   ],
   theme: {
     fontFamily: {
@@ -88,7 +92,8 @@ module.exports = {
           darker: "#D3080C",
         },
         "custom-gray": {
-          lighter: "#EAEBED",
+          lighter: "#EEEEEE",
+          darker: "#ACACAC",
         },
         "error-border-red": "#D3080C",
         "error-background-red": "#F3E9E8",


### PR DESCRIPTION
# Description

[SCL-711 - Dev: Update front-end to display "past" project label](https://jira-dev.bdm-dev.dts-stn.com/browse/SCL-711)

This PR updates the project cards to show the past project label as it is presented in the latest Figma files. I've also created 4 new fragments within AEM using Isabelle's project model and have adjusted the project page/Card component as necessary to fit with this new format

## Test Instructions

1. Pull in branch
2. Type `yarn dev`
3. Navigate to `/projects`
4. Click the filters to ensure projects filter properly, inspect past project label to ensure it matches Figma

## Checklist

- [x] Strings use placeholders for translation (No hard coded strings)
- [x] Unit tests have been added/updated
- [x] Update CHANGELOG

## Product and Sprint Backlog

[Jira](https://jira-dev.bdm-dev.dts-stn.com/secure/RapidBoard.jspa?rapidView=96&projectKey=SCL)
