### PR TITLE
update signup query

### DIFF
--- a/__mocks__/mockStore.js
+++ b/__mocks__/mockStore.js
@@ -488,12 +488,38 @@ export const error404Page = {
 
 export const signupPage = {
   data: {
-    sclabsSignupList: {
-      items: [
-        {
-          _path:
-            "/content/dam/decd-endc/content-fragments/alpha/sclabs/pages/signup",
-          form: {
+    sCLabsPageByPath: {
+      item: {
+        scId: "sclabs-signup-page",
+        scPageNameEn: "/signup",
+        scPageNameFr: "/fr/inscription",
+        scTitleEn: "Sign up to get invited to research sessions (Step 1 of 2)",
+        scTitleFr:
+          "S’inscrire pour être invité aux séances de recherche (étape 1 sur 2)",
+        scShortTitleEn: null,
+        scShortTitleFr: null,
+        scDescriptionEn: {
+          json: null,
+        },
+        scDescriptionFr: {
+          json: null,
+        },
+        scSubject: null,
+        scKeywordsEn: null,
+        scKeywordsFr: null,
+        scContentType: null,
+        scOwner: null,
+        scDateModifiedOverwrite: null,
+        scAudience: null,
+        scRegion: null,
+        scSocialMediaImageEn: null,
+        scSocialMediaImageFr: null,
+        scSocialMediaImageAltTextEn: null,
+        scSocialMediaImageAltTextFr: null,
+        scNoIndex: false,
+        scNoFollow: false,
+        scFragments: [
+          {
             formFields: {
               en: {
                 label: {
@@ -592,6 +618,7 @@ export const signupPage = {
                   errorUnknown:
                     "An unknown error has occurred during your registration. Please contact experience@servicecanada.gc.ca to continue your registration or try again later",
                 },
+                requiredInfo: "Indicates required information",
                 agreeToConditions:
                   "I have read, understood and agree to the above. I affirm that I am 18 years old, or older. I understand that I can withdraw from this participant pool, or any research study at any time without consequence.",
                 privacy: "Read the full privacy policy",
@@ -702,6 +729,7 @@ export const signupPage = {
                   errorUnknown:
                     "Une erreur inconnue s’est produite lors de votre inscription. Veuillez contacter experience@servicecanada.gc.ca pour poursuivre votre inscription ou réessayer plus tard",
                 },
+                requiredInfo: "Indique que les renseignements sont requis",
                 agreeToConditions:
                   "J’ai lu, compris et accepté ce qui précède. J’affirme que j’ai 18 ans ou plus. Je comprends que je peux me retirer de ce groupe de participants ou de toute étude de recherche à tout moment, sans conséquence.",
                 privacy:
@@ -713,15 +741,8 @@ export const signupPage = {
               },
             },
           },
-          title: "Sign up to get invited to research sessions (Step 1 of 2)",
-          titleFr:
-            "S’inscrire pour être invité aux séances de recherche (étape 1 sur 2)",
-          requiredInformation: "Indicates required information",
-          requiredInformationFr: "Indique que les renseignements sont requis",
-          url: "/signup",
-          urlFr: "/fr/inscription",
-        },
-      ],
+        ],
+      },
     },
   },
 };
@@ -731,7 +752,6 @@ export const homePageData = {
     sCLabsPageByPath: {
       item: {
         scId: "sclabs-homepage",
-        scPublishProd: false,
         scPageNameEn: "/home",
         scPageNameFr: "/fr/accueil",
         scTitleEn: "Your feedback can shape tomorrow’s services",
@@ -785,7 +805,6 @@ export const homePageData = {
             _path:
               "/content/dam/decd-endc/content-fragments/alpha/dev/sclabs/components/content/home---main-content",
             scId: "HOME-MAIN-CONTENT",
-            scPublishProd: false,
             scTitleEn: null,
             scTitleFr: null,
             scContentEn: {
@@ -888,7 +907,6 @@ export const homePageData = {
           },
           {
             scId: "HOMEPAGE-MAIN-IMAGE",
-            scPublishProd: false,
             scTitleEn: null,
             scTitleFr: null,
             scImageEn: {
@@ -906,7 +924,6 @@ export const homePageData = {
           },
           {
             scId: "sclabs-homepage-button-about",
-            scPublishProd: false,
             scTitleEn: "About Service Canada Labs",
             scTitleFr: null,
             scDestinationURLEn: "/about",
@@ -915,7 +932,6 @@ export const homePageData = {
           },
           {
             scId: "HOMEPAGE-VIEW-PROJECTS",
-            scPublishProd: false,
             scTitleEn: "Try out current projects",
             scTitleFr: null,
             scContentEn: {
@@ -957,7 +973,6 @@ export const homePageData = {
             scLabsButton: [
               {
                 scId: "sclabs-homepage-button-projects",
-                scPublishProd: false,
                 scTitleEn: "View projects",
                 scTitleFr: null,
                 scDestinationURLEn: "/projects",
@@ -968,7 +983,6 @@ export const homePageData = {
           },
           {
             scId: "SIGN-UP-TO-GET-INVITED-TO-RESEARCH-SESSIONS",
-            scPublishProd: false,
             scTitleEn: "Sign up to participate in user research",
             scTitleFr:
               "Inscrivez-vous pour être invité aux séances de recherche",
@@ -1032,7 +1046,6 @@ export const homePageData = {
             scLabsButton: [
               {
                 scId: "sclabs-homepage-button-signup",
-                scPublishProd: false,
                 scTitleEn: "Sign up to participate in user research",
                 scTitleFr: null,
                 scDestinationURLEn: "/signup-info",

--- a/__tests__/pages/signup.test.js
+++ b/__tests__/pages/signup.test.js
@@ -9,10 +9,10 @@ jest.mock("@apollo/client");
 
 describe("Signup", () => {
   it("renders without crashing", () => {
-    render(<Signup pageData={signupPage.data.sclabsSignupList} />);
+    render(<Signup pageData={signupPage.data.sCLabsPageByPath} />);
     expect(
       screen.getByRole("heading", {
-        name: "Sign up to get invited to research sessions (Step 1 of 2)",
+        name: "S’inscrire pour être invité aux séances de recherche (étape 1 sur 2)",
       })
     ).toBeInTheDocument();
   });

--- a/graphql/queries/homePageQuery.graphql
+++ b/graphql/queries/homePageQuery.graphql
@@ -1,153 +1,147 @@
 query getHomePage {
-	sCLabsPageByPath(_path: "/content/dam/decd-endc/content-fragments/alpha/sclabs/pages/home-page") {
-	    item {
+  sCLabsPageByPath(
+    _path: "/content/dam/decd-endc/content-fragments/alpha/sclabs/pages/home-page"
+  ) {
+    item {
+      scId
+      scPageNameEn
+      scPageNameFr
+      scTitleEn
+      scTitleFr
+      scShortTitleEn
+      scShortTitleFr
+      scDescriptionEn {
+        json
+      }
+      scDescriptionFr {
+        json
+      }
+      scSubject
+      scKeywordsEn
+      scKeywordsFr
+      scContentType
+      scOwner
+      scDateModifiedOverwrite
+      scAudience
+      scRegion
+      scSocialMediaImageEn {
+        ... on ImageRef {
+          _path
+        }
+        ... on DocumentRef {
+          _path
+        }
+      }
+      scSocialMediaImageFr {
+        ... on ImageRef {
+          _path
+        }
+        ... on DocumentRef {
+          _path
+        }
+      }
+      scSocialMediaImageAltTextEn
+      scSocialMediaImageAltTextFr
+      scNoIndex
+      scNoFollow
+      scFragments {
+        ... on SCLabsContentModel {
+          _path
+          scId
+          scContentEn {
+            json
+          }
+          scContentFr {
+            json
+          }
+        }
+        ... on SCLabsImageModel {
+          scId
+          scTitleEn
+          scTitleFr
+          scImageEn {
+            ... on ImageRef {
+              _path
+            }
+            ... on DocumentRef {
+              _path
+            }
+          }
+          scImageFr {
+            ... on ImageRef {
+              _path
+            }
+            ... on DocumentRef {
+              _path
+            }
+          }
+          scImageMobileEn {
+            ... on ImageRef {
+              _path
+            }
+            ... on DocumentRef {
+              _path
+            }
+          }
+          scImageMobileFr {
+            ... on ImageRef {
+              _path
+            }
+            ... on DocumentRef {
+              _path
+            }
+          }
+          scImageAltTextEn
+          scImageAltTextFr
+          scImageCaptionEn
+          scImageCaptionFr
+        }
+        ... on SCLabsButtonModel {
+          scId
+          scTitleEn
+          scTitleFr
+          scDestinationURLEn
+          scDestinationURLFr
+          scButtonType
+        }
+        ... on SCLabsFeatureModel {
+          scId
+          scTitleEn
+          scTitleFr
+          scContentEn {
+            json
+          }
+          scContentFr {
+            json
+          }
+          scImageEn {
+            ... on ImageRef {
+              _path
+            }
+            ... on DocumentRef {
+              _path
+            }
+          }
+          scImageFr {
+            ... on ImageRef {
+              _path
+            }
+            ... on DocumentRef {
+              _path
+            }
+          }
+          scImageAltTextEn
+          scImageAltTextFr
+          scLabsButton {
             scId
-            scPublishProd
-            scPageNameEn
-            scPageNameFr
             scTitleEn
             scTitleFr
-            scShortTitleEn
-            scShortTitleFr
-            scDescriptionEn {
-                json
-            }
-            scDescriptionFr {
-                json
-            }
-            scSubject
-            scKeywordsEn
-            scKeywordsFr
-            scContentType
-            scOwner
-            scDateModifiedOverwrite
-            scAudience
-            scRegion
-            scSocialMediaImageEn {
-                ... on ImageRef {
-                    _path
-                }
-                ... on DocumentRef {
-                    _path
-                }
-            }
-            scSocialMediaImageFr {
-                ... on ImageRef {
-                    _path
-                }
-                ... on DocumentRef {
-                    _path
-                }
-            }
-            scSocialMediaImageAltTextEn
-            scSocialMediaImageAltTextFr
-            scNoIndex
-            scNoFollow
-                scFragments {
-                ... on SCLabsContentModel {
-                    _path
-                    scId
-                    scPublishProd
-                    scTitleEn
-                    scTitleFr
-                    scContentEn {
-                        json
-                    }
-                    scContentFr {
-                        json
-                    }
-                }
-                ... on SCLabsImageModel {
-                    scId
-                    scPublishProd
-                    scTitleEn
-                    scTitleFr
-                    scImageEn {
-                        ... on ImageRef {
-                            _path
-                        }
-                        ... on DocumentRef {
-                            _path
-                        }
-                    }
-                    scImageFr {
-                        ... on ImageRef {
-                            _path
-                        }
-                        ... on DocumentRef {
-                            _path
-                        }
-                    }
-                    scImageMobileEn {
-                         ... on ImageRef {
-                            _path
-                        }
-                        ... on DocumentRef {
-                            _path
-                        }
-                    }
-                    scImageMobileFr {
-                         ... on ImageRef {
-                            _path
-                        }
-                        ... on DocumentRef {
-                            _path
-                        }
-                    }
-                    scImageAltTextEn
-                    scImageAltTextFr
-                    scImageCaptionEn
-                    scImageCaptionFr
-                }
-                ... on SCLabsButtonModel {
-                    scId
-                    scPublishProd
-                    scTitleEn
-                    scTitleFr
-                    scDestinationURLEn
-                    scDestinationURLFr
-                    scButtonType
-                }
-                ... on SCLabsFeatureModel {
-                    scId
-                    scPublishProd
-                    scTitleEn
-                    scTitleFr
-                    scContentEn {
-                        json
-                    }
-                    scContentFr {
-                        json
-                    }
-                    scImageEn {
-                         ... on ImageRef {
-                            _path
-                        }
-                        ... on DocumentRef {
-                            _path
-                        }
-                    }
-                    scImageFr {
-                         ... on ImageRef {
-                            _path
-                        }
-                        ... on DocumentRef {
-                            _path
-                        }
-                    }
-                    scImageAltTextEn
-                    scImageAltTextFr
-                    scLabsButton {
-                        scId
-                        scPublishProd
-                        scTitleEn
-                        scTitleFr
-                        scDestinationURLEn
-                        scDestinationURLFr
-                        scButtonType
-                    }
-                }
-            }
+            scDestinationURLEn
+            scDestinationURLFr
+            scButtonType
+          }
         }
-	}
+      }
+    }
+  }
 }

--- a/graphql/queries/projectsPageQuery.graphql
+++ b/graphql/queries/projectsPageQuery.graphql
@@ -4,7 +4,6 @@ query getProjectsPage {
   ) {
     item {
       scId
-      scPublishProd
       scPageNameEn
       scPageNameFr
       scTitleEn
@@ -49,9 +48,6 @@ query getProjectsPage {
         ... on SCLabsContentModel {
           _path
           scId
-          scPublishProd
-          scTitleEn
-          scTitleFr
           scContentEn {
             json
           }
@@ -61,7 +57,6 @@ query getProjectsPage {
         }
         ... on SCLabsImageModel {
           scId
-          scPublishProd
           scTitleEn
           scTitleFr
           scImageEn {
@@ -103,7 +98,6 @@ query getProjectsPage {
         }
         ... on SCLabsButtonModel {
           scId
-          scPublishProd
           scTitleEn
           scTitleFr
           scDestinationURLEn
@@ -112,7 +106,6 @@ query getProjectsPage {
         }
         ... on SCLabsFeatureModel {
           scId
-          scPublishProd
           scTitleEn
           scTitleFr
           scContentEn {
@@ -141,7 +134,6 @@ query getProjectsPage {
           scImageAltTextFr
           scLabsButton {
             scId
-            scPublishProd
             scTitleEn
             scTitleFr
             scDestinationURLEn

--- a/graphql/queries/signupQuery.graphql
+++ b/graphql/queries/signupQuery.graphql
@@ -1,16 +1,54 @@
 query getSignupPage {
-  sclabsSignupList {
-    items {
-      _path
-      form {
-        formFields
+  sCLabsPageByPath(
+    _path: "/content/dam/decd-endc/content-fragments/alpha/sclabs/pages/signup-page"
+  ) {
+    item {
+      scId
+      scPageNameEn
+      scPageNameFr
+      scTitleEn
+      scTitleFr
+      scShortTitleEn
+      scShortTitleFr
+      scDescriptionEn {
+        json
       }
-      title
-      titleFr
-      requiredInformation
-      requiredInformationFr
-      url
-      urlFr
+      scDescriptionFr {
+        json
+      }
+      scSubject
+      scKeywordsEn
+      scKeywordsFr
+      scContentType
+      scOwner
+      scDateModifiedOverwrite
+      scAudience
+      scRegion
+      scSocialMediaImageEn {
+        ... on ImageRef {
+          _path
+        }
+        ... on DocumentRef {
+          _path
+        }
+      }
+      scSocialMediaImageFr {
+        ... on ImageRef {
+          _path
+        }
+        ... on DocumentRef {
+          _path
+        }
+      }
+      scSocialMediaImageAltTextEn
+      scSocialMediaImageAltTextFr
+      scNoIndex
+      scNoFollow
+      scFragments {
+        ... on SclabsFormModel {
+          formFields
+        }
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.3",
   "private": true,
   "dependencies": {
-    "@apollo/client": "^3.6.6",
+    "@apollo/client": "^3.6.8",
     "@lottiefiles/react-lottie-player": "^3.4.7",
     "@storybook/addons": "^6.5.0",
     "@storybook/client-api": "^6.5.0",

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -29,13 +29,13 @@ import getSignupPage from "../graphql/queries/signupQuery.graphql";
 export default function Signup(props) {
   const { t } = useTranslation("common");
   const { push } = useRouter();
-  const [pageData] = useState(props.pageData.items);
+  const [pageData] = useState(props.pageData.item);
   const fr = props.locale === "fr";
 
   const [formField] = useState(
     props.locale === "en"
-      ? pageData[0].form.formFields.en
-      : pageData[0].form.formFields.fr
+      ? pageData.scFragments[0].formFields.en
+      : pageData.scFragments[0].formFields.fr
   );
 
   // get the options for the year of birth ranges
@@ -426,7 +426,9 @@ export default function Signup(props) {
     <>
       <Layout
         locale={props.locale}
-        langUrl={fr ? pageData[0].url : pageData[0].urlFr}
+        langUrl={
+          props.locale === "en" ? pageData.scPageNameFr : pageData.scPageNameEn
+        }
         breadcrumbItems={[
           { text: t("siteTitle"), link: t("breadCrumbsHref1") },
           { text: t("signupInfoTitle"), link: t("breadCrumbsHref4") },
@@ -522,7 +524,7 @@ export default function Signup(props) {
         <section className="layout-container mb-2 mt-12">
           <div className="xl:w-2/3">
             <h1 className="mb-12" id="pageMainTitle" tabIndex="-1">
-              {fr ? pageData[0].titleFr : pageData[0].title}
+              {props.locale === "en" ? pageData.scTitleEn : pageData.scTitleFr}
             </h1>
           </div>
         </section>
@@ -552,9 +554,7 @@ export default function Signup(props) {
                 <b className="text-error-border-red mr-2" aria-hidden="true">
                   *
                 </b>
-                {fr
-                  ? pageData[0].requiredInformationFr
-                  : pageData[0].requiredInformation}
+                {formField.requiredInfo}
               </p>
               <TextField
                 className="mb-10"
@@ -1163,7 +1163,7 @@ export const getStaticProps = async ({ locale }) => {
     return result;
   });
 
-  const data = res.data.sclabsSignupList;
+  const data = res.data.sCLabsPageByPath;
 
   return process.env.NEXT_PUBLIC_ISR_ENABLED
     ? {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,10 +9,10 @@
   dependencies:
     "@jridgewell/trace-mapping" "^0.3.0"
 
-"@apollo/client@^3.6.6":
-  version "3.6.6"
-  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.6.6.tgz#3fb1f5b11da9a64b51b5a86b62450bee034e7f41"
-  integrity sha512-AzNLN043wy0bDTTR9wzKYSu+I1IT2Ox3+vWckxgIt88Jfw5jHBvumf3lXE1JlgvbFCTiKS/Sa66AadQXWMVBRQ==
+"@apollo/client@^3.6.8":
+  version "3.6.9"
+  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.6.9.tgz#ad0ee2e3a3c92dbed4acd6917b6158a492739d94"
+  integrity sha512-Y1yu8qa2YeaCUBVuw08x8NHenFi0sw2I3KCu7Kw9mDSu86HmmtHJkCAifKVrN2iPgDTW/BbP3EpSV8/EQCcxZA==
   dependencies:
     "@graphql-typed-document-node/core" "^3.1.1"
     "@wry/context" "^0.6.0"


### PR DESCRIPTION
# Description

- Updates the graphql query for signup page to use the new page model 
- Removes `publishProd` fields and `title` fields in the `scLabsContent` since they were removed in AEM
- Addresses #540

## Test Instructions

1. yarn dev
2. go to Signup page and check if English and French content displays correctly

## Checklist

- [ ] Strings use placeholders for translation (No hard coded strings)
- [x] Unit tests have been added/updated
- [ ] Update CHANGELOG
