### PR TITLE
top of page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Remove Test Site banner on the projects page
 - Updated alt text across site based on best practices
 - Updated `/thankyou` page to use animated checkmark for consistency
+- Updated Footer component to add To top of page button in mobile view
 
 ## Fixed
 

--- a/components/organisms/Footer.js
+++ b/components/organisms/Footer.js
@@ -1,5 +1,6 @@
 import PropTypes from "prop-types";
 import Image from "next/image";
+import { ActionButton } from "../atoms/ActionButton";
 
 /**
  * footer element for all pages
@@ -67,8 +68,16 @@ export function Footer(props) {
               })}
             </ul>
           </div>
-          <div>
-            <span className="flex relative justify-end float-right footer-logo">
+          <div className="flex items-center justify-between">
+            <ActionButton
+              id="TopOfPageButton"
+              href="#"
+              custom="text-left w-32 flex flex-col lg:hidden"
+              text={props.topOfPage}
+              icon="icon-up-caret"
+              iconEnd
+            />
+            <span className="flex relative footer-logo">
               <Image
                 src={props.footerLogoImage}
                 alt={props.footerLogoAltText}

--- a/components/organisms/Layout.js
+++ b/components/organisms/Layout.js
@@ -202,6 +202,7 @@ export const Layout = ({
               footerBoxLinkText: t("footerOpenGov"),
             },
           ]}
+          topOfPage={t("topOfPage")}
         />
       </footer>
     </div>

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -349,5 +349,6 @@
   "requiredInfo": "Indicates required information",
   "externalLink": "external link",
   "animatedCheckmarkAltText": "An animated checkmark indicating a successful submission",
-  "informationIconAltText": "An icon indicating important information or instructions"
+  "informationIconAltText": "An icon indicating important information or instructions",
+  "topOfPage": "Top of page"
 }

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -339,5 +339,6 @@
   "requiredInfo": "Indique que les renseignements sont requis",
   "externalLink": "lien externe",
   "animatedCheckmarkAltText": "Une coche animée indiquant une soumission réussie",
-  "informationIconAltText": "Une icône indiquant des informations ou des instructions importantes"
+  "informationIconAltText": "Une icône indiquant des informations ou des instructions importantes",
+  "topOfPage": "Haut de la page"
 }


### PR DESCRIPTION
# Description

[Add "top of page" link to footer](https://dev.azure.com/VP-BD/DECD/_sprints/taskboard/Service%20Canada%20Labs/DECD/Service%20Canada%20Labs/PlanningSprint-1?workitem=65653)

The purpose of this pr is to add `Top of page` link to all the pages in mobile view. Currently, only the error pages have the `Top of page` link. To achieve this, simply add the link to the Footer component, it will appear on all the pages.

Description from the ticket: 

On Canada.ca, if you shrink the window or visit the site on a mobile device, you will see a "Top of Page" link at the bottom of the page with a caret icon. Currently, we have this hard-coded on the error pages, but it isn't present on any of our other pages. We have a Footer component that is being used across all of our pages (except the error pages since they're different) which we'll need to add this anchor link to.

## Acceptance Criteria

All pages should have `Top to page` link in mobile view

## Test Instructions

Adjust the screen resolution to mobile, each page should have `Top of page` link at the bottom of the page.

## Checklist

- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated
- [x] Update CHANGELOG
