### PR TITLE
Update alt text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Updated virtual assistant page to use data from AEM
 - Updated signup-info page to use data from AEM
 - Remove Test Site banner on the projects page
+- Updated alt text across site based on best practices
+- Updated `/thankyou` page to use animated checkmark for consistency
 
 ## Fixed
 

--- a/__mocks__/mockStore.js
+++ b/__mocks__/mockStore.js
@@ -4,32 +4,88 @@ export const notSupportedData = {
   data: {
     scLabsErrorPageByPath: {
       item: {
-        sclGcImages: [
+        scGcImages: [
           {
-            _path: "/content/dam/decd-endc/images/sclabs/sig-blk-en.svg",
+            scId: "SCLABS-GOC-HEADER-IMAGE",
+            scImageEn: {
+              _path: "/content/dam/decd-endc/images/sclabs/sig-blk-en.svg",
+            },
+            scImageAltTextEn: "Government of Canada",
+            scImageFr: {
+              _path: "/content/dam/decd-endc/images/sclabs/sig-blk-fr.svg",
+            },
+            scImageAltTextFr: "Gouvernement du Canada",
           },
           {
-            _path: "/content/dam/decd-endc/images/sclabs/wmms-blk.svg",
+            scId: "SCLABS-GOC-FOOTER-IMAGE",
+            scImageEn: {
+              _path: "/content/dam/decd-endc/images/sclabs/wmms-blk.svg",
+            },
+            scImageAltTextEn: "Symbol of the Government of Canada",
+            scImageFr: {
+              _path: "/content/dam/decd-endc/images/sclabs/wmms-blk.svg",
+            },
+            scImageAltTextFr: "Symbole du gouvernement du Canada",
           },
         ],
-        sclImagelist: [
+        scImageList: [
           {
-            _path: "/content/dam/decd-endc/images/sclabs/crackedbulb.svg",
+            scId: "SCLABS-CRACKED-LIGHTBULB",
+            scImageEn: {
+              _path: "/content/dam/decd-endc/images/sclabs/crackedbulb.svg",
+            },
+            scImageAltTextEn: null,
+            scImageFr: {
+              _path: "/content/dam/decd-endc/images/sclabs/crackedbulb.svg",
+            },
+            scImageAltTextFr: null,
           },
           {
-            _path: "/content/dam/decd-endc/images/sclabs/chrome.png",
+            scId: "SCLABS-CHROME-LOGO",
+            scImageEn: {
+              _path: "/content/dam/decd-endc/images/sclabs/chrome.png",
+            },
+            scImageAltTextEn: "The Google Chrome browser logo",
+            scImageFr: {
+              _path: "/content/dam/decd-endc/images/sclabs/chrome.png",
+            },
+            scImageAltTextFr: "Le logo du navigateur Google Chrome",
           },
           {
-            _path: "/content/dam/decd-endc/images/sclabs/safari.png",
+            scId: "SCLABS-SAFARI-LOGO",
+            scImageEn: {
+              _path: "/content/dam/decd-endc/images/sclabs/safari.png",
+            },
+            scImageAltTextEn: "The Safari browser logo",
+            scImageFr: {
+              _path: "/content/dam/decd-endc/images/sclabs/safari.png",
+            },
+            scImageAltTextFr: "Le logo du navigateur Safari",
           },
           {
-            _path: "/content/dam/decd-endc/images/sclabs/edge.png",
+            scId: "SCLABS-EDGE-LOGO",
+            scImageEn: {
+              _path: "/content/dam/decd-endc/images/sclabs/edge.png",
+            },
+            scImageAltTextEn: "The Microsoft Edge browser logo",
+            scImageFr: {
+              _path: "/content/dam/decd-endc/images/sclabs/edge.png",
+            },
+            scImageAltTextFr: "Le logo du navigateur Microsoft Edge",
           },
           {
-            _path: "/content/dam/decd-endc/images/sclabs/firefox.svg",
+            scId: "SCLABS-FIREFOX-LOGO",
+            scImageEn: {
+              _path: "/content/dam/decd-endc/images/sclabs/firefox.svg",
+            },
+            scImageAltTextEn: "The Mozilla Firefox browser logo",
+            scImageFr: {
+              _path: "/content/dam/decd-endc/images/sclabs/firefox.svg",
+            },
+            scImageAltTextFr: "Le logo du navigateur Mozilla Firefox",
           },
         ],
-        sclContentEn: {
+        scContentEn: {
           json: [
             {
               nodeType: "header",
@@ -54,9 +110,8 @@ export const notSupportedData = {
             },
           ],
         },
-        sclCopyToClipboardLabelEn:
-          "Copy the link below and paste in that browser.",
-        sclBrowserDownloadLinksEn: {
+        scCopyToClipboardLabelEn: "Copy link",
+        scBrowserDownloadLinksEn: {
           json: [
             {
               nodeType: "paragraph",
@@ -123,7 +178,7 @@ export const notSupportedData = {
             },
           ],
         },
-        sclContentFr: {
+        scContentFr: {
           json: [
             {
               nodeType: "header",
@@ -148,9 +203,8 @@ export const notSupportedData = {
             },
           ],
         },
-        sclCopyToClipboardLabelFr:
-          "Vous n'avez qu'à copier le lien ci-dessous et le coller dans ce navigateur.",
-        sclBrowserDownloadLinksFr: {
+        scCopyToClipboardLabelFr: "Copier lien",
+        scBrowserDownloadLinksFr: {
           json: [
             {
               nodeType: "paragraph",
@@ -226,20 +280,39 @@ export const error500Page = {
   data: {
     scLabsErrorPageByPath: {
       item: {
-        sclGcImages: [
+        scGcImages: [
           {
-            _path: "/content/dam/decd-endc/images/sclabs/sig-blk-en.svg",
+            scId: "SCLABS-GOC-HEADER-IMAGE",
+            scImageEn: {
+              _path: "/content/dam/decd-endc/images/sclabs/sig-blk-en.svg",
+            },
+            scImageAltTextEn: "Government of Canada",
+            scImageFr: {
+              _path: "/content/dam/decd-endc/images/sclabs/sig-blk-fr.svg",
+            },
+            scImageAltTextFr: "Gouvernement du Canada",
           },
           {
-            _path: "/content/dam/decd-endc/images/sclabs/wmms-blk.svg",
+            scId: "SCLABS-GOC-FOOTER-IMAGE",
+            scImageEn: {
+              _path: "/content/dam/decd-endc/images/sclabs/wmms-blk.svg",
+            },
+            scImageAltTextEn: "Symbol of the Government of Canada",
+            scImageFr: {
+              _path: "/content/dam/decd-endc/images/sclabs/wmms-blk.svg",
+            },
+            scImageAltTextFr: "Symbole du gouvernement du Canada",
           },
         ],
-        sclImagelist: [
+        scImageList: [
           {
-            _path: "/content/dam/decd-endc/images/sclabs/crackedbulb.svg",
+            scId: "SCLABS-CRACKED-LIGHTBULB",
+            scImageEn: {
+              _path: "/content/dam/decd-endc/images/sclabs/crackedbulb.svg",
+            },
           },
         ],
-        sclContentEn: {
+        scContentEn: {
           json: [
             {
               nodeType: "header",
@@ -272,29 +345,24 @@ export const error500Page = {
               ],
             },
             {
-              nodeType: "unordered-list",
+              nodeType: "paragraph",
               content: [
                 {
-                  nodeType: "list-item",
-                  content: [
-                    {
-                      nodeType: "text",
-                      value: "Return to the ",
-                    },
-                    {
-                      nodeType: "link",
-                      data: {
-                        href: "/",
-                      },
-                      value: "Service Canada Labs home page",
-                    },
-                  ],
+                  nodeType: "text",
+                  value: "Return to the ",
+                },
+                {
+                  nodeType: "link",
+                  data: {
+                    href: "/",
+                  },
+                  value: "Service Canada Labs home page",
                 },
               ],
             },
           ],
         },
-        sclContentFr: {
+        scContentFr: {
           json: [
             {
               nodeType: "header",
@@ -327,24 +395,18 @@ export const error500Page = {
               ],
             },
             {
-              nodeType: "unordered-list",
+              nodeType: "paragraph",
               content: [
                 {
-                  nodeType: "list-item",
-                  content: [
-                    {
-                      nodeType: "text",
-                      value: "Retournez à la ",
-                    },
-                    {
-                      nodeType: "link",
-                      data: {
-                        href: "/fr/",
-                      },
-                      value:
-                        "page d'accueil des laboratoires de Service Canada",
-                    },
-                  ],
+                  nodeType: "text",
+                  value: "Retournez à la ",
+                },
+                {
+                  nodeType: "link",
+                  data: {
+                    href: "/fr/",
+                  },
+                  value: "page d'accueil des laboratoires de Service Canada",
                 },
               ],
             },
@@ -359,20 +421,39 @@ export const error404Page = {
   data: {
     scLabsErrorPageByPath: {
       item: {
-        sclGcImages: [
+        scGcImages: [
           {
-            _path: "/content/dam/decd-endc/images/sclabs/sig-blk-en.svg",
+            scId: "SCLABS-GOC-HEADER-IMAGE",
+            scImageEn: {
+              _path: "/content/dam/decd-endc/images/sclabs/sig-blk-en.svg",
+            },
+            scImageAltTextEn: "Government of Canada",
+            scImageFr: {
+              _path: "/content/dam/decd-endc/images/sclabs/sig-blk-fr.svg",
+            },
+            scImageAltTextFr: "Gouvernement du Canada",
           },
           {
-            _path: "/content/dam/decd-endc/images/sclabs/wmms-blk.svg",
+            scId: "SCLABS-GOC-FOOTER-IMAGE",
+            scImageEn: {
+              _path: "/content/dam/decd-endc/images/sclabs/wmms-blk.svg",
+            },
+            scImageAltTextEn: "Symbol of the Government of Canada",
+            scImageFr: {
+              _path: "/content/dam/decd-endc/images/sclabs/wmms-blk.svg",
+            },
+            scImageAltTextFr: "Symbole du gouvernement du Canada",
           },
         ],
-        sclImagelist: [
+        scImageList: [
           {
-            _path: "/content/dam/decd-endc/images/sclabs/crackedbulb.svg",
+            scId: "SCLABS-CRACKED-LIGHTBULB",
+            scImageEn: {
+              _path: "/content/dam/decd-endc/images/sclabs/crackedbulb.svg",
+            },
           },
         ],
-        sclContentEn: {
+        scContentEn: {
           json: [
             {
               nodeType: "header",
@@ -404,29 +485,24 @@ export const error404Page = {
               ],
             },
             {
-              nodeType: "unordered-list",
+              nodeType: "paragraph",
               content: [
                 {
-                  nodeType: "list-item",
-                  content: [
-                    {
-                      nodeType: "text",
-                      value: "Return to the ",
-                    },
-                    {
-                      nodeType: "link",
-                      data: {
-                        href: "/",
-                      },
-                      value: "Service Canada Labs home page",
-                    },
-                  ],
+                  nodeType: "text",
+                  value: "Return to the ",
+                },
+                {
+                  nodeType: "link",
+                  data: {
+                    href: "/",
+                  },
+                  value: "Service Canada Labs home page",
                 },
               ],
             },
           ],
         },
-        sclContentFr: {
+        scContentFr: {
           json: [
             {
               nodeType: "header",
@@ -458,24 +534,18 @@ export const error404Page = {
               ],
             },
             {
-              nodeType: "unordered-list",
+              nodeType: "paragraph",
               content: [
                 {
-                  nodeType: "list-item",
-                  content: [
-                    {
-                      nodeType: "text",
-                      value: "Retournez à la ",
-                    },
-                    {
-                      nodeType: "link",
-                      data: {
-                        href: "/fr/",
-                      },
-                      value:
-                        "page d'accueil des laboratoires de Service Canada",
-                    },
-                  ],
+                  nodeType: "text",
+                  value: "Retournez à la ",
+                },
+                {
+                  nodeType: "link",
+                  data: {
+                    href: "/fr/",
+                  },
+                  value: "page d'accueil des laboratoires de Service Canada",
                 },
               ],
             },

--- a/__mocks__/mockStore.js
+++ b/__mocks__/mockStore.js
@@ -310,6 +310,9 @@ export const error500Page = {
             scImageEn: {
               _path: "/content/dam/decd-endc/images/sclabs/crackedbulb.svg",
             },
+            scImageFr: {
+              _path: "/content/dam/decd-endc/images/sclabs/crackedbulb.svg",
+            },
           },
         ],
         scContentEn: {
@@ -449,6 +452,9 @@ export const error404Page = {
           {
             scId: "SCLABS-CRACKED-LIGHTBULB",
             scImageEn: {
+              _path: "/content/dam/decd-endc/images/sclabs/crackedbulb.svg",
+            },
+            scImageFr: {
               _path: "/content/dam/decd-endc/images/sclabs/crackedbulb.svg",
             },
           },

--- a/graphql/queries/customErrorQuery.graphql
+++ b/graphql/queries/customErrorQuery.graphql
@@ -1,25 +1,44 @@
 query getCustomErrorPage {
-	scLabsErrorPageByPath(_path: "/content/dam/decd-endc/content-fragments/alpha/sclabs/pages/custom-error-page") {
-	    item {
-            sclGcImages {
-                ... on DocumentRef {
-                    _path
-                }
+  scLabsErrorPageByPath(
+    _path: "/content/dam/decd-endc/content-fragments/alpha/sclabs/pages/custom-error-page"
+  ) {
+    item {
+      scGcImages {
+        ... on SCLabsImageModel {
+          scId
+          scImageEn {
+            ... on DocumentRef {
+              _path
             }
-            sclImagelist {
-                ... on DocumentRef {
-                    _path
-                }
-                ... on ImageRef {
-                    _path
-                }
+          }
+          scImageAltTextEn
+          scImageFr {
+            ... on DocumentRef {
+              _path
             }
-            sclContentEn {
-                json
-            }
-            sclContentFr {
-                json
-            }
+          }
+          scImageAltTextFr
         }
-	}
+      }
+      scImageList {
+        ... on SCLabsImageModel {
+          scId
+          scImageEn {
+            ... on DocumentRef {
+              _path
+            }
+            ... on ImageRef {
+              _path
+            }
+          }
+        }
+      }
+      scContentEn {
+        json
+      }
+      scContentFr {
+        json
+      }
+    }
+  }
 }

--- a/graphql/queries/customErrorQuery.graphql
+++ b/graphql/queries/customErrorQuery.graphql
@@ -31,6 +31,14 @@ query getCustomErrorPage {
               _path
             }
           }
+          scImageFr {
+            ... on DocumentRef {
+              _path
+            }
+            ... on ImageRef {
+              _path
+            }
+          }
         }
       }
       scContentEn {

--- a/graphql/queries/error404Query.graphql
+++ b/graphql/queries/error404Query.graphql
@@ -31,6 +31,14 @@ query get404Page {
               _path
             }
           }
+          scImageFr {
+            ... on DocumentRef {
+              _path
+            }
+            ... on ImageRef {
+              _path
+            }
+          }
         }
       }
       scContentEn {

--- a/graphql/queries/error404Query.graphql
+++ b/graphql/queries/error404Query.graphql
@@ -1,25 +1,44 @@
 query get404Page {
-	scLabsErrorPageByPath(_path: "/content/dam/decd-endc/content-fragments/alpha/sclabs/pages/404-error-page") {
-	    item {
-            sclGcImages {
-                ... on DocumentRef {
-                    _path
-                }
+  scLabsErrorPageByPath(
+    _path: "/content/dam/decd-endc/content-fragments/alpha/sclabs/pages/404-error-page"
+  ) {
+    item {
+      scGcImages {
+        ... on SCLabsImageModel {
+          scId
+          scImageEn {
+            ... on DocumentRef {
+              _path
             }
-            sclImagelist {
-                ... on DocumentRef {
-                    _path
-                }
-                ... on ImageRef {
-                    _path
-                }
+          }
+          scImageAltTextEn
+          scImageFr {
+            ... on DocumentRef {
+              _path
             }
-            sclContentEn {
-                json
-            }
-            sclContentFr {
-                json
-            }
+          }
+          scImageAltTextFr
         }
-	}
+      }
+      scImageList {
+        ... on SCLabsImageModel {
+          scId
+          scImageEn {
+            ... on DocumentRef {
+              _path
+            }
+            ... on ImageRef {
+              _path
+            }
+          }
+        }
+      }
+      scContentEn {
+        json
+      }
+      scContentFr {
+        json
+      }
+    }
+  }
 }

--- a/graphql/queries/error500Query.graphql
+++ b/graphql/queries/error500Query.graphql
@@ -31,6 +31,14 @@ query get500Page {
               _path
             }
           }
+          scImageFr {
+            ... on DocumentRef {
+              _path
+            }
+            ... on ImageRef {
+              _path
+            }
+          }
         }
       }
       scContentEn {

--- a/graphql/queries/error500Query.graphql
+++ b/graphql/queries/error500Query.graphql
@@ -1,25 +1,44 @@
 query get500Page {
-	scLabsErrorPageByPath(_path: "/content/dam/decd-endc/content-fragments/alpha/sclabs/pages/500-error-page") {
-	    item {
-            sclGcImages {
-                ... on DocumentRef {
-                    _path
-                }
+  scLabsErrorPageByPath(
+    _path: "/content/dam/decd-endc/content-fragments/alpha/sclabs/pages/500-error-page"
+  ) {
+    item {
+      scGcImages {
+        ... on SCLabsImageModel {
+          scId
+          scImageEn {
+            ... on DocumentRef {
+              _path
             }
-            sclImagelist {
-                ... on DocumentRef {
-                    _path
-                }
-                ... on ImageRef {
-                    _path
-                }
+          }
+          scImageAltTextEn
+          scImageFr {
+            ... on DocumentRef {
+              _path
             }
-            sclContentEn {
-                json
-            }
-            sclContentFr {
-                json
-            }
+          }
+          scImageAltTextFr
         }
-	}
+      }
+      scImageList {
+        ... on SCLabsImageModel {
+          scId
+          scImageEn {
+            ... on DocumentRef {
+              _path
+            }
+            ... on ImageRef {
+              _path
+            }
+          }
+        }
+      }
+      scContentEn {
+        json
+      }
+      scContentFr {
+        json
+      }
+    }
+  }
 }

--- a/graphql/queries/notsupportedQuery.graphql
+++ b/graphql/queries/notsupportedQuery.graphql
@@ -1,33 +1,62 @@
 query getNotSupported {
-	scLabsErrorPageByPath(_path: "/content/dam/decd-endc/content-fragments/alpha/sclabs/pages/browser-not-supported-page") {
-	    item {
-            sclGcImages {
-                ... on DocumentRef {
-                    _path
-                }
+  scLabsErrorPageByPath(
+    _path: "/content/dam/decd-endc/content-fragments/alpha/sclabs/pages/browser-not-supported-page"
+  ) {
+    item {
+      scGcImages {
+        ... on SCLabsImageModel {
+          scId
+          scImageEn {
+            ... on DocumentRef {
+              _path
             }
-            sclImagelist {
-                ... on DocumentRef {
-                    _path
-                }
-                ... on ImageRef {
-                    _path
-                }
+          }
+          scImageAltTextEn
+          scImageFr {
+            ... on DocumentRef {
+              _path
             }
-            sclContentEn {
-                json
-            }
-            sclCopyToClipboardLabelEn
-            sclBrowserDownloadLinksEn {
-                json
-            }
-            sclContentFr {
-                json
-            }
-            sclCopyToClipboardLabelFr
-            sclBrowserDownloadLinksFr {
-                json
-            }
+          }
+          scImageAltTextFr
         }
-	}
+      }
+      scImageList {
+        ... on SCLabsImageModel {
+          scId
+          scImageEn {
+            ... on ImageRef {
+              _path
+            }
+            ... on DocumentRef {
+              _path
+            }
+          }
+          scImageAltTextEn
+          scImageFr {
+            ... on ImageRef {
+              _path
+            }
+            ... on DocumentRef {
+              _path
+            }
+          }
+          scImageAltTextFr
+        }
+      }
+      scContentEn {
+        json
+      }
+      scCopyToClipboardLabelEn
+      scBrowserDownloadLinksEn {
+        json
+      }
+      scContentFr {
+        json
+      }
+      scCopyToClipboardLabelFr
+      scBrowserDownloadLinksFr {
+        json
+      }
+    }
+  }
 }

--- a/pages/404.js
+++ b/pages/404.js
@@ -47,8 +47,8 @@ export default function error404(props) {
 
           {/* Primary HTML Meta Tags */}
           <title data-gc-analytics-error="404">
-            {pageData.sclContentEn.json[0].content[0].value} (404) |{" "}
-            {pageData.sclContentFr.json[0].content[0].value} (404)
+            {pageData.scContentEn.json[0].content[0].value} (404) |{" "}
+            {pageData.scContentFr.json[0].content[0].value} (404)
           </title>
           <meta
             name="description"
@@ -121,8 +121,16 @@ export default function error404(props) {
         <section className="layout-container pb-44">
           <div className="pt-6">
             <Image
-              src={`https://www.canada.ca${pageData.sclGcImages[0]._path}`}
-              alt={"Symbol of the Government of Canada"}
+              src={`https://www.canada.ca${
+                props.locale === "en"
+                  ? pageData.scGcImages[0].scImageEn._path
+                  : pageData.scGcImages[0].scImageFr._path
+              }`}
+              alt={
+                props.locale === "en"
+                  ? pageData.scGcImages[0].scImageAltTextEn
+                  : pageData.scGcImages[0].scImageAltTextFr
+              }
               width={575}
               height={59}
             />
@@ -131,29 +139,23 @@ export default function error404(props) {
             <div>
               <div className="relative h-auto xl:w-96 xxl:w-400px lg:w-72 xl:h-400px lg:h-500px mb-8 lg:mb-0">
                 <h1 className="font-bold font-display mb-4">
-                  {pageData.sclContentEn.json[0].content[0].value}
+                  {pageData.scContentEn.json[0].content[0].value}
                 </h1>
                 <p className="font-bold font-body mb-8">
-                  {pageData.sclContentEn.json[1].content[0].value}
+                  {pageData.scContentEn.json[1].content[0].value}
                 </p>
                 <p className="font-body text-sm mb-4 leading-30px">
-                  {pageData.sclContentEn.json[2].content[0].value}
+                  {pageData.scContentEn.json[2].content[0].value}
                 </p>
                 <div className="flex">
                   <span className="error404-link" />
                   <p className="font-body text-sm leading-30px">
-                    {pageData.sclContentEn.json[3].content[0].content[0].value}
+                    {pageData.scContentEn.json[3].content[0].value}
                     <Link
-                      href={
-                        pageData.sclContentEn.json[3].content[0].content[1].data
-                          .href
-                      }
+                      href={pageData.scContentEn.json[3].content[1].data.href}
                     >
                       <a className="underline hover:text-canada-footer-hover-font-blue text-canada-footer-font">
-                        {
-                          pageData.sclContentEn.json[3].content[0].content[1]
-                            .value
-                        }
+                        {pageData.scContentEn.json[3].content[1].value}
                       </a>
                     </Link>
                   </p>
@@ -164,8 +166,12 @@ export default function error404(props) {
             <div className="flex items-center justify-center circle-background my-8 mx-4 lg:mt-0 lightbulb-bg shrink-0">
               <span className="relative lightbulb">
                 <Image
-                  src={`https://www.canada.ca${pageData.sclImagelist[0]._path}`}
-                  alt="Cracked lightbulb"
+                  src={`https://www.canada.ca${
+                    props.locale === "en"
+                      ? pageData.scImageList[0].scImageEn._path
+                      : pageData.scImageList[0].scImageFr._path
+                  }`}
+                  alt=""
                   layout="fill"
                   objectFit="cover"
                 />
@@ -177,29 +183,23 @@ export default function error404(props) {
                 lang="fr"
               >
                 <h1 className="font-bold font-display mb-4">
-                  {pageData.sclContentFr.json[0].content[0].value}
+                  {pageData.scContentFr.json[0].content[0].value}
                 </h1>
                 <p className="font-bold font-body mb-8">
-                  {pageData.sclContentFr.json[1].content[0].value}
+                  {pageData.scContentFr.json[1].content[0].value}
                 </p>
                 <p className="font-body text-sm mb-4 leading-30px">
-                  {pageData.sclContentFr.json[2].content[0].value}
+                  {pageData.scContentFr.json[2].content[0].value}
                 </p>
                 <div className="flex">
                   <span className="error404-link" />
                   <p className="font-body text-sm leading-30px">
-                    {pageData.sclContentFr.json[3].content[0].content[0].value}
+                    {pageData.scContentFr.json[3].content[0].value}
                     <Link
-                      href={
-                        pageData.sclContentFr.json[3].content[0].content[1].data
-                          .href
-                      }
+                      href={pageData.scContentFr.json[3].content[1].data.href}
                     >
                       <a className="underline hover:text-canada-footer-hover-font-blue text-canada-footer-font">
-                        {
-                          pageData.sclContentFr.json[3].content[0].content[1]
-                            .value
-                        }
+                        {pageData.scContentFr.json[3].content[1].value}
                       </a>
                     </Link>
                   </p>
@@ -221,8 +221,16 @@ export default function error404(props) {
             />
             <span className="relative footer-logo">
               <Image
-                src={`https://www.canada.ca${pageData.sclGcImages[1]._path}`}
-                alt="Symbol of the Government of Canada"
+                src={`https://www.canada.ca${
+                  props.locale === "en"
+                    ? pageData.scGcImages[1].scImageEn._path
+                    : pageData.scGcImages[1].scImageFr._path
+                }`}
+                alt={
+                  props.locale === "en"
+                    ? pageData.scGcImages[1].scImageAltTextEn
+                    : pageData.scGcImages[1].scImageAltTextFr
+                }
                 layout="fill"
               />
             </span>

--- a/pages/500.js
+++ b/pages/500.js
@@ -47,8 +47,8 @@ export default function error500(props) {
 
           {/* Primary HTML Meta Tags */}
           <title data-gc-analytics-error="500">
-            {pageData.sclContentEn.json[0].content[0].value} (500) |{" "}
-            {pageData.sclContentFr.json[0].content[0].value} (500)
+            {pageData.scContentEn.json[0].content[0].value} (500) |{" "}
+            {pageData.scContentFr.json[0].content[0].value} (500)
           </title>
           <meta
             name="description"
@@ -154,8 +154,16 @@ export default function error500(props) {
         <section className="layout-container pb-44">
           <div className="pt-6">
             <Image
-              src={`https://www.canada.ca${pageData.sclGcImages[0]._path}`}
-              alt={"Symbol of the Government of Canada"}
+              src={`https://www.canada.ca${
+                props.locale === "en"
+                  ? pageData.scGcImages[0].scImageEn._path
+                  : pageData.scGcImages[0].scImageFr._path
+              }`}
+              alt={
+                props.locale === "en"
+                  ? pageData.scGcImages[0].scImageAltTextEn
+                  : pageData.scGcImages[0].scImageAltTextFr
+              }
               width={575}
               height={59}
             />
@@ -164,29 +172,23 @@ export default function error500(props) {
             <div>
               <div className="relative h-auto xl:w-96 xxl:w-400px lg:w-72 xl:h-400px lg:h-500px mb-8 lg:mb-0">
                 <h1 className="font-bold font-display mb-4">
-                  {pageData.sclContentEn.json[0].content[0].value}
+                  {pageData.scContentEn.json[0].content[0].value}
                 </h1>
                 <p className="font-bold font-body mb-8">
-                  {pageData.sclContentEn.json[1].content[0].value}
+                  {pageData.scContentEn.json[1].content[0].value}
                 </p>
                 <p className="font-body text-sm mb-4 leading-30px">
-                  {pageData.sclContentEn.json[2].content[0].value}
+                  {pageData.scContentEn.json[2].content[0].value}
                 </p>
                 <div className="flex">
                   <span className="error404-link" />
                   <p className="font-body text-sm leading-30px">
-                    {pageData.sclContentEn.json[3].content[0].content[0].value}
+                    {pageData.scContentEn.json[3].content[0].value}
                     <Link
-                      href={
-                        pageData.sclContentEn.json[3].content[0].content[1].data
-                          .href
-                      }
+                      href={pageData.scContentEn.json[3].content[1].data.href}
                     >
                       <a className="underline hover:text-canada-footer-hover-font-blue text-canada-footer-font">
-                        {
-                          pageData.sclContentEn.json[3].content[0].content[1]
-                            .value
-                        }
+                        {pageData.scContentEn.json[3].content[1].value}
                       </a>
                     </Link>
                   </p>
@@ -197,8 +199,12 @@ export default function error500(props) {
             <div className="flex items-center justify-center circle-background my-8 lg:mt-0 lightbulb-bg">
               <span className="relative lightbulb">
                 <Image
-                  src={`https://www.canada.ca${pageData.sclImagelist[0]._path}`}
-                  alt="Cracked lightbulb"
+                  src={`https://www.canada.ca${
+                    props.locale === "en"
+                      ? pageData.scImageList[0].scImageEn._path
+                      : pageData.scImageList[0].scImageFr._path
+                  }`}
+                  alt=""
                   layout="fill"
                   objectFit="cover"
                 />
@@ -210,29 +216,23 @@ export default function error500(props) {
                 lang="fr"
               >
                 <h1 className="font-bold font-display mb-4">
-                  {pageData.sclContentFr.json[0].content[0].value}
+                  {pageData.scContentFr.json[0].content[0].value}
                 </h1>
                 <p className="font-bold font-body mb-8">
-                  {pageData.sclContentFr.json[1].content[0].value}
+                  {pageData.scContentFr.json[1].content[0].value}
                 </p>
                 <p className="font-body text-sm mb-4 leading-30px">
-                  {pageData.sclContentFr.json[2].content[0].value}
+                  {pageData.scContentFr.json[2].content[0].value}
                 </p>
                 <div className="flex">
-                  <span className="error404-link" />
+                  <span className="error50-link" />
                   <p className="font-body text-sm leading-30px">
-                    {pageData.sclContentFr.json[3].content[0].content[0].value}
+                    {pageData.scContentFr.json[3].content[0].value}
                     <Link
-                      href={
-                        pageData.sclContentFr.json[3].content[0].content[1].data
-                          .href
-                      }
+                      href={pageData.scContentFr.json[3].content[1].data.href}
                     >
                       <a className="underline hover:text-canada-footer-hover-font-blue text-canada-footer-font">
-                        {
-                          pageData.sclContentFr.json[3].content[0].content[1]
-                            .value
-                        }
+                        {pageData.scContentFr.json[3].content[1].value}
                       </a>
                     </Link>
                   </p>
@@ -254,8 +254,16 @@ export default function error500(props) {
             />
             <span className="relative footer-logo">
               <Image
-                src={`https://www.canada.ca${pageData.sclGcImages[1]._path}`}
-                alt="Symbol of the Government of Canada"
+                src={`https://www.canada.ca${
+                  props.locale === "en"
+                    ? pageData.scGcImages[1].scImageEn._path
+                    : pageData.scGcImages[1].scImageFr._path
+                }`}
+                alt={
+                  props.locale === "en"
+                    ? pageData.scGcImages[1].scImageAltTextEn
+                    : pageData.scGcImages[1].scImageAltTextFr
+                }
                 layout="fill"
               />
             </span>

--- a/pages/confirmation.js
+++ b/pages/confirmation.js
@@ -5,7 +5,8 @@ import { Layout } from "../components/organisms/Layout";
 import Head from "next/head";
 import { TextButtonField } from "../components/molecules/TextButtonField";
 import { useEffect } from "react";
-import Image from "next/image";
+import { Player, Controls } from "@lottiefiles/react-lottie-player";
+import animatedCheckmark from "../public/animatedCheckmark.json";
 
 export default function Confirmation(props) {
   const { t } = useTranslation("common");
@@ -160,14 +161,27 @@ export default function Confirmation(props) {
               : t("emailConfirmationTitle")}
           </h1>
           <div className="lg:flex lg:flex-row-reverse">
-            <span className="w-full flex justify-center lg:w-1/3">
-              <Image
-                src="/circle-check.svg"
-                alt="checkmark"
-                width="160"
-                height="160"
-              />
-            </span>
+            <div
+              role="img"
+              aria-label={t("animatedCheckmarkAltText")}
+              className="w-full flex justify-center lg:w-1/3"
+            >
+              <Player
+                autoplay
+                keepLastFrame
+                src={animatedCheckmark}
+                alt={t("animatedCheckmarkAltText")}
+                style={{
+                  height: "248px",
+                  width: "248px",
+                }}
+              >
+                <Controls
+                  visible={false}
+                  buttons={["play", "repeat", "frame", "debug"]}
+                />
+              </Player>
+            </div>
             {referrer === "unsubscribe" ? (
               <div className="lg:w-2/3">
                 <p className="mb-4 text-sm lg:text-p leading-30px">

--- a/pages/error.js
+++ b/pages/error.js
@@ -17,13 +17,13 @@ export default function ErrorPage(props) {
 
   const statusCode = query.statusCode || "";
   const errorTitle =
-    query.errorTitle || pageData.sclContentEn.json[0].content[0].value;
+    query.errorTitle || pageData.scContentEn.json[0].content[0].value;
   const errorTitleFr =
-    query.errorTitleFr || pageData.sclContentFr.json[0].content[0].value;
+    query.errorTitleFr || pageData.scContentFr.json[0].content[0].value;
   const errorMessage =
-    query.errorMessage || pageData.sclContentEn.json[1].content[0].value;
+    query.errorMessage || pageData.scContentEn.json[1].content[0].value;
   const errorMessageFr =
-    query.errorMessageFr || pageData.sclContentFr.json[1].content[0].value;
+    query.errorMessageFr || pageData.scContentFr.json[1].content[0].value;
 
   useEffect(() => {
     if (props.adobeAnalyticsUrl) {
@@ -44,8 +44,8 @@ export default function ErrorPage(props) {
 
           {/* Primary HTML Meta Tags */}
           <title data-gc-analytics-error={props.statusCode}>
-            {pageData.sclContentEn.json[0].content[0].value} |{" "}
-            {pageData.sclContentFr.json[0].content[0].value}
+            {pageData.scContentEn.json[0].content[0].value} |{" "}
+            {pageData.scContentFr.json[0].content[0].value}
           </title>
           <link rel="schema.dcterms" href="http://purl.org/dc/terms/" />
           <meta content="width=device-width, initial-scale=1" name="viewport" />
@@ -171,8 +171,16 @@ export default function ErrorPage(props) {
           <section className="layout-container pb-44">
             <div className="pt-6">
               <Image
-                src={`https://www.canada.ca${pageData.sclGcImages[0]._path}`}
-                alt={"Symbol of the Government of Canada"}
+                src={`https://www.canada.ca${
+                  props.locale === "en"
+                    ? pageData.scGcImages[0].scImageEn._path
+                    : pageData.scGcImages[0].scImageFr._path
+                }`}
+                alt={
+                  props.locale === "en"
+                    ? pageData.scGcImages[0].scImageAltTextEn
+                    : pageData.scGcImages[0].scImageAltTextFr
+                }
                 width={575}
                 height={59}
               />
@@ -192,7 +200,7 @@ export default function ErrorPage(props) {
                       className="font-bold font-body mb-8"
                       data-testid="statuscode-en"
                     >
-                      {pageData.sclContentEn.json[2].content[0].value}{" "}
+                      {pageData.scContentEn.json[2].content[0].value}{" "}
                       {statusCode}
                     </p>
                   ) : (
@@ -208,19 +216,19 @@ export default function ErrorPage(props) {
                     <>
                       {/* Wrong URL English Section */}
                       <p className="font-body text-sm leading-30px mb-5">
-                        {pageData.sclContentEn.json[3].content[0].value}
+                        {pageData.scContentEn.json[3].content[0].value}
                       </p>
                       <ul>
                         <li className="flex">
                           <span className="error404-link" />
                           <p className="font-body text-sm leading-30px">
-                            {pageData.sclContentEn.json[4].content[0].value}
+                            {pageData.scContentEn.json[4].content[0].value}
                           </p>
                         </li>
                         <li className="flex">
                           <span className="error404-link" />
                           <p className="font-body text-sm leading-30px">
-                            {pageData.sclContentEn.json[5].content[0].value}
+                            {pageData.scContentEn.json[5].content[0].value}
                             <a
                               href={`mailto:${process.env.NEXT_PUBLIC_NOTIFY_REPORT_A_PROBLEM_EMAIL}`}
                               className="text-custom-blue-link underline"
@@ -230,19 +238,19 @@ export default function ErrorPage(props) {
                                   .NEXT_PUBLIC_NOTIFY_REPORT_A_PROBLEM_EMAIL
                               }
                             </a>{" "}
-                            {pageData.sclContentEn.json[6].content[0].value}
+                            {pageData.scContentEn.json[6].content[0].value}
                           </p>
                         </li>
                       </ul>
                       <p className="font-body text-sm leading-30px mt-5">
-                        {pageData.sclContentEn.json[7].content[0].value}
+                        {pageData.scContentEn.json[7].content[0].value}
                       </p>
                     </>
                   ) : errorMessage === "Expired URL" ? (
                     <>
                       {/* Expired URL English Section */}
                       <p className="font-body text-sm leading-30px mb-5">
-                        {pageData.sclContentEn.json[8].content[0].value}
+                        {pageData.scContentEn.json[8].content[0].value}
                       </p>
                       <ul>
                         <li className="flex">
@@ -250,20 +258,20 @@ export default function ErrorPage(props) {
                           <p className="font-body text-sm leading-30px">
                             <Link
                               href={
-                                pageData.sclContentEn.json[9].content[0].data
+                                pageData.scContentEn.json[9].content[0].data
                                   .href
                               }
                             >
                               <a className="underline hover:text-canada-footer-hover-font-blue text-canada-footer-font">
-                                {pageData.sclContentEn.json[9].content[0].value}
+                                {pageData.scContentEn.json[9].content[0].value}
                               </a>
                             </Link>{" "}
-                            {pageData.sclContentEn.json[9].content[1].value}
+                            {pageData.scContentEn.json[9].content[1].value}
                           </p>
                         </li>
                       </ul>
                       <p className="font-body text-sm leading-30px mt-5">
-                        {pageData.sclContentEn.json[7].content[0].value}
+                        {pageData.scContentEn.json[7].content[0].value}
                       </p>
                     </>
                   ) : (
@@ -271,14 +279,14 @@ export default function ErrorPage(props) {
                     <div className="flex">
                       <span className="error404-link" />
                       <p className="font-body text-sm leading-30px">
-                        {pageData.sclContentEn.json[10].content[0].value}
+                        {pageData.scContentEn.json[10].content[0].value}
                         <Link
                           href={
-                            pageData.sclContentEn.json[10].content[1].data.href
+                            pageData.scContentEn.json[10].content[1].data.href
                           }
                         >
                           <a className="underline hover:text-canada-footer-hover-font-blue text-canada-footer-font">
-                            {pageData.sclContentEn.json[10].content[1].value}
+                            {pageData.scContentEn.json[10].content[1].value}
                           </a>
                         </Link>
                       </p>
@@ -290,8 +298,12 @@ export default function ErrorPage(props) {
               <div className="flex items-center justify-center circle-background my-8 lg:mt-0 lightbulb-bg">
                 <span className="relative lightbulb">
                   <Image
-                    src={`https://www.canada.ca${pageData.sclImagelist[0]._path}`}
-                    alt="Cracked lightbulb"
+                    src={`https://www.canada.ca${
+                      props.locale === "en"
+                        ? pageData.scImageList[0].scImageEn._path
+                        : pageData.scImageList[0].scImageFr._path
+                    }`}
+                    alt=""
                     layout="fill"
                     objectFit="cover"
                   />
@@ -314,7 +326,7 @@ export default function ErrorPage(props) {
                       className="font-bold font-body mb-8"
                       data-testid="statuscode-fr"
                     >
-                      {pageData.sclContentFr.json[2].content[0].value}{" "}
+                      {pageData.scContentFr.json[2].content[0].value}{" "}
                       {statusCode}
                     </p>
                   ) : (
@@ -330,19 +342,19 @@ export default function ErrorPage(props) {
                     <>
                       {/* Wrong URL French Section */}
                       <p className="font-body text-sm leading-30px mb-5">
-                        {pageData.sclContentFr.json[3].content[0].value}
+                        {pageData.scContentFr.json[3].content[0].value}
                       </p>
                       <ul>
                         <li className="flex">
                           <span className="error404-link" />
                           <p className="font-body text-sm leading-30px">
-                            {pageData.sclContentFr.json[4].content[0].value}
+                            {pageData.scContentFr.json[4].content[0].value}
                           </p>
                         </li>
                         <li className="flex">
                           <span className="error404-link" />
                           <p className="font-body text-sm leading-30px">
-                            {pageData.sclContentFr.json[5].content[0].value}
+                            {pageData.scContentFr.json[5].content[0].value}
                             <a
                               href={`mailto:${process.env.NEXT_PUBLIC_NOTIFY_REPORT_A_PROBLEM_EMAIL}`}
                               className="text-custom-blue-link underline"
@@ -351,20 +363,20 @@ export default function ErrorPage(props) {
                                 process.env
                                   .NEXT_PUBLIC_NOTIFY_REPORT_A_PROBLEM_EMAIL
                               }
-                            </a>
-                            {pageData.sclContentFr.json[6].content[0].value}
+                            </a>{" "}
+                            {pageData.scContentFr.json[6].content[0].value}
                           </p>
                         </li>
                       </ul>
                       <p className="font-body text-sm leading-30px mt-5">
-                        {pageData.sclContentFr.json[7].content[0].value}
+                        {pageData.scContentFr.json[7].content[0].value}
                       </p>
                     </>
                   ) : errorMessageFr === "URL expirée" ? (
                     <>
                       {/* Expired URL French Section */}
                       <p className="font-body text-sm leading-30px mb-5">
-                        {pageData.sclContentFr.json[8].content[0].value}
+                        {pageData.scContentFr.json[8].content[0].value}
                       </p>
                       <ul>
                         <li className="flex">
@@ -372,20 +384,20 @@ export default function ErrorPage(props) {
                           <p className="font-body text-sm leading-30px">
                             <Link
                               href={
-                                pageData.sclContentFr.json[9].content[0].data
+                                pageData.scContentFr.json[9].content[0].data
                                   .href
                               }
                             >
                               <a className="underline hover:text-canada-footer-hover-font-blue text-canada-footer-font">
-                                {pageData.sclContentFr.json[9].content[0].value}
+                                {pageData.scContentFr.json[9].content[0].value}
                               </a>
                             </Link>{" "}
-                            {pageData.sclContentFr.json[9].content[1].value}
+                            {pageData.scContentFr.json[9].content[1].value}
                           </p>
                         </li>
                       </ul>
                       <p className="font-body text-sm leading-30px mt-5">
-                        {pageData.sclContentFr.json[7].content[0].value}
+                        {pageData.scContentFr.json[7].content[0].value}
                       </p>
                     </>
                   ) : (
@@ -393,14 +405,14 @@ export default function ErrorPage(props) {
                     <div className="flex">
                       <span className="error404-link" />
                       <p className="font-body text-sm leading-30px">
-                        {pageData.sclContentFr.json[10].content[0].value}
+                        {pageData.scContentFr.json[10].content[0].value}
                         <Link
                           href={
-                            pageData.sclContentFr.json[10].content[1].data.href
+                            pageData.scContentFr.json[10].content[1].data.href
                           }
                         >
                           <a className="underline hover:text-canada-footer-hover-font-blue text-canada-footer-font">
-                            {pageData.sclContentFr.json[10].content[1].value}
+                            {pageData.scContentFr.json[10].content[1].value}
                           </a>
                         </Link>
                       </p>
@@ -424,8 +436,16 @@ export default function ErrorPage(props) {
             />
             <span className="relative footer-logo">
               <Image
-                src={`https://www.canada.ca${pageData.sclGcImages[1]._path}`}
-                alt="Symbol of the Government of Canada"
+                src={`https://www.canada.ca${
+                  props.locale === "en"
+                    ? pageData.scGcImages[1].scImageEn._path
+                    : pageData.scGcImages[1].scImageFr._path
+                }`}
+                alt={
+                  props.locale === "en"
+                    ? pageData.scGcImages[1].scImageAltTextEn
+                    : pageData.scGcImages[1].scImageAltTextFr
+                }
                 layout="fill"
               />
             </span>

--- a/pages/home.js
+++ b/pages/home.js
@@ -161,6 +161,7 @@ export default function Home(props) {
             <span
               className="relative hidden lg:flex w-full mt-4 lg:ml-8"
               style={{ height: "316px", width: "452px", minWidth: "452px" }}
+              role="presentation"
             >
               <Image
                 src={`https://www.canada.ca${
@@ -168,29 +169,24 @@ export default function Home(props) {
                     ? pageData.scFragments[1].scImageEn._path
                     : pageData.scFragments[1].scImageFr._path
                 }`}
-                alt={
-                  props.locale === "en"
-                    ? pageData.scFragments[1].scImageAltTextEn
-                    : pageData.scFragments[1].scImageAltTextFr
-                }
+                alt=""
                 layout="fill"
                 objectFit="cover"
               />
             </span>
           </div>
           <div className="xl:w-2/3"></div>
-          <div className="grid lg:grid-cols-2 lg:gap-x-11 lg:gap-y-12">
+          <div
+            role="presentation"
+            className="grid lg:grid-cols-2 lg:gap-x-11 lg:gap-y-12"
+          >
             <Card
               imgSrc={`https://www.canada.ca${
                 props.locale === "en"
                   ? pageData.scFragments[3].scImageEn._path
                   : pageData.scFragments[3].scImageFr._path
               }`}
-              imgAlt={
-                props.locale === "en"
-                  ? pageData.scFragments[3].scImageAltTextEn
-                  : pageData.scFragments[3].scImageAltTextFr
-              }
+              imgAlt=""
               title={
                 props.locale === "en"
                   ? pageData.scFragments[3].scTitleEn
@@ -219,11 +215,7 @@ export default function Home(props) {
                   ? pageData.scFragments[4].scImageEn._path
                   : pageData.scFragments[4].scImageFr._path
               }`}
-              imgAlt={
-                props.locale === "en"
-                  ? pageData.scFragments[4].scImageAltTextEn
-                  : pageData.scFragments[4].scImageAltTextFr
-              }
+              imgAlt=""
               title={
                 props.locale === "en"
                   ? pageData.scFragments[4].scTitleEn

--- a/pages/home.js
+++ b/pages/home.js
@@ -176,10 +176,7 @@ export default function Home(props) {
             </span>
           </div>
           <div className="xl:w-2/3"></div>
-          <div
-            role="presentation"
-            className="grid lg:grid-cols-2 lg:gap-x-11 lg:gap-y-12"
-          >
+          <div className="grid lg:grid-cols-2 lg:gap-x-11 lg:gap-y-12">
             <Card
               imgSrc={`https://www.canada.ca${
                 props.locale === "en"

--- a/pages/notsupported.js
+++ b/pages/notsupported.js
@@ -43,8 +43,8 @@ export default function notSupported(props) {
 
           {/* Primary HTML Meta Tags */}
           <title data-gc-analytics-error="notSupported">
-            {pageData.sclContentEn.json[0].content[0].value} |{" "}
-            {pageData.sclContentFr.json[0].content[0].value}
+            {pageData.scContentEn.json[0].content[0].value} |{" "}
+            {pageData.scContentFr.json[0].content[0].value}
           </title>
           <meta
             name="description"
@@ -153,8 +153,16 @@ export default function notSupported(props) {
         <section className="xs:px-0 lg:mx-auto lg:px-6 container">
           <div className="pt-6">
             <Image
-              src={`https://www.canada.ca${pageData.sclGcImages[0]._path}`}
-              alt={"Symbol of the Government of Canada"}
+              src={`https://www.canada.ca${
+                props.locale === "en"
+                  ? pageData.scGcImages[0].scImageEn._path
+                  : pageData.scGcImages[0].scImageFr._path
+              }`}
+              alt={
+                props.locale === "en"
+                  ? pageData.scGcImages[0].scImageAltTextEn
+                  : pageData.scGcImages[0].scImageAltTextFr
+              }
               width={575}
               height={59}
             />
@@ -163,18 +171,22 @@ export default function notSupported(props) {
             <div>
               <div className="relative h-auto xl:w-96 xxl:w-400px lg:w-72 xl:h-400px lg:h-500px mb-8 lg:mb-0">
                 <h1 className="font-bold font-display mb-4">
-                  {pageData.sclContentEn.json[0].content[0].value}
+                  {pageData.scContentEn.json[0].content[0].value}
                 </h1>
                 <p className="font-body text-sm mb-4 leading-normal">
-                  {pageData.sclContentEn.json[1].content[0].value}
+                  {pageData.scContentEn.json[1].content[0].value}
                 </p>
               </div>
             </div>
             <div className="flex items-center justify-center circle-background my-8 lg:mt-0 lightbulb-bg">
               <span className="relative lightbulb">
                 <Image
-                  src={`https://www.canada.ca${pageData.sclImagelist[0]._path}`}
-                  alt="Cracked lightbulb"
+                  src={`https://www.canada.ca${
+                    props.locale === "en"
+                      ? pageData.scImageList[0].scImageEn._path
+                      : pageData.scImageList[0].scImageFr._path
+                  }`}
+                  alt=""
                   layout="fill"
                   objectFit="cover"
                 />
@@ -186,10 +198,10 @@ export default function notSupported(props) {
                 lang="fr"
               >
                 <h1 className="font-bold font-display mb-4">
-                  {pageData.sclContentFr.json[0].content[0].value}
+                  {pageData.scContentFr.json[0].content[0].value}
                 </h1>
                 <p className="font-body text-sm mb-4 leading-normal">
-                  {pageData.sclContentFr.json[1].content[0].value}
+                  {pageData.scContentFr.json[1].content[0].value}
                 </p>
               </div>
             </div>
@@ -199,8 +211,16 @@ export default function notSupported(props) {
           <div className="flex items-center justify-center">
             <figure className="mx-4">
               <Image
-                src={`https://www.canada.ca${pageData.sclImagelist[1]._path}`}
-                alt="chrome"
+                src={`https://www.canada.ca${
+                  props.locale === "en"
+                    ? pageData.scImageList[1].scImageEn._path
+                    : pageData.scImageList[1].scImageFr._path
+                }`}
+                alt={
+                  props.locale === "en"
+                    ? pageData.scImageList[1].scImageAltTextEn
+                    : pageData.scImageList[1].scImageAltTextFr
+                }
                 width="98"
                 height="98"
               />
@@ -210,8 +230,16 @@ export default function notSupported(props) {
             </figure>
             <figure className="mx-4">
               <Image
-                src={`https://www.canada.ca${pageData.sclImagelist[2]._path}`}
-                alt="safari"
+                src={`https://www.canada.ca${
+                  props.locale === "en"
+                    ? pageData.scImageList[2].scImageEn._path
+                    : pageData.scImageList[2].scImageFr._path
+                }`}
+                alt={
+                  props.locale === "en"
+                    ? pageData.scImageList[2].scImageAltTextEn
+                    : pageData.scImageList[2].scImageAltTextFr
+                }
                 width="98"
                 height="98"
               />
@@ -221,8 +249,16 @@ export default function notSupported(props) {
             </figure>
             <figure className="mx-4">
               <Image
-                src={`https://www.canada.ca${pageData.sclImagelist[3]._path}`}
-                alt="edge"
+                src={`https://www.canada.ca${
+                  props.locale === "en"
+                    ? pageData.scImageList[3].scImageEn._path
+                    : pageData.scImageList[3].scImageFr._path
+                }`}
+                alt={
+                  props.locale === "en"
+                    ? pageData.scImageList[3].scImageAltTextEn
+                    : pageData.scImageList[3].scImageAltTextFr
+                }
                 width="94"
                 height="94"
               />
@@ -232,8 +268,16 @@ export default function notSupported(props) {
             </figure>
             <figure className="mx-4">
               <Image
-                src={`https://www.canada.ca${pageData.sclImagelist[4]._path}`}
-                alt="firefox"
+                src={`https://www.canada.ca${
+                  props.locale === "en"
+                    ? pageData.scImageList[4].scImageEn._path
+                    : pageData.scImageList[4].scImageFr._path
+                }`}
+                alt={
+                  props.locale === "en"
+                    ? pageData.scImageList[4].scImageAltTextEn
+                    : pageData.scImageList[4].scImageAltTextFr
+                }
                 width="98"
                 height="98"
               />
@@ -247,7 +291,7 @@ export default function notSupported(props) {
           <div className="flex flex-col lg:flex-row justify-between items-center lg:items-start mt-8">
             <div className="relative h-auto xl:w-96 xxl:w-400px lg:w-72 mb-8 lg:mb-0">
               <p className="font-body text-sm mb-4 pb-5 leading-normal">
-                {pageData.sclCopyToClipboardLabelEn}
+                {pageData.scCopyToClipboardLabelEn}
               </p>
               <CopyToClipboard
                 buttonId="enClipboardButton"
@@ -261,18 +305,18 @@ export default function notSupported(props) {
                 aria_label="Copy the link below and paste in that browser."
               />
               <p className="font-body text-sm pt-6 leading-normal">
-                {pageData.sclBrowserDownloadLinksEn.json[0].content[0].value}
+                {pageData.scBrowserDownloadLinksEn.json[0].content[0].value}
               </p>
               <ul className="underline pt-4 font-body text-sm ieLinksList">
                 <li className="browser-item">
                   <a
                     href={
-                      pageData.sclBrowserDownloadLinksEn.json[1].content[0]
+                      pageData.scBrowserDownloadLinksEn.json[1].content[0]
                         .content[0].data.href
                     }
                   >
                     {
-                      pageData.sclBrowserDownloadLinksEn.json[1].content[0]
+                      pageData.scBrowserDownloadLinksEn.json[1].content[0]
                         .content[0].value
                     }
                   </a>
@@ -280,12 +324,12 @@ export default function notSupported(props) {
                 <li className="browser-item">
                   <a
                     href={
-                      pageData.sclBrowserDownloadLinksEn.json[1].content[1]
+                      pageData.scBrowserDownloadLinksEn.json[1].content[1]
                         .content[0].data.href
                     }
                   >
                     {
-                      pageData.sclBrowserDownloadLinksEn.json[1].content[1]
+                      pageData.scBrowserDownloadLinksEn.json[1].content[1]
                         .content[0].value
                     }
                   </a>
@@ -293,12 +337,12 @@ export default function notSupported(props) {
                 <li className="browser-item">
                   <a
                     href={
-                      pageData.sclBrowserDownloadLinksEn.json[1].content[2]
+                      pageData.scBrowserDownloadLinksEn.json[1].content[2]
                         .content[0].data.href
                     }
                   >
                     {
-                      pageData.sclBrowserDownloadLinksEn.json[1].content[2]
+                      pageData.scBrowserDownloadLinksEn.json[1].content[2]
                         .content[0].value
                     }
                   </a>
@@ -306,12 +350,12 @@ export default function notSupported(props) {
                 <li className="browser-item">
                   <a
                     href={
-                      pageData.sclBrowserDownloadLinksEn.json[1].content[3]
+                      pageData.scBrowserDownloadLinksEn.json[1].content[3]
                         .content[0].data.href
                     }
                   >
                     {
-                      pageData.sclBrowserDownloadLinksEn.json[1].content[3]
+                      pageData.scBrowserDownloadLinksEn.json[1].content[3]
                         .content[0].value
                     }
                   </a>
@@ -324,7 +368,7 @@ export default function notSupported(props) {
                 lang="fr"
               >
                 <p className="font-body text-sm mb-4 leading-normal">
-                  {pageData.sclCopyToClipboardLabelFr}
+                  {pageData.scCopyToClipboardLabelFr}
                 </p>
                 <CopyToClipboard
                   buttonText={frCopied ? "Copié!" : "Copier lien"}
@@ -338,18 +382,18 @@ export default function notSupported(props) {
                   aria_label="Vous n'avez qu'à copier le lien ci-dessous et le coller dans ce navigateur."
                 />
                 <p className="font-body text-sm pt-6 leading-normal">
-                  {pageData.sclBrowserDownloadLinksFr.json[0].content[0].value}
+                  {pageData.scBrowserDownloadLinksFr.json[0].content[0].value}
                 </p>
                 <ul className="underline pt-4 font-body text-sm ieLinksList">
                   <li className="browser-item">
                     <a
                       href={
-                        pageData.sclBrowserDownloadLinksFr.json[1].content[0]
+                        pageData.scBrowserDownloadLinksFr.json[1].content[0]
                           .content[0].data.href
                       }
                     >
                       {
-                        pageData.sclBrowserDownloadLinksFr.json[1].content[0]
+                        pageData.scBrowserDownloadLinksFr.json[1].content[0]
                           .content[0].value
                       }
                     </a>
@@ -357,12 +401,12 @@ export default function notSupported(props) {
                   <li className="browser-item">
                     <a
                       href={
-                        pageData.sclBrowserDownloadLinksFr.json[1].content[1]
+                        pageData.scBrowserDownloadLinksFr.json[1].content[1]
                           .content[0].data.href
                       }
                     >
                       {
-                        pageData.sclBrowserDownloadLinksFr.json[1].content[1]
+                        pageData.scBrowserDownloadLinksFr.json[1].content[1]
                           .content[0].value
                       }
                     </a>
@@ -370,12 +414,12 @@ export default function notSupported(props) {
                   <li className="browser-item">
                     <a
                       href={
-                        pageData.sclBrowserDownloadLinksFr.json[1].content[2]
+                        pageData.scBrowserDownloadLinksFr.json[1].content[2]
                           .content[0].data.href
                       }
                     >
                       {
-                        pageData.sclBrowserDownloadLinksFr.json[1].content[2]
+                        pageData.scBrowserDownloadLinksFr.json[1].content[2]
                           .content[0].value
                       }
                     </a>
@@ -383,12 +427,12 @@ export default function notSupported(props) {
                   <li className="browser-item">
                     <a
                       href={
-                        pageData.sclBrowserDownloadLinksFr.json[1].content[3]
+                        pageData.scBrowserDownloadLinksFr.json[1].content[3]
                           .content[0].data.href
                       }
                     >
                       {
-                        pageData.sclBrowserDownloadLinksFr.json[1].content[3]
+                        pageData.scBrowserDownloadLinksFr.json[1].content[3]
                           .content[0].value
                       }
                     </a>
@@ -410,8 +454,16 @@ export default function notSupported(props) {
             />
             <span className="relative footer-logo">
               <Image
-                src={`https://www.canada.ca${pageData.sclGcImages[1]._path}`}
-                alt="Symbol of the Government of Canada"
+                src={`https://www.canada.ca${
+                  props.locale === "en"
+                    ? pageData.scGcImages[1].scImageEn._path
+                    : pageData.scGcImages[1].scImageFr._path
+                }`}
+                alt={
+                  props.locale === "en"
+                    ? pageData.scGcImages[1].scImageAltTextEn
+                    : pageData.scGcImages[1].scImageAltTextFr
+                }
                 layout="fill"
               />
             </span>

--- a/pages/projects.js
+++ b/pages/projects.js
@@ -174,14 +174,11 @@ export default function Projects(props) {
             <span
               className="relative flex mt-4 lg:ml-8 lg:w-3/4"
               style={{ height: "274px", maxWidth: "453px" }}
+              role="presentation"
             >
               <Image
                 src={`https://www.canada.ca${pageData.scFragments[2].scImageEn._path}`}
-                alt={
-                  props.locale === "en"
-                    ? pageData.scFragments[2].scImageAltTextEn
-                    : pageData.scFragments[2].scImageAltTextFr
-                }
+                alt=""
                 layout="fill"
                 objectFit="cover"
               />
@@ -247,6 +244,7 @@ export default function Projects(props) {
                   dataCy={`${experiment.scId}`}
                   isExperiment
                   imgSrc="/placeholder.png"
+                  //Eventually this alt text will change as we provide unique images for each project
                   imgAlt="placeholder"
                   icon={`https://www.canada.ca${pageData.scFragments[3].scImageEn._path}`}
                   iconAlt={

--- a/pages/thankyou.js
+++ b/pages/thankyou.js
@@ -173,7 +173,7 @@ export default function Confirmation(props) {
             <span className="w-full flex justify-center lg:w-1/3">
               <Image
                 src="/circle-info.svg"
-                alt="info"
+                alt={t("informationIconAltText")}
                 width="160"
                 height="160"
               />
@@ -224,11 +224,16 @@ export default function Confirmation(props) {
               {resent ? t("emailResent") : t("resendEmail")}
             </ActionButton>
             {resent ? (
-              <div className="flex justify-start my-6">
+              <div
+                role="img"
+                aria-label={t("animatedCheckmarkAltText")}
+                className="flex justify-start my-6"
+              >
                 <Player
                   autoplay
                   keepLastFrame
                   src={animatedCheckmark}
+                  alt={t("animatedCheckmarkAltText")}
                   style={{
                     height: "248px",
                     width: "248px",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -347,5 +347,7 @@
   "confirmEmail": "Confirm Email address",
   "emailError": "Emails must match",
   "requiredInfo": "Indicates required information",
-  "externalLink": "external link"
+  "externalLink": "external link",
+  "animatedCheckmarkAltText": "An animated checkmark indicating a successful submission",
+  "informationIconAltText": "An icon indicating important information or instructions"
 }

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -337,5 +337,7 @@
   "confirmEmail": "Confirmer l'adresse courriel",
   "emailError": "les courriels doivent être identiques",
   "requiredInfo": "Indique que les renseignements sont requis",
-  "externalLink": "lien externe"
+  "externalLink": "lien externe",
+  "animatedCheckmarkAltText": "Une coche animée indiquant une soumission réussie",
+  "informationIconAltText": "Une icône indiquant des informations ou des instructions importantes"
 }


### PR DESCRIPTION
# Description

[63994 - DEV: Verify alt text for all images follows best practices](https://dev.azure.com/VP-BD/DECD/_boards/board/t/Service%20Canada%20Labs/Stories%20and%20Activities/?workitem=63994)

Pretty meaty PR that takes care of a couple things. Firstly, I've updated alt text across the site where necessary so it follows best practices. Most of this was done directly in AEM however I have removed alt text (ie `alt=""`) on images that are purely decorative manually. Since the `/notsupported` page has browser icons which needed updated alt text, I overhauled the error page model in AEM to leverage the SCLabs-Image model which has fields for alt text and so the field names followed our agreed upon naming convention (`scSomethingSomething` vs `sclSomethingSomething`). Doing this required that I update all the error pages so they are up to date with the new model. 

Lastly, I've updated the `/thankyou` page to use the animated checkmark Lottie file instead of the static checkmark SVG since it made no sense that we had two separate images for checkmarks. I've also ensured that the animated checkmark has descriptive text that is announced to the screen reader. 


## Test Instructions

1. Pull in branch
2. Type `yarn dev`
3. Navigate through all the pages and ensure images that aren't purely decorative have alt text that follows best practices (based on the link provided in the task description)

## Checklist

- [x] Strings use placeholders for translation (No hard coded strings)
- [x] Unit tests have been added/updated
- [x] Update CHANGELOG

## Product and Sprint Backlog

[Azure](https://dev.azure.com/VP-BD/DECD/_boards/board/t/Service%20Canada%20Labs/Stories%20and%20Activities)
