### PR TITLE
Modify CosmosDB collection-level TTL to have no default value

### DIFF
--- a/lib/mongodb/connect.js
+++ b/lib/mongodb/connect.js
@@ -39,11 +39,8 @@ export async function connectToDatabase(mongoURI, mongoDB) {
   }
 
   // create new connection from connection creator
-  // Azure CosmoDB does not support partial indexes by default, but hopefully the do support sparse indexes
-  // Similarly, the TTL index in CosmoDB is different than default Mongo so this might not work locally
-  // TTL in CosmosDB needs an end time and can store an int32. Max for int32 is 2147483647, which turns into about 68 years
-  // We are still setting a per document TTL, which gets removed when the email is verified, but after 68 years,
-  // it will still be removed from the database because CosmosDB needs the TTL index to do per document TTL.
+  // ttl index on collection set to 0 but is overridden by ttl at the document level
+  // ttl index is set to 0 because an index is required to make per-document ttl supported on CosmosDB
   cached.conn = await cached.promise;
   await cached.conn.db.collection("users").createIndexes([
     {
@@ -53,7 +50,7 @@ export async function connectToDatabase(mongoURI, mongoDB) {
     },
     {
       key: { _ts: 1 },
-      expireAfterSeconds: process.env.NODE_ENV === "test" ? 0 : 2147483647,
+      expireAfterSeconds: 0,
     },
   ]);
   return cached.conn;

--- a/lib/mongodb/connect.js
+++ b/lib/mongodb/connect.js
@@ -38,9 +38,9 @@ export async function connectToDatabase(mongoURI, mongoDB) {
     });
   }
 
-  // create new connection from connection creator
-  // ttl index on collection set to 0 but is overridden by ttl at the document level
-  // ttl index is set to 0 because an index is required to make per-document ttl supported on CosmosDB
+  // Create new connection from connection creator
+  // Documentation suggests to use -1 to create a ttl index with no default ttl in CosmosDB. Document-level ttl will take precedence.
+  // Only use -1 value in development and production environments as it throws an error with standard MongoDB clients
   cached.conn = await cached.promise;
   await cached.conn.db.collection("users").createIndexes([
     {
@@ -50,7 +50,11 @@ export async function connectToDatabase(mongoURI, mongoDB) {
     },
     {
       key: { _ts: 1 },
-      expireAfterSeconds: 0,
+      expireAfterSeconds:
+        process.env.ENVIRONMENT === "development" ||
+        process.env.ENVIRONMENT === "production"
+          ? -1
+          : 0,
     },
   ]);
   return cached.conn;

--- a/lib/mongodb/connect.js
+++ b/lib/mongodb/connect.js
@@ -39,8 +39,8 @@ export async function connectToDatabase(mongoURI, mongoDB) {
   }
 
   // Create new connection from connection creator
-  // Documentation suggests to use -1 to create a ttl index with no default ttl in CosmosDB. Document-level ttl will take precedence.
-  // Only use -1 value in development and production environments as it throws an error with standard MongoDB clients
+  // Use -1 to create a ttl index with no default ttl in CosmosDB. Document-level ttl will take precedence.
+  // Only use -1 value in environments using CosmosDB as it throws an error with standard MongoDB clients
   cached.conn = await cached.promise;
   await cached.conn.db.collection("users").createIndexes([
     {


### PR DESCRIPTION
# Description

[DEV: Local mongodb clients and Atlas mongodb return error on first signup when connecting from local dev](https://dev.azure.com/VP-BD/DECD/_sprints/taskboard/Service%20Canada%20Labs/DECD/Service%20Canada%20Labs/PlanningSprint-2?workitem=68141)

Noticed that there was an error on first signup when connected to local and atlas mongodb instances. This error was due to the value on the `expireAfterSeconds` field in our index initialization in `connect.js` being too high for standard mongodb clients. While this configuration does appear to work for CosmosDB, it is setting a collection-level TTL of 68 years for documents based on their last date of modification.

While it is unlikely this site or even CosmosDB will be around in 68 years, I thought it would be useful to investigate how we can create a no-default TTL on the collection and let documents declare their ttl.

According to a [couple](https://www.striim.com/docs/en/cosmos-db-setup-for-mongo-cosmos-db-reader.html) [places](https://github.com/Azure/azure-cli/issues/13229) online but not explicitly mentioned in the official documentation we can use a value of `-1` in the `expireAfterSeconds` field to enable TTL at the collection level with no default TTL value. Documents would declare their own TTL always. 

EDIT: [Found some official documentation](https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.documents.documentcollection.defaulttimetolive?view=azure-dotnet) that adds some clarity (it's in C# but should translate)

![Screen Shot 2022-08-09 at 11 34 52 AM](https://user-images.githubusercontent.com/31868510/183735478-f7488880-e01f-4487-8020-ea7b819d4340.png)

When running the application locally during dev and connecting to a local mongodb client or Atlas, `expireAfterSeconds` should be set to 0 to avoid errors. While this avoids errors, TTL is not actually being set on these mongodb instances and require a [separate configuration](https://www.mongodb.com/docs/manual/tutorial/expire-data/).

Once this is merged I will ensure that TTL works as expected for the development environment.

## Acceptance Criteria

When running the application locally and connecting to a local mongodb client or Atlas, there should be no errors on first signup. Ensure your .env ENVIRONMENT variable value is neither "development" or "production".

## Test Instructions

1. yarn dev
2. attempt signup on the site
3. signup should be successful with no errors

## Product and Sprint Backlog

[Jira](https://jira-dev.bdm-dev.dts-stn.com/secure/RapidBoard.jspa?rapidView=96&projectKey=SCL)
