### PR TITLE
Remove disclaimer from all pages except projects page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Updated DateModified component to accept a manual date (for use with AEM)
 - Updated images to use next/image instead of html img tag
 - Updated past project label to be gray instead of red, and also updated projects page to use new AEM data
+- Added the `showDisclaimer` prop to the `Layout` component so control which pages have the disclaimer
 
 ## Fixed
 

--- a/components/organisms/Layout.js
+++ b/components/organisms/Layout.js
@@ -27,6 +27,7 @@ export const Layout = ({
   langUrl,
   breadcrumbItems,
   feedbackActive,
+  showDisclaimer,
   projectName,
   path,
   dateModifiedOverride,
@@ -54,13 +55,17 @@ export const Layout = ({
       <header>
         <h2 className="sr-only">{t("globalHeader")}</h2>
         <h3 className="sr-only">{t("testSiteNotice")}</h3>
-        <PhaseBanner
-          phase={t("phaseBannerTag")}
-          feedbackActive={feedbackActive}
-          text={t("phaseBannerText")}
-          projectName={projectName}
-          path={path}
-        />
+        {showDisclaimer ? (
+          <PhaseBanner
+            phase={t("phaseBannerTag")}
+            feedbackActive={feedbackActive}
+            text={t("phaseBannerText")}
+            projectName={projectName}
+            path={path}
+          />
+        ) : (
+          ""
+        )}
         <div className="layout-container flex-col flex lg:flex lg:flex-row justify-between  mt-2">
           <div
             className="flex flex-row justify-between items-center lg:mt-7 mt-1.5"
@@ -254,6 +259,10 @@ Layout.propTypes = {
    * For activating feedback on active projects pages
    */
   feedbackActive: PropTypes.bool,
+  /**
+   * Boolean that determines whether the disclaimer at the top of the screen is shown or not
+   */
+  showDisclaimer: PropTypes.bool,
   /**
    * Project/page name that feedback is coming from
    */

--- a/pages/projects.js
+++ b/pages/projects.js
@@ -59,6 +59,7 @@ export default function Projects(props) {
         breadcrumbItems={[
           { text: t("siteTitle"), link: t("breadCrumbsHref1") },
         ]}
+        showDisclaimer
       >
         <Head>
           {process.env.NEXT_PUBLIC_ADOBE_ANALYTICS_URL ? (


### PR DESCRIPTION
# Description

[SCL-757 - Remove universal banner from header](https://jira-dev.bdm-dev.dts-stn.com/browse/SCL-757)

Very small PR that simply adds a boolean prop to the Layout component to determine whether or not we show the disclaimer banner at the top of the screen. The banner design will be changing soon and from my understanding will only be shown on the Explore our projects page and the project overview pages.

## Acceptance Criteria

The disclaimer banner is only shown on the Explore our projects page for now.

## Test Instructions

1. Pull in branch
2. Type `yarn dev`
3. Navigate to `/home` and `/projects` and ensure that the disclaimer banner only appears on `/projects`

## Checklist

- [x] Strings use placeholders for translation (No hard coded strings)
- [x] Unit tests have been added/updated
- [x] Update CHANGELOG

## Product and Sprint Backlog

[Jira](https://jira-dev.bdm-dev.dts-stn.com/secure/RapidBoard.jspa?rapidView=96&projectKey=SCL)
