### PR TITLE
Updated sign up banner using FontAwesome icon

### DIFF
--- a/components/molecules/CallToAction.js
+++ b/components/molecules/CallToAction.js
@@ -2,6 +2,8 @@ import PropTypes from "prop-types";
 import { ActionButton } from "../atoms/ActionButton";
 import Link from "next/link";
 import { useTranslation } from "next-i18next";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faUser } from "@fortawesome/free-regular-svg-icons";
 
 /**
  * A section that will have a title, small description, and a link to some action we want to user to make
@@ -9,58 +11,72 @@ import { useTranslation } from "next-i18next";
 export function CallToAction(props) {
   const { t } = useTranslation("common");
   return (
-    <aside>
-      <div
-        className={`${
-          props.feedbackActive ? "bg-custom-blue-blue" : "bg-circle-color"
-        } text-white`}
-      >
-        <div className="layout-container pb-10 pt-10 text-sm md:text-base">
-          <h2>{props.title}</h2>
-          <div className="flex flex-col lg:grid lg:grid-cols-2 lg:gap-24 gap-5">
-            {props.description ? (
-              <p className="whitespace-pre-line">{props.description}</p>
-            ) : (
-              <div
-                className="whitespace-pre-line"
-                dangerouslySetInnerHTML={{ __html: props.html }}
+    <div className="bg-[#ebf2fc] text-[#333]">
+      <div className="layout-container pb-10 pt-10 text-sm md:text-base">
+        <div>
+          <div className="flex flex-col">
+            <div className="flex -my-2">
+              <FontAwesomeIcon
+                icon={faUser}
+                color={"#1d5b90"}
+                fixedWidth
+                size="xl"
+                className="pt-2"
               />
-            )}
-            <div>
-              <p className="flex mb-4 text-center">
-                <ActionButton
-                  id="become-a-participant-btn"
-                  custom={`py-2 ${
-                    props.feedbackActive
-                      ? "text-sm md:text-base px-24 lg:ml-8"
-                      : "px-4"
-                  } rounded text-custom-blue-projects-link bg-details-button-gray hover:bg-gray-300 border border-custom-blue-blue active:bg-custom-blue-dark active:border-2 active:border-white hover:ring-2 hover:ring-white`}
-                  className=""
-                  href={props.href}
-                  text={props.hrefText}
-                  expandIcon={
-                    props.feedbackActive ? (
-                      <img className="px-2" src="/feedback-icon.svg" alt="" />
-                    ) : undefined
-                  }
-                  onClick={props.feedbackActive ? props.clicked : undefined}
-                  ariaExpanded={props.ariaExpanded}
-                />
-              </p>
-              <p>
-                {props.feedbackActive ? undefined : (
-                  <Link href={t("privacyRedirect")} locale={props.lang}>
-                    <a className="text-sm underline flex xl:inline lg:mr-10">
-                      {t("privacyLinkText")}
-                    </a>
-                  </Link>
-                )}
-              </p>
+              <h2 className="text-h3 lg:text-h1 ml-2">{props.title}</h2>
             </div>
+            <aside className="pt-3 border-l-2 ml-2 lg:ml-3.5 border-custom-blue-blue xl:w-3/4">
+              {props.description ? (
+                <div>
+                  <p className="text-base lg:text-p ml-6 pb-3 whitespace-pre-line">
+                    {props.description}
+                  </p>
+                  <p className="text-base lg:text-p ml-6 pb-3 whitespace-pre-line">
+                    {props.disclaimer}
+                  </p>
+                </div>
+              ) : (
+                <div
+                  className="text-base lg:text-p ml-6 pb-3 whitespace-pre-line"
+                  dangerouslySetInnerHTML={{ __html: props.html }}
+                />
+              )}
+              <div className="ml-6">
+                <p className="flex mb-4 text-center">
+                  <ActionButton
+                    id="become-a-participant-btn"
+                    custom={`py-1.5 px-3 rounded text-white text-base lg:text-p font-display bg-custom-blue-dark hover:bg-custom-blue-light border border-custom-blue-darker active:bg-custom-blue-darker hover:ring-2 hover:ring-white`}
+                    className=""
+                    href={props.href}
+                    text={props.hrefText}
+                    expandIcon={
+                      props.feedbackActive ? (
+                        <img
+                          className="px-2"
+                          src="/feedback-icon-white.svg"
+                          alt=""
+                        />
+                      ) : undefined
+                    }
+                    onClick={props.feedbackActive ? props.clicked : undefined}
+                    ariaExpanded={props.ariaExpanded}
+                  />
+                </p>
+                <p>
+                  {props.feedbackActive ? undefined : (
+                    <Link href={t("privacyRedirect")} locale={props.lang}>
+                      <a className="text-base lg:text-p underline flex xl:inline lg:mr-10">
+                        {t("privacyLinkText")}
+                      </a>
+                    </Link>
+                  )}
+                </p>
+              </div>
+            </aside>
           </div>
         </div>
       </div>
-    </aside>
+    </div>
   );
 }
 
@@ -74,6 +90,10 @@ CallToAction.propTypes = {
    * a short description about what the call to action is about - string format
    */
   description: PropTypes.string,
+  /**
+   * a short disclaimer after the description - ie. for a sign up banner an explanation that participation is voluntary
+   */
+  disclaimer: PropTypes.string,
 
   /**
    * a short description about what the call to action is about - html format

--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "private": true,
   "dependencies": {
     "@apollo/client": "^3.6.8",
+    "@fortawesome/fontawesome-svg-core": "^6.1.2",
+    "@fortawesome/free-regular-svg-icons": "^6.1.2",
+    "@fortawesome/free-solid-svg-icons": "^6.1.2",
+    "@fortawesome/react-fontawesome": "^0.2.0",
     "@lottiefiles/react-lottie-player": "^3.4.7",
     "@storybook/addons": "^6.5.0",
     "@storybook/client-api": "^6.5.0",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -4,6 +4,10 @@ import "../styles/globals.css";
 import "../styles/forms.css";
 import "../styles/menu.css";
 import Head from "next/head";
+import { config } from "@fortawesome/fontawesome-svg-core";
+import "@fortawesome/fontawesome-svg-core/styles.css";
+
+config.autoAddCss = false;
 
 if (process.env.NEXT_PUBLIC_API_MOCKING === "enabled") {
   require("../mocks");

--- a/pages/projects.js
+++ b/pages/projects.js
@@ -5,6 +5,7 @@ import { useTranslation } from "next-i18next";
 import { Layout } from "../components/organisms/Layout";
 import { Card } from "../components/molecules/Card";
 import { Filter } from "../components/molecules/Filter";
+import { CallToAction } from "../components/molecules/CallToAction";
 import queryGraphQL from "../graphql/client";
 import getAllProjects from "../graphql/queries/projectQuery.graphql";
 import getProjectsPage from "../graphql/queries/projectsPageQuery.graphql";
@@ -258,6 +259,14 @@ export default function Projects(props) {
             ))}
           </ul>
         </section>
+        <CallToAction
+          title={t("signupHomeButton")}
+          description={t("signupBannerDescription")}
+          disclaimer={t("signupBannerDisclaimer")}
+          lang={props.locale}
+          href="/signup-info"
+          hrefText={t("signupBannerBtnText")}
+        />
       </Layout>
       {props.adobeAnalyticsUrl ? (
         <script type="text/javascript">_satellite.pageBottom()</script>

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -350,5 +350,8 @@
   "externalLink": "external link",
   "animatedCheckmarkAltText": "An animated checkmark indicating a successful submission",
   "informationIconAltText": "An icon indicating important information or instructions",
-  "topOfPage": "Top of page"
+  "topOfPage": "Top of page",
+  "signupBannerBtnText": "Sign up for research session invites",
+  "signupBannerDescription": "You’re invited to fill out quick surveys or take part in research sessions to make Service Canada better for everyone. Your feedback helps us make our services simple and easy to use.",
+  "signupBannerDisclaimer": "Your participation will not affect your access to government services. Participation is voluntary and you can opt out at any time."
 }

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -340,5 +340,8 @@
   "externalLink": "lien externe",
   "animatedCheckmarkAltText": "Une coche animée indiquant une soumission réussie",
   "informationIconAltText": "Une icône indiquant des informations ou des instructions importantes",
-  "topOfPage": "Haut de la page"
+  "topOfPage": "Haut de la page",
+  "signupBannerBtnText": "Inscrivez-vous pour recevoir les invitations aux sessions de recherche",
+  "signupBannerDescription": "Nous vous invitons à remplir des enquêtes rapides ou à participer à des séances de recherche afin d'améliorer Service Canada pour tous. Vos commentaires nous aident à rendre nos services simples et faciles à utiliser.",
+  "signupBannerDisclaimer": "Votre participation n'affectera pas votre accès aux services gouvernementaux. La participation est volontaire et vous pouvez vous retirer à tout moment."
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1329,6 +1329,39 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
 
+"@fortawesome/fontawesome-common-types@6.1.2":
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.1.2.tgz#c1095b1bbabf19f37f9ff0719db38d92a410bcfe"
+  integrity sha512-wBaAPGz1Awxg05e0PBRkDRuTsy4B3dpBm+zreTTyd9TH4uUM27cAL4xWyWR0rLJCrRwzVsQ4hF3FvM6rqydKPA==
+
+"@fortawesome/fontawesome-svg-core@^6.1.2":
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.1.2.tgz#11e2e8583a7dea75d734e4d0e53d91c63fae7511"
+  integrity sha512-853G/Htp0BOdXnPoeCPTjFrVwyrJHpe8MhjB/DYE9XjwhnNDfuBCd3aKc2YUYbEfHEcBws4UAA0kA9dymZKGjA==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "6.1.2"
+
+"@fortawesome/free-regular-svg-icons@^6.1.2":
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.1.2.tgz#9f04009098addcc11d0d185126f058ed042c3099"
+  integrity sha512-xR4hA+tAwsaTHGfb+25H1gVU/aJ0Rzu+xIUfnyrhaL13yNQ7TWiI2RvzniAaB+VGHDU2a+Pk96Ve+pkN3/+TTQ==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "6.1.2"
+
+"@fortawesome/free-solid-svg-icons@^6.1.2":
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.1.2.tgz#491d668b8a6603698d0ce1ac620f66fd22b74c84"
+  integrity sha512-lTgZz+cMpzjkHmCwOG3E1ilUZrnINYdqMmrkv30EC3XbRsGlbIOL8H9LaNp5SV4g0pNJDfQ4EdTWWaMvdwyLiQ==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "6.1.2"
+
+"@fortawesome/react-fontawesome@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.0.tgz#d90dd8a9211830b4e3c08e94b63a0ba7291ddcf4"
+  integrity sha512-uHg75Rb/XORTtVt7OS9WoK8uM276Ufi7gCzshVWkUJbHhh3svsUUeqXerrM96Wm7fRiDzfKRwSoahhMIkGAYHw==
+  dependencies:
+    prop-types "^15.8.1"
+
 "@gar/promisify@^1.0.1":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"


### PR DESCRIPTION
# Description

[64042 - DEV: Update "sign up" banner (front end design)](https://dev.azure.com/VP-BD/DECD/_sprints/taskboard/Service%20Canada%20Labs/DECD/Service%20Canada%20Labs/PlanningSprint-1?workitem=64042)

In this PR, I've added Font Awesome to our app in order for the sign up banner to match the design in Figma. This will also be used for the contextual alert on the `/projects` page. 

Since the designs on Figma are purely for Desktop, I've gone ahead and scaled the text down for mobile as I saw fit, input here would be appreciated.

Since we currently don't know what exactly is to happen with the feedback component, I haven't touched the related code in the `CallToAction` component (aside from padding and text size just so it doesn't look like garbage). If it's decided that we will be keeping it/repurposing it, we can then revisit this and adjust the `CallToAction` component. Currently though, there are no designs. If you're curious though, you can check out `/projects/digital-centre` to see what it currently looks like with the new design.


## Test Instructions

1. Pull in branch
2. Type `yarn dev`
3. Navigate to `/projects`
4. Scroll to the bottom of the page to see the new sign up banner
5. Open developer tools and play around with different resolutions to make sure it shows up properly/scales well

## Notes

- A fragment holding the sign up banner text will eventually need to be created within AEM if it hasn't already been created (it may already be created using the `feature` model and if that's the case we would just have to add that fragment to our page fragment)

## Checklist

- [x] Strings use placeholders for translation (No hard coded strings)
- [x] Unit tests have been added/updated
- [x] Update CHANGELOG

## Product and Sprint Backlog

[Jira](https://jira-dev.bdm-dev.dts-stn.com/secure/RapidBoard.jspa?rapidView=96&projectKey=SCL)
