### PR TITLE
Privacy page redesign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Added image in Experiment card
 - Added Sharp for image optimization in production
 - Added the `Alert` component for contextual alerts
+- Added the `TableOfContents` component to convert page headings into a table of contents
 
 ## Changed
 

--- a/__mocks__/mockStore.js
+++ b/__mocks__/mockStore.js
@@ -4678,3 +4678,859 @@ export const signupInfoPageData = {
     },
   },
 };
+export const privacyPageData = {
+  data: {
+    sCLabsPageByPath: {
+      item: {
+        scId: "sclabs-privacy-policy-page",
+        scPageNameEn: "/signup/privacy",
+        scPageNameFr: "/fr/inscription/protection-renseignements-personnels",
+        scTitleEn: "Privacy Policy",
+        scTitleFr:
+          "Politique en matière de protection des renseignements personnels",
+        scShortTitleEn: null,
+        scShortTitleFr: null,
+        scDescriptionEn: {
+          json: null,
+        },
+        scDescriptionFr: {
+          json: null,
+        },
+        scSubject: null,
+        scKeywordsEn: null,
+        scKeywordsFr: null,
+        scContentType: null,
+        scOwner: null,
+        scDateModifiedOverwrite: "2022-07-14",
+        scAudience: null,
+        scRegion: null,
+        scSocialMediaImageEn: null,
+        scSocialMediaImageFr: null,
+        scSocialMediaImageAltTextEn: null,
+        scSocialMediaImageAltTextFr: null,
+        scNoIndex: false,
+        scNoFollow: false,
+        scFragments: [
+          {
+            _path:
+              "/content/dam/decd-endc/content-fragments/alpha/dev/sclabs/components/content/privacy-policy---main-content",
+            scId: "sclabs-privacy-policy-main-content",
+            scContentEn: {
+              json: [
+                {
+                  nodeType: "paragraph",
+                  content: [
+                    {
+                      nodeType: "text",
+                      value: "Your participation is completely voluntary.",
+                    },
+                  ],
+                },
+                {
+                  nodeType: "paragraph",
+                  content: [
+                    {
+                      nodeType: "text",
+                      value:
+                        "You can withdraw your personal information from our list at any time with no impact.",
+                    },
+                  ],
+                },
+                {
+                  nodeType: "header",
+                  style: "h2",
+                  content: [
+                    {
+                      nodeType: "text",
+                      value: "What we will collect",
+                    },
+                  ],
+                },
+                {
+                  nodeType: "paragraph",
+                  content: [
+                    {
+                      nodeType: "text",
+                      value:
+                        "To sign up to join our group of participants we need the following information so we can contact you with any relevant opportunities to take part in our research:",
+                    },
+                  ],
+                },
+                {
+                  nodeType: "unordered-list",
+                  content: [
+                    {
+                      nodeType: "list-item",
+                      content: [
+                        {
+                          nodeType: "text",
+                          value: "Email address",
+                        },
+                      ],
+                    },
+                    {
+                      nodeType: "list-item",
+                      content: [
+                        {
+                          nodeType: "text",
+                          value: "Year of birth",
+                        },
+                      ],
+                    },
+                    {
+                      nodeType: "list-item",
+                      content: [
+                        {
+                          nodeType: "text",
+                          value: "Language preference",
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  nodeType: "paragraph",
+                  content: [
+                    {
+                      nodeType: "text",
+                      value:
+                        "You can also choose to answer a few more questions below. Your answers will help us invite you to research opportunities relevant to your life experiences.",
+                    },
+                  ],
+                },
+                {
+                  nodeType: "unordered-list",
+                  content: [
+                    {
+                      nodeType: "list-item",
+                      content: [
+                        {
+                          nodeType: "text",
+                          value: "Province or territory",
+                        },
+                      ],
+                    },
+                    {
+                      nodeType: "list-item",
+                      content: [
+                        {
+                          nodeType: "text",
+                          value: "Gender identity",
+                        },
+                      ],
+                    },
+                    {
+                      nodeType: "list-item",
+                      content: [
+                        {
+                          nodeType: "text",
+                          value: "Indigenous identity",
+                        },
+                      ],
+                    },
+                    {
+                      nodeType: "list-item",
+                      content: [
+                        {
+                          nodeType: "text",
+                          value: "Disabilities",
+                        },
+                      ],
+                    },
+                    {
+                      nodeType: "list-item",
+                      content: [
+                        {
+                          nodeType: "text",
+                          value: "Visible Minority group",
+                        },
+                      ],
+                    },
+                    {
+                      nodeType: "list-item",
+                      content: [
+                        {
+                          nodeType: "text",
+                          value: "Income range",
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  nodeType: "paragraph",
+                  content: [
+                    {
+                      nodeType: "text",
+                      value:
+                        "This information will be collected under the authority of the ",
+                    },
+                    {
+                      nodeType: "text",
+                      value:
+                        "Department of Employment and Social Development Act",
+                      format: {
+                        variants: ["emphasis"],
+                      },
+                    },
+                    {
+                      nodeType: "text",
+                      value: " and the ",
+                    },
+                    {
+                      nodeType: "text",
+                      value: "Financial Administration Act",
+                      format: {
+                        variants: ["emphasis"],
+                      },
+                    },
+                    {
+                      nodeType: "text",
+                      value:
+                        ". Employment and Social Development Canada’s Digital Experience and Client Data group will use this information to understand and improve how it delivers benefits and services through Service Canada.",
+                    },
+                  ],
+                },
+                {
+                  nodeType: "paragraph",
+                  content: [
+                    {
+                      nodeType: "text",
+                      value:
+                        "We collect this information to ensure our research groups are diverse, and to identify trends in feedback for specific groups.",
+                    },
+                  ],
+                },
+                {
+                  nodeType: "header",
+                  style: "h2",
+                  content: [
+                    {
+                      nodeType: "text",
+                      value: "How we will use this information",
+                    },
+                  ],
+                },
+                {
+                  nodeType: "paragraph",
+                  content: [
+                    {
+                      nodeType: "text",
+                      value:
+                        "This personal information is confidential and will not be used for any “administrative purposes.” This means that your information will not be used for any decision-making process that directly affects you or your access to Government of Canada services. Your information will be used by Employment and Social Development Canada for policy analysis, research, and evaluation purposes.",
+                    },
+                  ],
+                },
+                {
+                  nodeType: "paragraph",
+                  content: [
+                    {
+                      nodeType: "text",
+                      value:
+                        "We will only use your email address to communicate with you.",
+                    },
+                  ],
+                },
+                {
+                  nodeType: "paragraph",
+                  content: [
+                    {
+                      nodeType: "text",
+                      value:
+                        "The Digital Experience and Client Data group will own the information for two years after the project’s end date. Your information may be shared with other government departments such as the Canada Revenue Agency, Immigration, Refugees and Citizenship Canada for the purpose of collaborating on other service improvement projects and would not include your name, or email address.",
+                    },
+                  ],
+                },
+                {
+                  nodeType: "header",
+                  style: "h2",
+                  content: [
+                    {
+                      nodeType: "text",
+                      value: "How to withdraw your information",
+                    },
+                  ],
+                },
+                {
+                  nodeType: "paragraph",
+                  content: [
+                    {
+                      nodeType: "text",
+                      value:
+                        "If you have previously signed up to become a participant and no longer wish to be contacted for future research studies, you can ",
+                    },
+                    {
+                      nodeType: "link",
+                      data: {
+                        href: "/unsubscribe/",
+                      },
+                      value: "unsubscribe",
+                    },
+                    {
+                      nodeType: "text",
+                      value:
+                        " yourself from the participant list and we will remove your personal information.",
+                    },
+                  ],
+                },
+                {
+                  nodeType: "header",
+                  style: "h2",
+                  content: [
+                    {
+                      nodeType: "text",
+                      value: "Who we are",
+                    },
+                  ],
+                },
+                {
+                  nodeType: "paragraph",
+                  content: [
+                    {
+                      nodeType: "text",
+                      value:
+                        "The Digital Experience and Client Data group is a program within Employment and Social Development Canada.",
+                    },
+                  ],
+                },
+                {
+                  nodeType: "paragraph",
+                  content: [
+                    {
+                      nodeType: "text",
+                      value:
+                        "The collection, use, and disclosure of your personal information is in accordance with the federal ",
+                    },
+                    {
+                      nodeType: "text",
+                      value: "Privacy Act",
+                      format: {
+                        variants: ["emphasis"],
+                      },
+                    },
+                    {
+                      nodeType: "text",
+                      value: ", the",
+                    },
+                    {
+                      nodeType: "text",
+                      value:
+                        " Department of Employment and Social Development Act",
+                      format: {
+                        variants: ["emphasis"],
+                      },
+                    },
+                    {
+                      nodeType: "text",
+                      value: ", the",
+                    },
+                    {
+                      nodeType: "text",
+                      value: " Financial Administration Act",
+                      format: {
+                        variants: ["emphasis"],
+                      },
+                    },
+                    {
+                      nodeType: "text",
+                      value: " and any other applicable laws.",
+                    },
+                  ],
+                },
+                {
+                  nodeType: "paragraph",
+                  content: [
+                    {
+                      nodeType: "text",
+                      value:
+                        "You have the right to the protection of, access to, and correction of your personal information which is described in the Standard Personal Information Banks entitled “PSU 914 – Public Communications” and “PSU 938 – Outreach Activities.”",
+                    },
+                  ],
+                },
+                {
+                  nodeType: "paragraph",
+                  content: [
+                    {
+                      nodeType: "text",
+                      value:
+                        "Instructions for obtaining this information are outlined in the government publication ",
+                    },
+                    {
+                      nodeType: "link",
+                      data: {
+                        href: "https://www.canada.ca/en/treasury-board-secretariat/services/access-information-privacy/access-information/information-about-programs-information-holdings.html",
+                      },
+                      value:
+                        "Information about programs and information holdings",
+                    },
+                    {
+                      nodeType: "text",
+                      value: ".",
+                    },
+                  ],
+                },
+                {
+                  nodeType: "paragraph",
+                  content: [
+                    {
+                      nodeType: "text",
+                      value:
+                        "Information about programs and information holdings",
+                      format: {
+                        variants: ["emphasis"],
+                      },
+                    },
+                    {
+                      nodeType: "text",
+                      value:
+                        " may also be accessed on-line at any Service Canada Centre.",
+                    },
+                  ],
+                },
+                {
+                  nodeType: "header",
+                  style: "h2",
+                  content: [
+                    {
+                      nodeType: "text",
+                      value: "Your legal rights",
+                    },
+                  ],
+                },
+                {
+                  nodeType: "paragraph",
+                  content: [
+                    {
+                      nodeType: "text",
+                      value: "You have the right to file a complaint with the ",
+                    },
+                    {
+                      nodeType: "link",
+                      data: {
+                        href: "https://www.priv.gc.ca/en/about-the-opc/who-we-are/the-privacy-commissioner-of-canada/",
+                      },
+                      value: "Privacy Commissioner of Canada ",
+                    },
+                    {
+                      nodeType: "text",
+                      value:
+                        "regarding Employment and Social Development Canada’s handling of your personal information.",
+                    },
+                  ],
+                },
+              ],
+            },
+            scContentFr: {
+              json: [
+                {
+                  nodeType: "paragraph",
+                  content: [
+                    {
+                      nodeType: "text",
+                      value: "Votre participation est volontaire.",
+                    },
+                  ],
+                },
+                {
+                  nodeType: "paragraph",
+                  content: [
+                    {
+                      nodeType: "text",
+                      value:
+                        "Vous pouvez retirer vos renseignements personnels de notre liste à tout moment, sans aucune conséquence.",
+                    },
+                  ],
+                },
+                {
+                  nodeType: "header",
+                  style: "h2",
+                  content: [
+                    {
+                      nodeType: "text",
+                      value: "Ce que nous allons recueillir",
+                    },
+                  ],
+                },
+                {
+                  nodeType: "paragraph",
+                  content: [
+                    {
+                      nodeType: "text",
+                      value:
+                        "Pour vous inscrire à notre groupe de participants, vous devez nous fournir les renseignements suivants. Ils nous permettront de communiquer avec vous pour vous proposer de participer à nos recherches :",
+                    },
+                  ],
+                },
+                {
+                  nodeType: "unordered-list",
+                  content: [
+                    {
+                      nodeType: "list-item",
+                      content: [
+                        {
+                          nodeType: "text",
+                          value: "Adresse de courrier électronique",
+                        },
+                      ],
+                    },
+                    {
+                      nodeType: "list-item",
+                      content: [
+                        {
+                          nodeType: "text",
+                          value: "Année de naissance",
+                        },
+                      ],
+                    },
+                    {
+                      nodeType: "list-item",
+                      content: [
+                        {
+                          nodeType: "text",
+                          value: "Langue de votre choix",
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  nodeType: "paragraph",
+                  content: [
+                    {
+                      nodeType: "text",
+                      value:
+                        "Vous pouvez également choisir de répondre à quelques questions supplémentaires ci-dessous. Vos réponses nous permettront de vous inviter à participer à des recherches et à des essais correspondant à vos expériences de vie.",
+                    },
+                  ],
+                },
+                {
+                  nodeType: "unordered-list",
+                  content: [
+                    {
+                      nodeType: "list-item",
+                      content: [
+                        {
+                          nodeType: "text",
+                          value: "Province ou territoire",
+                        },
+                      ],
+                    },
+                    {
+                      nodeType: "list-item",
+                      content: [
+                        {
+                          nodeType: "text",
+                          value: "Identité de genre",
+                        },
+                      ],
+                    },
+                    {
+                      nodeType: "list-item",
+                      content: [
+                        {
+                          nodeType: "text",
+                          value: "Identité autochtone",
+                        },
+                      ],
+                    },
+                    {
+                      nodeType: "list-item",
+                      content: [
+                        {
+                          nodeType: "text",
+                          value: "Situation de handicap",
+                        },
+                      ],
+                    },
+                    {
+                      nodeType: "list-item",
+                      content: [
+                        {
+                          nodeType: "text",
+                          value: "Groupe de minorité visible",
+                        },
+                      ],
+                    },
+                    {
+                      nodeType: "list-item",
+                      content: [
+                        {
+                          nodeType: "text",
+                          value: "Niveau de revenus",
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  nodeType: "paragraph",
+                  content: [
+                    {
+                      nodeType: "text",
+                      value:
+                        "Ces renseignements seront recueillis en vertu de la ",
+                    },
+                    {
+                      nodeType: "text",
+                      value:
+                        "Loi sur le ministère de l’Emploi et du Développement social",
+                      format: {
+                        variants: ["emphasis"],
+                      },
+                    },
+                    {
+                      nodeType: "text",
+                      value: " et de la ",
+                    },
+                    {
+                      nodeType: "text",
+                      value: "Loi sur la gestion des finances publiques",
+                      format: {
+                        variants: ["emphasis"],
+                      },
+                    },
+                    {
+                      nodeType: "text",
+                      value:
+                        ". Le groupe Expérience numérique et données clients d’Emploi et Développement social Canada utilisera ces renseignements pour comprendre et améliorer la façon dont il verse les prestations et fournit les services par l’intermédiaire de Service Canada.",
+                    },
+                  ],
+                },
+                {
+                  nodeType: "paragraph",
+                  content: [
+                    {
+                      nodeType: "text",
+                      value:
+                        "Nous recueillons ces renseignements pour nous assurer que nos groupes de recherche sont diversifiés et pour reconnaître les tendances en matière de rétroaction provenant de groupes précis.",
+                    },
+                  ],
+                },
+                {
+                  nodeType: "header",
+                  style: "h2",
+                  content: [
+                    {
+                      nodeType: "text",
+                      value: "Comment nous utiliserons ces renseignements",
+                    },
+                  ],
+                },
+                {
+                  nodeType: "paragraph",
+                  content: [
+                    {
+                      nodeType: "text",
+                      value:
+                        "Ces renseignements personnels ne seront pas utilisés à des « fins administratives ». Cela signifie que vos renseignements ne seront pas utilisés dans le cadre d’un processus décisionnel qui vous touche directement ou qui peut modifier votre accès aux services du gouvernement du Canada. Vos renseignements seront utilisés par Emploi et Développement social Canada aux fins d’analyse des politiques, de recherche et d’évaluation.",
+                    },
+                  ],
+                },
+                {
+                  nodeType: "paragraph",
+                  content: [
+                    {
+                      nodeType: "text",
+                      value:
+                        "Nous n’utiliserons votre adresse de courrier électronique que pour communiquer avec vous.",
+                    },
+                  ],
+                },
+                {
+                  nodeType: "paragraph",
+                  content: [
+                    {
+                      nodeType: "text",
+                      value:
+                        "Le groupe Expérience numérique et données clients conservera vos renseignements pendant deux ans après la date de fin du projet. Vos renseignements pourraient être communiqués à d’autres ministères, tels que l’Agence du revenu du Canada, Immigration, Réfugiés et Citoyenneté Canada, dans le but de collaborer à d’autres projets d’amélioration du service, et n'incluraient pas votre nom ou votre adresse de courrier électronique.",
+                    },
+                  ],
+                },
+                {
+                  nodeType: "header",
+                  style: "h2",
+                  content: [
+                    {
+                      nodeType: "text",
+                      value: "Comment retirer vos informations",
+                    },
+                  ],
+                },
+                {
+                  nodeType: "paragraph",
+                  content: [
+                    {
+                      nodeType: "text",
+                      value:
+                        "Si vous vous êtes déjà inscrit pour participer et que vous ne souhaitez plus être contacté pour de futures recherches, vous pouvez ",
+                    },
+                    {
+                      nodeType: "link",
+                      data: {
+                        href: "/fr/desabonnement/",
+                      },
+                      value: "vous désabonner",
+                    },
+                    {
+                      nodeType: "text",
+                      value:
+                        " et nous supprimerons vos renseignements personnels.",
+                    },
+                  ],
+                },
+                {
+                  nodeType: "header",
+                  style: "h2",
+                  content: [
+                    {
+                      nodeType: "text",
+                      value: "Qui nous sommes",
+                    },
+                  ],
+                },
+                {
+                  nodeType: "paragraph",
+                  content: [
+                    {
+                      nodeType: "text",
+                      value:
+                        "Le groupe Expérience numérique et données clients relève de la responsabilité d’Emploi et Développement social Canada.",
+                    },
+                  ],
+                },
+                {
+                  nodeType: "paragraph",
+                  content: [
+                    {
+                      nodeType: "text",
+                      value:
+                        "La collecte, l’utilisation et la divulgation de vos renseignements personnels sont conformes à la ",
+                    },
+                    {
+                      nodeType: "text",
+                      value:
+                        "Loi sur la protection des renseignements personnels ",
+                      format: {
+                        variants: ["emphasis"],
+                      },
+                    },
+                    {
+                      nodeType: "text",
+                      value: ", à la",
+                    },
+                    {
+                      nodeType: "text",
+                      value:
+                        " Loi sur le ministère de l’Emploi et du Développement social",
+                      format: {
+                        variants: ["emphasis"],
+                      },
+                    },
+                    {
+                      nodeType: "text",
+                      value: ", à la",
+                    },
+                    {
+                      nodeType: "text",
+                      value: " Loi sur la gestion des finances publiques",
+                      format: {
+                        variants: ["emphasis"],
+                      },
+                    },
+                    {
+                      nodeType: "text",
+                      value: " et à toute autre loi applicable.",
+                    },
+                  ],
+                },
+                {
+                  nodeType: "paragraph",
+                  content: [
+                    {
+                      nodeType: "text",
+                      value:
+                        "Vous avez droit à la protection de vos renseignements personnels et vous avez le droit d’y accéder et de les faire corriger. Ce droit est décrit dans les fichiers de renseignements personnels POU 914, « Communications publiques » et POU 938, « Activités de sensibilisation ».",
+                    },
+                  ],
+                },
+                {
+                  nodeType: "paragraph",
+                  content: [
+                    {
+                      nodeType: "text",
+                      value:
+                        "Les instructions pour obtenir ces renseignements sont décrites dans la publication du gouvernement ",
+                    },
+                    {
+                      nodeType: "link",
+                      data: {
+                        href: "https://www.canada.ca/fr/secretariat-conseil-tresor/services/acces-information-protection-reseignements-personnels/acces-information/renseignements-programmes-fonds-renseignements.html",
+                      },
+                      value:
+                        "Renseignements sur les programmes et les fonds de renseignements",
+                    },
+                    {
+                      nodeType: "text",
+                      value: ".",
+                    },
+                  ],
+                },
+                {
+                  nodeType: "paragraph",
+                  content: [
+                    {
+                      nodeType: "text",
+                      value:
+                        "Renseignements sur les programmes et les fonds de renseignements",
+                      format: {
+                        variants: ["emphasis"],
+                      },
+                    },
+                    {
+                      nodeType: "text",
+                      value:
+                        " peut également être consultée en ligne dans n’importe quel Centre Service Canada.",
+                    },
+                  ],
+                },
+                {
+                  nodeType: "header",
+                  style: "h2",
+                  content: [
+                    {
+                      nodeType: "text",
+                      value: "Vos droits",
+                    },
+                  ],
+                },
+                {
+                  nodeType: "paragraph",
+                  content: [
+                    {
+                      nodeType: "text",
+                      value:
+                        "Vous avez le droit de déposer une plainte auprès du ",
+                    },
+                    {
+                      nodeType: "link",
+                      data: {
+                        href: "https://www.priv.gc.ca/fr/a-propos-du-commissariat/qui-nous-sommes/commissaire-a-la-protection-de-la-vie-privee-du-canada/",
+                      },
+                      value:
+                        "Commissaire à la protection de la vie privée du Canada ",
+                    },
+                    {
+                      nodeType: "text",
+                      value:
+                        "au sujet du mode de traitement de vos renseignements personnels par Emploi et Développement social Canada.",
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  },
+};

--- a/__tests__/pages/privacy.test.js
+++ b/__tests__/pages/privacy.test.js
@@ -3,10 +3,17 @@
  */
 import { render, screen } from "@testing-library/react";
 import Privacy from "../../pages/signup/privacy";
+import { privacyPageData } from "../../__mocks__/mockStore";
+
+jest.mock("@apollo/client");
 
 describe("Privacy Policy", () => {
   it("renders without crashing", () => {
-    render(<Privacy />);
-    expect(screen.getByText("privacyTitle")).toBeInTheDocument();
+    render(<Privacy pageData={privacyPageData.data.sCLabsPageByPath} />);
+    expect(
+      screen.getByRole("heading", {
+        name: "Comment retirer vos informations",
+      })
+    ).toBeInTheDocument();
   });
 });

--- a/components/atoms/TableOfContents.js
+++ b/components/atoms/TableOfContents.js
@@ -1,0 +1,34 @@
+import PropTypes from "prop-types";
+
+export function TableOfContents(props) {
+  return (
+    <>
+      <p className="font-semibold">{props.title}</p>
+      <nav>
+        <ul className="leading-4 list-disc">
+          {props.headings.map((heading) => (
+            <li key={heading.id}>
+              <a
+                className="underline text-custom-blue-link underline hover:text-custom-blue-projects-link"
+                href={`#${heading.id}`}
+              >
+                {heading.text}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </nav>
+    </>
+  );
+}
+
+TableOfContents.propTypes = {
+  /**
+   * The title for the table of contents
+   */
+  title: PropTypes.string,
+  /**
+   * An array of headings
+   */
+  headings: PropTypes.array,
+};

--- a/components/atoms/TableOfContents.stories.js
+++ b/components/atoms/TableOfContents.stories.js
@@ -1,0 +1,15 @@
+import { TableOfContents } from "./TableOfContents";
+
+export default {
+  title: "Components/Atoms/TableOfContents",
+  component: TableOfContents,
+};
+
+const Template = (args) => <TableOfContents {...args} />;
+
+export const Primary = Template.bind({});
+
+Primary.args = {
+  title: "Table of Contents Title",
+  headings: [{ id: "heading-one", text: "Heading one" }],
+};

--- a/components/atoms/TableOfContents.test.js
+++ b/components/atoms/TableOfContents.test.js
@@ -1,0 +1,27 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/extend-expect";
+import { axe, toHaveNoViolations } from "jest-axe";
+import { Primary } from "./TableOfContents.stories";
+
+expect.extend(toHaveNoViolations);
+
+describe("Alert tests", () => {
+  it("renders TableOfContents in its primary state", () => {
+    render(<Primary {...Primary.args} />);
+    const title = screen.getByText("Table of Contents Title");
+    const text = screen.getByText("Heading one");
+    expect(title).toBeTruthy();
+    expect(text).toBeTruthy();
+  });
+
+  it("has no a11y violations", async () => {
+    const { container } = render(<Primary {...Primary.args} />);
+    const results = await axe(container);
+
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/graphql/queries/privacyPageQuery.graphql
+++ b/graphql/queries/privacyPageQuery.graphql
@@ -1,0 +1,65 @@
+query getPrivacyPage {
+  sCLabsPageByPath(
+    _path: "/content/dam/decd-endc/content-fragments/alpha/sclabs/pages/privacy-policy-page"
+  ) {
+    item {
+      scId
+      scPageNameEn
+      scPageNameFr
+      scTitleEn
+      scTitleFr
+      scShortTitleEn
+      scShortTitleFr
+      scDescriptionEn {
+        json
+      }
+      scDescriptionFr {
+        json
+      }
+      scSubject
+      scKeywordsEn
+      scKeywordsFr
+      scContentType
+      scOwner
+      scDateModifiedOverwrite
+      scAudience
+      scRegion
+      scSocialMediaImageEn {
+        ... on ImageRef {
+          _publishUrl
+          width
+          height
+        }
+        ... on DocumentRef {
+          _publishUrl
+        }
+      }
+      scSocialMediaImageFr {
+        ... on ImageRef {
+          _publishUrl
+          width
+          height
+        }
+        ... on DocumentRef {
+          _publishUrl
+        }
+      }
+      scSocialMediaImageAltTextEn
+      scSocialMediaImageAltTextFr
+      scNoIndex
+      scNoFollow
+      scFragments {
+        ... on SCLabsContentModel {
+          _path
+          scId
+          scContentEn {
+            json
+          }
+          scContentFr {
+            json
+          }
+        }
+      }
+    }
+  }
+}

--- a/pages/projects.js
+++ b/pages/projects.js
@@ -319,7 +319,7 @@ export default function Projects(props) {
           description={t("signupBannerDescription")}
           disclaimer={t("signupBannerDisclaimer")}
           lang={props.locale}
-          href="/signup-info"
+          href={t("signupInfoRedirect")}
           hrefText={t("signupBannerBtnText")}
         />
       </Layout>

--- a/pages/signup/privacy.js
+++ b/pages/signup/privacy.js
@@ -2,7 +2,6 @@ import { Layout } from "../../components/organisms/Layout";
 import Head from "next/head";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { useTranslation } from "next-i18next";
-import { HTMList } from "../../components/atoms/HTMList";
 import { CallToAction } from "../../components/molecules/CallToAction";
 import { useEffect, useState } from "react";
 import { Alert } from "../../components/atoms/Alert";

--- a/pages/signup/privacy.js
+++ b/pages/signup/privacy.js
@@ -4,12 +4,26 @@ import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { useTranslation } from "next-i18next";
 import { HTMList } from "../../components/atoms/HTMList";
 import { CallToAction } from "../../components/molecules/CallToAction";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
+import { Alert } from "../../components/atoms/Alert";
+import queryGraphQL from "../../graphql/client";
+import getPrivacyPage from "../../graphql/queries/privacyPageQuery.graphql";
+import { TableOfContents } from "../../components/atoms/TableOfContents";
 
 export default function Privacy(props) {
   const { t } = useTranslation("common");
+  const [pageData] = useState(props.pageData.item);
+  const [headings, setHeadings] = useState([]);
 
   useEffect(() => {
+    const headingElements = Array.from(document.querySelectorAll("h2"))
+      .filter((element) => element.id)
+      .map((element) => ({
+        id: element.id,
+        text: element.textContent ?? "",
+      }));
+    setHeadings(headingElements);
+
     if (props.adobeAnalyticsUrl) {
       window.adobeDataLayer = window.adobeDataLayer || [];
       window.adobeDataLayer.push({ event: "pageLoad" });
@@ -120,103 +134,279 @@ export default function Privacy(props) {
             className="mb-8 text-h1l font-bold flex-wrap"
             tabIndex="-1"
           >
-            {t("privacyTitle")}
+            {props.locale === "en" ? pageData.scTitleEn : pageData.scTitleFr}
           </h1>
+          <TableOfContents
+            title={t("tableOfContentsTitle")}
+            headings={headings}
+          />
+          <div className="lg:ml-4 pb-8 pt-4">
+            <Alert
+              title={
+                props.locale === "en"
+                  ? pageData.scFragments[0].scContentEn.json[0].content[0].value
+                  : pageData.scFragments[0].scContentFr.json[0].content[0].value
+              }
+              text={
+                props.locale === "en"
+                  ? pageData.scFragments[0].scContentEn.json[1].content[0].value
+                  : pageData.scFragments[0].scContentFr.json[1].content[0].value
+              }
+            />
+          </div>
           <div className="xl:w-2/3">
-            <p className="mb-8">{t("privacyPolicyContent1")}</p>
-            <h2 className="mb-4 font-bold leading-10">
-              {t("privacyPolicyHeading1")}
+            <h2 id="what-we-collect" className="mb-4 font-bold leading-10">
+              {props.locale === "en"
+                ? pageData.scFragments[0].scContentEn.json[2].content[0].value
+                : pageData.scFragments[0].scContentFr.json[2].content[0].value}
             </h2>
-            <p className="mb-4">{t("privacyPolicyContent2")}</p>
-            <HTMList
-              listClassName={"ml-9 mb-4 text-p list-disc"}
-              content={t("privacyPolicyList1")}
-            />
-            <p className="mb-4">{t("privacyPolicyContent3")}</p>
-            <HTMList
-              listClassName={"ml-9 mb-4 text-p list-disc"}
-              content={t("privacyPolicyList2")}
-            />
             <p className="mb-4">
-              {t("privacyPolicyContent4")}
+              {props.locale === "en"
+                ? pageData.scFragments[0].scContentEn.json[3].content[0].value
+                : pageData.scFragments[0].scContentFr.json[3].content[0].value}
+            </p>
+            <ul className="ml-9 mb-4 text-p list-disc">
+              {pageData.scFragments[0].scContentEn.json[4].content.map(
+                (item) => (
+                  <li key={item.content[0].value}>{item.content[0].value}</li>
+                )
+              )}
+            </ul>
+            <p className="mb-4">
+              {props.locale === "en"
+                ? pageData.scFragments[0].scContentEn.json[5].content[0].value
+                : pageData.scFragments[0].scContentFr.json[5].content[0].value}
+            </p>
+            <ul className="ml-9 mb-4 text-p list-disc">
+              {pageData.scFragments[0].scContentEn.json[6].content.map(
+                (item) => (
+                  <li key={item.content[0].value}>{item.content[0].value}</li>
+                )
+              )}
+            </ul>
+            <p className="mb-4">
+              {props.locale === "en"
+                ? pageData.scFragments[0].scContentEn.json[7].content[0].value
+                : pageData.scFragments[0].scContentFr.json[7].content[0].value}
               <span>
                 {" "}
-                <i>{t("privacyPolicyAct1")}</i> {t("privacyPolicyAnd")}{" "}
-                <i>{t("privacyPolicyAct2")}</i>
-                {". "} {t("privacyPolicyContent5")}
+                <i>
+                  {props.locale === "en"
+                    ? pageData.scFragments[0].scContentEn.json[7].content[1]
+                        .value
+                    : pageData.scFragments[0].scContentFr.json[7].content[1]
+                        .value}
+                </i>{" "}
+                {props.locale === "en"
+                  ? pageData.scFragments[0].scContentEn.json[7].content[2].value
+                  : pageData.scFragments[0].scContentFr.json[7].content[2]
+                      .value}
+                <i>
+                  {props.locale === "en"
+                    ? pageData.scFragments[0].scContentEn.json[7].content[3]
+                        .value
+                    : pageData.scFragments[0].scContentFr.json[7].content[3]
+                        .value}
+                </i>
+                {props.locale === "en"
+                  ? pageData.scFragments[0].scContentEn.json[7].content[4].value
+                  : pageData.scFragments[0].scContentFr.json[7].content[4]
+                      .value}
               </span>
             </p>
-            <p className="mb-8">{t("privacyPolicyContent6")}</p>
-            <h2 className="mb-4 font-bold leading-10">
-              {t("privacyPolicyHeading2")}
-            </h2>
-            <p className="mb-4">{t("privacyPolicyContent7")}</p>
-            <p className="mb-4">{t("privacyPolicyContent8")}</p>
-            <p className="mb-8">{t("privacyPolicyContent9")}</p>
-            <h2 className="mb-4 font-bold leading-10">{t("withdraw")}</h2>
             <p className="mb-8">
-              {t("privacyWithdraw")}
+              {props.locale === "en"
+                ? pageData.scFragments[0].scContentEn.json[8].content[0].value
+                : pageData.scFragments[0].scContentFr.json[8].content[0].value}
+            </p>
+            <h2 id="how-we-use" className="mb-4 font-bold leading-10">
+              {props.locale === "en"
+                ? pageData.scFragments[0].scContentEn.json[9].content[0].value
+                : pageData.scFragments[0].scContentFr.json[9].content[0].value}
+            </h2>
+            <p className="mb-4">
+              {props.locale === "en"
+                ? pageData.scFragments[0].scContentEn.json[10].content[0].value
+                : pageData.scFragments[0].scContentFr.json[10].content[0].value}
+            </p>
+            <p className="mb-4">
+              {props.locale === "en"
+                ? pageData.scFragments[0].scContentEn.json[11].content[0].value
+                : pageData.scFragments[0].scContentFr.json[11].content[0].value}
+            </p>
+            <p className="mb-8">
+              {props.locale === "en"
+                ? pageData.scFragments[0].scContentEn.json[12].content[0].value
+                : pageData.scFragments[0].scContentFr.json[12].content[0].value}
+            </p>
+            <h2 id="how-to-withdraw" className="mb-4 font-bold leading-10">
+              {props.locale === "en"
+                ? pageData.scFragments[0].scContentEn.json[13].content[0].value
+                : pageData.scFragments[0].scContentFr.json[13].content[0].value}
+            </h2>
+            <p className="mb-8">
+              {props.locale === "en"
+                ? pageData.scFragments[0].scContentEn.json[14].content[0].value
+                : pageData.scFragments[0].scContentFr.json[14].content[0].value}
               <a
-                href={t("unsubRedirect")}
+                href={
+                  props.locale === "en"
+                    ? pageData.scFragments[0].scContentEn.json[14].content[1]
+                        .data.href
+                    : pageData.scFragments[0].scContentFr.json[14].content[1]
+                        .data.href
+                }
                 className="text-custom-blue-link underline"
               >
-                {t("unsubscribeWord")}
+                {props.locale === "en"
+                  ? pageData.scFragments[0].scContentEn.json[14].content[1]
+                      .value
+                  : pageData.scFragments[0].scContentFr.json[14].content[1]
+                      .value}
               </a>
-              {t("privacyWithdraw2")}
+              {props.locale === "en"
+                ? pageData.scFragments[0].scContentEn.json[14].content[2].value
+                : pageData.scFragments[0].scContentFr.json[14].content[2].value}
             </p>
-            <h2 className="mb-4 font-bold leading-10">
-              {t("privacyPolicyHeading3")}
+            <h2 id="who-we-are" className="mb-4 font-bold leading-10">
+              {props.locale === "en"
+                ? pageData.scFragments[0].scContentEn.json[15].content[0].value
+                : pageData.scFragments[0].scContentFr.json[15].content[0].value}
             </h2>
-            <p className="mb-4">{t("privacyPolicyContent10")}</p>
             <p className="mb-4">
-              {t("privacyPolicyContent11")}
+              {props.locale === "en"
+                ? pageData.scFragments[0].scContentEn.json[16].content[0].value
+                : pageData.scFragments[0].scContentFr.json[16].content[0].value}
+            </p>
+            <p className="mb-4">
+              {props.locale === "en"
+                ? pageData.scFragments[0].scContentEn.json[17].content[0].value
+                : pageData.scFragments[0].scContentFr.json[17].content[0].value}
               <span>
-                <i>{t("privacyPolicyAct3")}</i>
-                {", "}
-                {t("privacyPolicyThe")}
-                <i> {t("privacyPolicyAct1")}</i>
-                {", "}
-                {t("privacyPolicyThe")}
-                <i> {t("privacyPolicyAct2")}</i>
-                {t("privacyPolicyContent12")}
+                <i>
+                  {props.locale === "en"
+                    ? pageData.scFragments[0].scContentEn.json[17].content[1]
+                        .value
+                    : pageData.scFragments[0].scContentFr.json[17].content[1]
+                        .value}
+                </i>
+                {props.locale === "en"
+                  ? pageData.scFragments[0].scContentEn.json[17].content[2]
+                      .value
+                  : pageData.scFragments[0].scContentFr.json[17].content[2]
+                      .value}
+                <i>
+                  {" "}
+                  {props.locale === "en"
+                    ? pageData.scFragments[0].scContentEn.json[17].content[3]
+                        .value
+                    : pageData.scFragments[0].scContentFr.json[17].content[3]
+                        .value}
+                </i>
+                {props.locale === "en"
+                  ? pageData.scFragments[0].scContentEn.json[17].content[4]
+                      .value
+                  : pageData.scFragments[0].scContentFr.json[17].content[4]
+                      .value}
+                <i>
+                  {props.locale === "en"
+                    ? pageData.scFragments[0].scContentEn.json[17].content[5]
+                        .value
+                    : pageData.scFragments[0].scContentFr.json[17].content[5]
+                        .value}
+                </i>
+                {props.locale === "en"
+                  ? pageData.scFragments[0].scContentEn.json[17].content[6]
+                      .value
+                  : pageData.scFragments[0].scContentFr.json[17].content[6]
+                      .value}
               </span>
             </p>
-            <p className="mb-4">{t("privacyPolicyContent13")}</p>
             <p className="mb-4">
-              {t("privacyPolicyContent14")}
+              {props.locale === "en"
+                ? pageData.scFragments[0].scContentEn.json[18].content[0].value
+                : pageData.scFragments[0].scContentFr.json[18].content[0].value}
+            </p>
+            <p className="mb-4">
+              {props.locale === "en"
+                ? pageData.scFragments[0].scContentEn.json[19].content[0].value
+                : pageData.scFragments[0].scContentFr.json[19].content[0].value}
               <a
-                href={t("privacyPolicyInfoHoldingsURL")}
+                href={
+                  props.locale === "en"
+                    ? pageData.scFragments[0].scContentEn.json[19].content[1]
+                        .data.href
+                    : pageData.scFragments[0].scContentFr.json[19].content[1]
+                        .data.href
+                }
                 className="text-custom-blue-link underline"
               >
-                {" "}
-                {t("privacyPolicyInfoHoldings")}
+                {props.locale === "en"
+                  ? pageData.scFragments[0].scContentEn.json[19].content[1]
+                      .value
+                  : pageData.scFragments[0].scContentFr.json[19].content[1]
+                      .value}
               </a>
               {"."}
             </p>
-            <p className="mb-8 italic">
-              {t("privacyPolicyInfoHoldings")}
-              <span className="not-italic">{t("privacyPolicyContent15")}</span>
+            <p className="mb-8">
+              <i>
+                {props.locale === "en"
+                  ? pageData.scFragments[0].scContentEn.json[20].content[0]
+                      .value
+                  : pageData.scFragments[0].scContentFr.json[20].content[0]
+                      .value}
+              </i>
+              <span>
+                {props.locale === "en"
+                  ? pageData.scFragments[0].scContentEn.json[20].content[1]
+                      .value
+                  : pageData.scFragments[0].scContentFr.json[20].content[1]
+                      .value}
+              </span>
             </p>
-            <h2 className="mb-4 font-bold leading-10">
-              {t("privacyPolicyHeading4")}
+            <h2 id="legal-rights" className="mb-4 font-bold leading-10">
+              {props.locale === "en"
+                ? pageData.scFragments[0].scContentEn.json[21].content[0].value
+                : pageData.scFragments[0].scContentFr.json[21].content[0].value}
             </h2>
             <p className="mb-4">
-              {t("privacyPolicyContent16")}
+              {props.locale === "en"
+                ? pageData.scFragments[0].scContentEn.json[22].content[0].value
+                : pageData.scFragments[0].scContentFr.json[22].content[0].value}
               <a
-                href={t("privacyPolicyPrivacyCommissionerURL")}
+                href={
+                  props.locale === "en"
+                    ? pageData.scFragments[0].scContentEn.json[22].content[1]
+                        .data.href
+                    : pageData.scFragments[0].scContentFr.json[22].content[1]
+                        .data.href
+                }
                 className="text-custom-blue-link underline"
               >
-                {t("privacyPolicyPrivacyCommissioner")}
+                {props.locale === "en"
+                  ? pageData.scFragments[0].scContentEn.json[22].content[1]
+                      .value
+                  : pageData.scFragments[0].scContentFr.json[22].content[1]
+                      .value}
               </a>
-              <span>{t("privacyPolicyContent17")}</span>
+              <span>
+                {props.locale === "en"
+                  ? pageData.scFragments[0].scContentEn.json[22].content[2]
+                      .value
+                  : pageData.scFragments[0].scContentFr.json[22].content[2]
+                      .value}
+              </span>
             </p>
           </div>
         </section>
         <CallToAction
-          title={t("signupTitleCallToAction")}
-          html={t("becomeAParticipantDescription")}
+          title={t("signupHomeButton")}
+          description={t("signupBannerDescription")}
+          disclaimer={t("signupBannerDisclaimer")}
+          lang={props.locale}
           href={t("signupInfoRedirect")}
-          hrefText={t("signupBtn")}
+          hrefText={t("signupBannerBtnText")}
         />
       </Layout>
       {props.adobeAnalyticsUrl ? (
@@ -229,10 +419,17 @@ export default function Privacy(props) {
 }
 
 export const getStaticProps = async ({ locale }) => {
+  // get page data from AEM
+  const res = await queryGraphQL(getPrivacyPage).then((result) => {
+    return result;
+  });
+
+  const data = res.data.sCLabsPageByPath;
   return {
     props: {
       locale: locale,
       adobeAnalyticsUrl: process.env.ADOBE_ANALYTICS_URL,
+      pageData: data,
       ...(await serverSideTranslations(locale, ["common"])),
     },
   };

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -353,5 +353,6 @@
   "topOfPage": "Top of page",
   "signupBannerBtnText": "Sign up for research session invites",
   "signupBannerDescription": "You’re invited to fill out quick surveys or take part in research sessions to make Service Canada better for everyone. Your feedback helps us make our services simple and easy to use.",
-  "signupBannerDisclaimer": "Your participation will not affect your access to government services. Participation is voluntary and you can opt out at any time."
+  "signupBannerDisclaimer": "Your participation will not affect your access to government services. Participation is voluntary and you can opt out at any time.",
+  "tableOfContentsTitle": "On this page:"
 }

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -343,5 +343,6 @@
   "topOfPage": "Haut de la page",
   "signupBannerBtnText": "Inscrivez-vous pour recevoir les invitations aux sessions de recherche",
   "signupBannerDescription": "Nous vous invitons à remplir des enquêtes rapides ou à participer à des séances de recherche afin d'améliorer Service Canada pour tous. Vos commentaires nous aident à rendre nos services simples et faciles à utiliser.",
-  "signupBannerDisclaimer": "Votre participation n'affectera pas votre accès aux services gouvernementaux. La participation est volontaire et vous pouvez vous retirer à tout moment."
+  "signupBannerDisclaimer": "Votre participation n'affectera pas votre accès aux services gouvernementaux. La participation est volontaire et vous pouvez vous retirer à tout moment.",
+  "tableOfContentsTitle": "Sur cette page :"
 }


### PR DESCRIPTION
# Description

[67714 - DEV: Add "On This Page" section and Information Alert component to Privacy Policy page](https://dev.azure.com/VP-BD/DECD/_boards/board/t/Service%20Canada%20Labs/Stories%20and%20Activities/?workitem=67714)

This PR adds the `TableOfContents` component, which accepts an array of headings with their IDs and displays them in a list. I've also updated the privacy page content fragment and converted the page to use the data from AEM. I've also added the Alert component to the page as per the new design.


## Test Instructions

1. Pull in branch
2. Type `yarn dev`
3. Navigate to `/signup/privacy`
4. Ensure the page looks like the new design and the table of contents functions properly

## Checklist

- [x] Strings use placeholders for translation (No hard coded strings)
- [x] Unit tests have been added/updated
- [x] Update CHANGELOG

## Product and Sprint Backlog

[ADO](https://dev.azure.com/VP-BD/DECD/_boards/board/t/Service%20Canada%20Labs/Stories%20and%20Activities)
