### PR TITLE
Updated card component and GraphQL page queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Fixed CallToAction redirect on `/projects` page so that it links to `/signup-info` instead of `/signup`
 - Fixed email and close button focus on the feedback widget
 - Moved content security policy entries from `_document` to `next.config.js` so there is a single source of truth (and also added a few other security headers)
+- Fixed issue with our `Next/Image` implementation within our `Card` component and with the image on the `/projects` page
 
 ## [v1.1.3] - 2021-10-27
 

--- a/__mocks__/mockStore.js
+++ b/__mocks__/mockStore.js
@@ -867,7 +867,7 @@ export const homePageData = {
         scKeywordsFr: "services numériques",
         scContentType: null,
         scOwner: null,
-        scDateModifiedOverwrite: null,
+        scDateModifiedOverwrite: "2022-06-27",
         scAudience: null,
         scRegion: null,
         scSocialMediaImageEn: null,
@@ -881,8 +881,6 @@ export const homePageData = {
             _path:
               "/content/dam/decd-endc/content-fragments/alpha/dev/sclabs/components/content/home---main-content",
             scId: "HOME-MAIN-CONTENT",
-            scTitleEn: null,
-            scTitleFr: null,
             scContentEn: {
               json: [
                 {
@@ -983,18 +981,22 @@ export const homePageData = {
           },
           {
             scId: "HOMEPAGE-MAIN-IMAGE",
-            scTitleEn: null,
-            scTitleFr: null,
             scImageEn: {
-              _path: "/content/dam/decd-endc/images/sclabs/homePage_image1.png",
+              _publishUrl:
+                "https://www.canada.ca/content/dam/decd-endc/images/sclabs/homePage_image1.png",
+              width: 452,
+              height: 316,
             },
             scImageFr: {
-              _path: "/content/dam/decd-endc/images/sclabs/homePage_image1.png",
+              _publishUrl:
+                "https://www.canada.ca/content/dam/decd-endc/images/sclabs/homePage_image1.png",
+              width: 452,
+              height: 316,
             },
             scImageMobileEn: null,
             scImageMobileFr: null,
-            scImageAltTextEn: null,
-            scImageAltTextFr: null,
+            scImageAltTextEn: "Placeholder",
+            scImageAltTextFr: "Placeholder(FR)",
             scImageCaptionEn: null,
             scImageCaptionFr: null,
           },
@@ -1039,13 +1041,19 @@ export const homePageData = {
               ],
             },
             scImageEn: {
-              _path: "/content/dam/decd-endc/images/sclabs/homePage_image2.png",
+              _publishUrl:
+                "https://www.canada.ca/content/dam/decd-endc/images/sclabs/homePage_image2.png",
+              width: 547,
+              height: 326,
             },
             scImageFr: {
-              _path: "/content/dam/decd-endc/images/sclabs/homePage_image2.png",
+              _publishUrl:
+                "https://www.canada.ca/content/dam/decd-endc/images/sclabs/homePage_image2.png",
+              width: 547,
+              height: 326,
             },
-            scImageAltTextEn: null,
-            scImageAltTextFr: null,
+            scImageAltTextEn: "Placeholder",
+            scImageAltTextFr: "Placeholder(FR)",
             scLabsButton: [
               {
                 scId: "sclabs-homepage-button-projects",
@@ -1112,13 +1120,19 @@ export const homePageData = {
               ],
             },
             scImageEn: {
-              _path: "/content/dam/decd-endc/images/sclabs/homePage_image3.png",
+              _publishUrl:
+                "https://www.canada.ca/content/dam/decd-endc/images/sclabs/homePage_image3.png",
+              width: 549,
+              height: 326,
             },
             scImageFr: {
-              _path: "/content/dam/decd-endc/images/sclabs/homePage_image3.png",
+              _publishUrl:
+                "https://www.canada.ca/content/dam/decd-endc/images/sclabs/homePage_image3.png",
+              width: 549,
+              height: 326,
             },
-            scImageAltTextEn: null,
-            scImageAltTextFr: null,
+            scImageAltTextEn: "Placeholder",
+            scImageAltTextFr: "Placeholder(FR)",
             scLabsButton: [
               {
                 scId: "sclabs-homepage-button-signup",

--- a/components/molecules/Card.js
+++ b/components/molecules/Card.js
@@ -28,18 +28,13 @@ export const Card = (props) => {
         maxWidth: "560px",
       }}
     >
-      <div
-        className="mb-4"
-        style={{
-          height: `${props.isExperiment ? "290px" : "326px"}`,
-          position: "relative",
-        }}
-      >
+      <div className="mb-4">
         <Image
           src={props.imgSrc}
           alt={props.imgAlt}
-          layout="fill"
-          objectFit="cover"
+          height={props.imgHeight}
+          width={props.imgWidth}
+          layout="responsive"
           priority={props.priority}
         />
       </div>

--- a/components/molecules/Card.stories.js
+++ b/components/molecules/Card.stories.js
@@ -16,6 +16,8 @@ Primary.args = {
   description: "Description",
   imgSrc: "/placeholderImg",
   imgAlt: "placeholderAlt",
+  imgHeight: 500,
+  imgWidth: 500,
 };
 
 Experiment.args = {
@@ -27,4 +29,6 @@ Experiment.args = {
   href: "/some/link",
   imgSrc: "/placeholderImg",
   imgAlt: "placeholderAlt",
+  imgHeight: 500,
+  imgWidth: 500,
 };

--- a/graphql/queries/homePageQuery.graphql
+++ b/graphql/queries/homePageQuery.graphql
@@ -26,18 +26,22 @@ query getHomePage {
       scRegion
       scSocialMediaImageEn {
         ... on ImageRef {
-          _path
+          _publishUrl
+          width
+          height
         }
         ... on DocumentRef {
-          _path
+          _publishUrl
         }
       }
       scSocialMediaImageFr {
         ... on ImageRef {
-          _path
+          _publishUrl
+          width
+          height
         }
         ... on DocumentRef {
-          _path
+          _publishUrl
         }
       }
       scSocialMediaImageAltTextEn
@@ -59,34 +63,42 @@ query getHomePage {
           scId
           scImageEn {
             ... on ImageRef {
-              _path
+              _publishUrl
+              width
+              height
             }
             ... on DocumentRef {
-              _path
+              _publishUrl
             }
           }
           scImageFr {
             ... on ImageRef {
-              _path
+              _publishUrl
+              width
+              height
             }
             ... on DocumentRef {
-              _path
+              _publishUrl
             }
           }
           scImageMobileEn {
             ... on ImageRef {
-              _path
+              _publishUrl
+              width
+              height
             }
             ... on DocumentRef {
-              _path
+              _publishUrl
             }
           }
           scImageMobileFr {
             ... on ImageRef {
-              _path
+              _publishUrl
+              width
+              height
             }
             ... on DocumentRef {
-              _path
+              _publishUrl
             }
           }
           scImageAltTextEn
@@ -114,18 +126,22 @@ query getHomePage {
           }
           scImageEn {
             ... on ImageRef {
-              _path
+              _publishUrl
+              width
+              height
             }
             ... on DocumentRef {
-              _path
+              _publishUrl
             }
           }
           scImageFr {
             ... on ImageRef {
-              _path
+              _publishUrl
+              width
+              height
             }
             ... on DocumentRef {
-              _path
+              _publishUrl
             }
           }
           scImageAltTextEn

--- a/graphql/queries/projectsPageQuery.graphql
+++ b/graphql/queries/projectsPageQuery.graphql
@@ -26,18 +26,18 @@ query getProjectsPage {
       scRegion
       scSocialMediaImageEn {
         ... on ImageRef {
-          _path
+          _publishUrl
         }
         ... on DocumentRef {
-          _path
+          _publishUrl
         }
       }
       scSocialMediaImageFr {
         ... on ImageRef {
-          _path
+          _publishUrl
         }
         ... on DocumentRef {
-          _path
+          _publishUrl
         }
       }
       scSocialMediaImageAltTextEn
@@ -59,34 +59,42 @@ query getProjectsPage {
           scId
           scImageEn {
             ... on ImageRef {
-              _path
+              _publishUrl
+              width
+              height
             }
             ... on DocumentRef {
-              _path
+              _publishUrl
             }
           }
           scImageFr {
             ... on ImageRef {
-              _path
+              _publishUrl
+              width
+              height
             }
             ... on DocumentRef {
-              _path
+              _publishUrl
             }
           }
           scImageMobileEn {
             ... on ImageRef {
               _path
+              width
+              height
             }
             ... on DocumentRef {
-              _path
+              _publishUrl
             }
           }
           scImageMobileFr {
             ... on ImageRef {
               _path
+              width
+              height
             }
             ... on DocumentRef {
-              _path
+              _publishUrl
             }
           }
           scImageAltTextEn
@@ -114,18 +122,22 @@ query getProjectsPage {
           }
           scImageEn {
             ... on ImageRef {
-              _path
+              _publishUrl
+              width
+              height
             }
             ... on DocumentRef {
-              _path
+              _publishUrl
             }
           }
           scImageFr {
             ... on ImageRef {
-              _path
+              _publishUrl
+              width
+              height
             }
             ... on DocumentRef {
-              _path
+              _publishUrl
             }
           }
           scImageAltTextEn

--- a/pages/home.js
+++ b/pages/home.js
@@ -164,11 +164,11 @@ export default function Home(props) {
               role="presentation"
             >
               <Image
-                src={`https://www.canada.ca${
+                src={
                   props.locale === "en"
-                    ? pageData.scFragments[1].scImageEn._path
-                    : pageData.scFragments[1].scImageFr._path
-                }`}
+                    ? pageData.scFragments[1].scImageEn._publishUrl
+                    : pageData.scFragments[1].scImageFr._publishUrl
+                }
                 alt=""
                 layout="fill"
                 objectFit="cover"
@@ -178,11 +178,21 @@ export default function Home(props) {
           <div className="xl:w-2/3"></div>
           <div className="grid lg:grid-cols-2 lg:gap-x-11 lg:gap-y-12">
             <Card
-              imgSrc={`https://www.canada.ca${
+              imgSrc={
                 props.locale === "en"
-                  ? pageData.scFragments[3].scImageEn._path
-                  : pageData.scFragments[3].scImageFr._path
-              }`}
+                  ? pageData.scFragments[3].scImageEn._publishUrl
+                  : pageData.scFragments[3].scImageFr._publishUrl
+              }
+              imgHeight={
+                props.locale === "en"
+                  ? pageData.scFragments[3].scImageEn.height
+                  : pageData.scFragments[3].scImageFr.height
+              }
+              imgWidth={
+                props.locale === "en"
+                  ? pageData.scFragments[3].scImageEn.width
+                  : pageData.scFragments[3].scImageFr.width
+              }
               imgAlt=""
               title={
                 props.locale === "en"
@@ -207,12 +217,22 @@ export default function Home(props) {
               btnId={pageData.scFragments[3].scLabsButton[0].scId}
             />
             <Card
-              imgSrc={`https://www.canada.ca${
+              imgSrc={
                 props.locale === "en"
-                  ? pageData.scFragments[4].scImageEn._path
-                  : pageData.scFragments[4].scImageFr._path
-              }`}
+                  ? pageData.scFragments[4].scImageEn._publishUrl
+                  : pageData.scFragments[4].scImageFr._publishUrl
+              }
               imgAlt=""
+              imgHeight={
+                props.locale === "en"
+                  ? pageData.scFragments[4].scImageEn.height
+                  : pageData.scFragments[4].scImageFr.height
+              }
+              imgWidth={
+                props.locale === "en"
+                  ? pageData.scFragments[4].scImageEn.width
+                  : pageData.scFragments[4].scImageFr.width
+              }
               title={
                 props.locale === "en"
                   ? pageData.scFragments[4].scTitleEn

--- a/pages/projects.js
+++ b/pages/projects.js
@@ -18,6 +18,7 @@ export default function Projects(props) {
   const [filteredExperiments, setFilteredExperiments] = useState(
     props.experimentData.items
   );
+  console.log(pageData.scFragments[3].scImageEn._publishUrl);
 
   // get the filters from the data
   const filters = props.filters.map((value) => {
@@ -172,15 +173,24 @@ export default function Projects(props) {
               </p>
             </span>
             <span
-              className="relative flex mt-4 lg:ml-8 lg:w-3/4"
-              style={{ height: "274px", maxWidth: "453px" }}
+              className="block mt-4 lg:ml-8 lg:w-3/4"
+              style={{ maxWidth: "453px" }}
               role="presentation"
             >
               <Image
-                src={`https://www.canada.ca${pageData.scFragments[2].scImageEn._path}`}
+                src={pageData.scFragments[2].scImageEn._publishUrl}
                 alt=""
-                layout="fill"
-                objectFit="cover"
+                height={
+                  props.locale === "en"
+                    ? pageData.scFragments[2].scImageEn.height
+                    : pageData.scFragments[2].scImageFr.height
+                }
+                width={
+                  props.locale === "en"
+                    ? pageData.scFragments[2].scImageEn.width
+                    : pageData.scFragments[2].scImageFr.width
+                }
+                layout="responsive"
               />
             </span>
           </div>
@@ -246,7 +256,10 @@ export default function Projects(props) {
                   imgSrc="/placeholder.png"
                   //Eventually this alt text will change as we provide unique images for each project
                   imgAlt="placeholder"
-                  icon={`https://www.canada.ca${pageData.scFragments[3].scImageEn._path}`}
+                  //Manually entered width and height for now, will eventually take these values from AEM image data
+                  imgHeight={290}
+                  imgWidth={547}
+                  icon={pageData.scFragments[3].scImageEn._publishUrl}
                   iconAlt={
                     props.locale === "en"
                       ? pageData.scFragments[3].scImageAltTextEn

--- a/pages/projects.js
+++ b/pages/projects.js
@@ -18,7 +18,6 @@ export default function Projects(props) {
   const [filteredExperiments, setFilteredExperiments] = useState(
     props.experimentData.items
   );
-  console.log(pageData.scFragments[3].scImageEn._publishUrl);
 
   // get the filters from the data
   const filters = props.filters.map((value) => {


### PR DESCRIPTION
# Description

This PR addresses a concern that Celeste had with the images within our Card component (specifically the blue paper plane one). This issue was also present on the project page and has to do with how we set up our pages to use `Next/Image`. Previously, we were using `layout="fill"` and `objectFit="cover"` to maintain aspect ratio when scaling through different viewport sizes. This worked okay until you get down to a mobile resolution and then the sides of the image get cut off.

The solution here was to switch to `layout="responsive"` and provide the length and width of the image straight from AEM data (since Next/Image requires you to explicitly provide this if you are not using `layout="fill"`) for proper scaling.

That said, I've made a couple changes to the queries themselves, notably adding `height` and `width` to the image fields and changing `_path` to `_publishUrl` which is cleaner. Note that once we remove the placeholder images from the project cards and supply them with images from AEM, we will need to also grab the height and width for those images from AEM.

One thing of note is that while AEM supplies the height and width of images when querying using `... on ImageRef`, there is no equivalent for `... on DocumentRef`, so this way of obtaining the dimensions of the image ONLY works if we are not using an SVG.


## Test Instructions

1. Pull in branch
2. Type `yarn dev`
3. Navigate to both `/home` and `/projects`
4. Open developer tools to view the page in different viewports or resize your window to ensure the images resize properly and aren't being cut off

## Checklist

- [x] Strings use placeholders for translation (No hard coded strings)
- [x] Unit tests have been added/updated
- [x] Update CHANGELOG
