### PR TITLE
Revalidation for Remaining Routes

### DIFF
--- a/pages/api/revalidate.js
+++ b/pages/api/revalidate.js
@@ -1,4 +1,21 @@
-const REVALIDATION_ROUTES = ["/blog"];
+const REVALIDATION_ROUTES = [
+  "/404",
+  "/500",
+  "/about",
+  "/blog",
+  "/confirmation",
+  "/error",
+  "/home",
+  "/",
+  "/notsupported",
+  "/projects",
+  "/signup-info",
+  "/signup",
+  "/signup/privacy",
+  "/thankyou",
+  "/unsubscribe",
+  "/projects",
+];
 
 export default async function handler(req, res) {
   // Check for secret to confirm this is a valid request
@@ -8,12 +25,13 @@ export default async function handler(req, res) {
 
   try {
     await Promise.all(
-      REVALIDATION_ROUTES.map((route) => res.unstable_revalidate(route))
+      REVALIDATION_ROUTES.map((route) => res.revalidate(route))
     );
     return res.json({ revalidated: true });
   } catch (err) {
     // If there was an error, Next.js will continue
     // to show the last successfully generated page
+    console.log(err);
     return res.status(500).send("Error revalidating");
   }
 }


### PR DESCRIPTION
- added revalidation for all remaining routes

```
[
  "/404",
  "/500",
  "/about",
  "/blog",
  "/confirmation",
  "/error",
  "/home",
  "/",
  "/notsupported",
  "/projects",
  "/signup-info",
  "/signup",
  "/signup/privacy",
  "/thankyou",
  "/unsubscribe",
  "/projects",
]
```

**Note:** `/projects` will revalidate all nested routes too.